### PR TITLE
Add comments for user.add_balance, remove unnecessary is_paying from update_fields there

### DIFF
--- a/app_users/models.py
+++ b/app_users/models.py
@@ -107,6 +107,15 @@ class AppUser(models.Model):
     @db_middleware
     @transaction.atomic
     def add_balance(self, amount: int, invoice_id: str) -> "AppUserTransaction":
+        """
+        Used to add/deduct credits when they are bought or consumed.
+
+        When credits are bought with stripe -- invoice_id is the stripe
+        invoice ID.
+        When credits are deducted due to a run -- invoice_id is of the
+        form "gooey_in_{uuid}"
+        """
+
         # if an invoice entry exists
         try:
             # avoid updating twice for same invoice
@@ -121,7 +130,7 @@ class AppUser(models.Model):
         # Also we're not using .update() here because it won't give back the updated end balance
         user: AppUser = AppUser.objects.select_for_update().get(pk=self.pk)
         user.balance += amount
-        user.save(update_fields=["balance", "is_paying"])
+        user.save(update_fields=["balance"])
 
         return AppUserTransaction.objects.create(
             user=self,


### PR DESCRIPTION
**Changes**
* Add comment explaining that add_balance is used for both additions/deductions in credits
* Remove is_paying field from `update_fields` when only balance needs to be updated

### Q/A checklist

- [ ] Do a code review of the changes
- [ ] Add any new dependencies to poetry & export to requirementst.txt (`poetry export -o requirements.txt`) 
- [ ] Carefully think about the stuff that might break because of this change
- [ ] The relevant pages still run when you press submit
- [ ] If you added new settings / knobs, the values get saved if you save it on the UI
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
