### PR TITLE
dev setup: more verbose celery logging

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -17,6 +17,6 @@ admin: poetry run python manage.py runserver 127.0.0.1:8000
 
 dashboard: poetry run streamlit run Home.py --server.port 8501 --server.headless true
 
-celery: poetry run celery -A celeryapp worker -P threads -c 16
+celery: poetry run celery -A celeryapp worker -P threads -c 16 -l DEBUG
 
 ui: cd ../gooey-ui/; PORT=3000 npm run dev


### PR DESCRIPTION
By default, Celery won't log anything once it has started. This is not very helpful in a local dev environment,
where you'll have to debug frequently.

Adding `-l DEBUG` flag to the worker makes this a lot better because we get to see the worker logs such as traceback and started / completed tasks.

### Q/A checklist

- [ ] Do a code review of the changes
- [ ] Add any new dependencies to poetry & export to requirementst.txt (`poetry export -o requirements.txt`) 
- [ ] Carefully think about the stuff that might break because of this change
- [ ] The relevant pages still run when you press submit
- [ ] If you added new settings / knobs, the values get saved if you save it on the UI
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
