### PR TITLE
Fix: add trailing slash at the end of canonical URLs

### DIFF
--- a/routers/root.py
+++ b/routers/root.py
@@ -250,6 +250,7 @@ def st_page(
         )
         / latest_slug
         / tab
+        / "/"  # preserve trailing slash
     )
 
     ret |= {


### PR DESCRIPTION
### Q/A checklist

- [ ] Do a code review of the changes
- [ ] Add any new dependencies to poetry & export to requirementst.txt (`poetry export -o requirements.txt`) 
- [ ] Carefully think about the stuff that might break because of this change
- [ ] The relevant pages still run when you press submit
- [ ] If you added new settings / knobs, the values get saved if you save it on the UI
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
