### PR TITLE
fix double quotes in 'People also ask' recipe title

### DIFF
--- a/recipes/RelatedQnA.py
+++ b/recipes/RelatedQnA.py
@@ -24,7 +24,7 @@ class RelatedGoogleGPTResponse(GoogleGPTPage.ResponseModel):
 
 
 class RelatedQnAPage(BasePage):
-    title = 'Generate “People Also Ask” SEO Content '
+    title = "Generate “People Also Ask” SEO Content "
     workflow = Workflow.RELATED_QNA_MAKER
     slug_versions = ["related-qna-maker"]
 


### PR DESCRIPTION
The font was interpreting both double quotes as being the closing
quote.

Before:
<img width="429" alt="image" src="https://github.com/dara-network/gooey-server/assets/37668193/170bfef6-dc34-409a-8407-57d6d3cf29e8">

After:
<img width="429" alt="image" src="https://github.com/dara-network/gooey-server/assets/37668193/d82cf4ff-885f-48b2-bb8f-a93fe98d1565">


### Q/A checklist

- [ ] Do a code review of the changes
- [ ] Add any new dependencies to poetry & export to requirementst.txt (`poetry export -o requirements.txt`) 
- [ ] Carefully think about the stuff that might break because of this change
- [ ] The relevant pages still run when you press submit
- [ ] If you added new settings / knobs, the values get saved if you save it on the UI
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
