### PR TITLE
bugfix: qr-code: preserve state when switching between input modes

### DIFF
--- a/recipes/QRCodeGenerator.py
+++ b/recipes/QRCodeGenerator.py
@@ -164,7 +164,9 @@ class QRCodeGeneratorPage(BasePage):
                 accept=["image/*"],
             )
         else:
-            self._set_active_qr_input_field(st.session_state, "qr_code_data", default="")
+            self._set_active_qr_input_field(
+                st.session_state, "qr_code_data", default=""
+            )
             st.text_area(
                 """
                 ### 🔗 URL


### PR DESCRIPTION
input modes: text/url, image, and (wip) vcard

### Q/A checklist

- [ ] Do a code review of the changes
- [ ] Add any new dependencies to poetry & export to requirementst.txt (`poetry export -o requirements.txt`) 
- [ ] Carefully think about the stuff that might break because of this change
- [ ] The relevant pages still run when you press submit
- [ ] If you added new settings / knobs, the values get saved if you save it on the UI
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
