### PR TITLE
Fix breadcrumbs: newlines in prompt title, link in empty space

### DIFF
--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -244,12 +244,7 @@ class BasePage:
                         )
             st.write(f"# {h1_title}")
         else:
-            with st.link(
-                to=self.app_url(),
-                className="text-decoration-none d-inline-block",
-                target="_blank",
-            ):
-                st.write(f"# {self.get_recipe_title(st.session_state)}")
+            st.write(f"# {self.get_recipe_title(st.session_state)}")
 
     def get_recipe_title(self, state: dict) -> str:
         return state.get(StateKeys.page_title) or self.title or ""


### PR DESCRIPTION
- Fix trailing whitespace
- Replace newlines with space in prompt_title
- <a> tag on recipe root shouldn't occupy full width -- this is misleading because blank space becomes clickable

### Q/A checklist

- [ ] Do a code review of the changes
- [ ] Add any new dependencies to poetry & export to requirementst.txt (`poetry export -o requirements.txt`) 
- [ ] Carefully think about the stuff that might break because of this change
- [ ] The relevant pages still run when you press submit
- [ ] If you added new settings / knobs, the values get saved if you save it on the UI
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
