### PR TITLE
Add h1 and meta title for all tabs

### DIFF
--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -243,7 +243,12 @@ class BasePage:
 
                 if tbreadcrumbs:
                     with st.tag("div", className="me-3 mb-1 mb-lg-0 py-2 py-lg-0"):
-                        render_breadcrumbs(tbreadcrumbs, current_run.is_api_call)
+                        render_breadcrumbs(
+                            tbreadcrumbs,
+                            is_api_call=(
+                                current_run.is_api_call and self.tab == MenuTabs.run
+                            ),
+                        )
 
                 author = self.run_user or current_run.get_creator()
                 if not is_root_example:

--- a/daras_ai_v2/meta_content.py
+++ b/daras_ai_v2/meta_content.py
@@ -111,27 +111,20 @@ def meta_title_for_page(
     pr: PublishedRun | None,
     tab: str,
 ) -> str:
-    suffix = f" {sep} Gooey.AI"
-
     match tab:
         case MenuTabs.examples:
-            return f"Examples: {metadata.meta_title}" + suffix
-        case MenuTabs.run_as_api:
-            return "API: " + meta_title_for_page(
-                page=page, metadata=metadata, sr=sr, pr=pr, tab=MenuTabs.run
-            )
-        case MenuTabs.integrations:
-            return "Integrations: " + meta_title_for_page(
-                page=page, metadata=metadata, sr=sr, pr=pr, tab=MenuTabs.run
-            )
-        case MenuTabs.history:
-            return f"History for {metadata.short_title}" + suffix
-        case MenuTabs.saved:
-            return f"Saved Runs for {metadata.short_title}" + suffix
-        case MenuTabs.run if pr and pr.saved_run == sr and pr.is_root():
+            label = MenuTabs.display_labels[tab]
+            ret = f"{label}: {metadata.meta_title}"
+        case MenuTabs.run_as_api | MenuTabs.integrations:
+            label = MenuTabs.display_labels[tab]
+            return f"{label} for {meta_title_for_page(page=page, metadata=metadata, sr=sr, pr=pr, tab=MenuTabs.run)}"
+        case MenuTabs.history | MenuTabs.saved:
+            label = MenuTabs.display_labels[tab]
+            ret = f"{label} for {metadata.short_title}"
+        case _ if pr and pr.saved_run == sr and pr.is_root():
             # for root page
-            return metadata.meta_title + suffix
-        case MenuTabs.run:
+            ret = metadata.meta_title
+        case _:
             # non-root runs and examples
             parts = []
 
@@ -148,9 +141,9 @@ def meta_title_for_page(
                 part += f" by {user.display_name}"
             parts.append(part)
 
-            return sep.join(parts) + suffix
-        case _:
-            raise ValueError(f"Unknown tab: {tab}")
+            ret = sep.join(parts)
+
+    return f"{ret} {sep} Gooey.AI"
 
 
 def meta_description_for_page(

--- a/daras_ai_v2/tabs_widget.py
+++ b/daras_ai_v2/tabs_widget.py
@@ -22,6 +22,14 @@ class MenuTabs:
     }
     paths_reverse = {v: k for k, v in paths.items()}
 
+    display_labels = {
+        examples: "Examples",
+        history: "History",
+        saved: "Saved Runs",
+        run_as_api: "API",
+        integrations: "Integrations",
+    }
+
 
 def page_tabs(*, tabs, key=None):
     selected_menu = option_menu(


### PR DESCRIPTION
- Add different meta title and h1 title for Examples tab
- refactor: meta_title_for_page function
- Add h1 title and meta title for all tabs

### Q/A checklist

- [ ] Do a code review of the changes
- [ ] Add any new dependencies to poetry & export to requirementst.txt (`poetry export -o requirements.txt`) 
- [ ] Carefully think about the stuff that might break because of this change
- [ ] The relevant pages still run when you press submit
- [ ] If you added new settings / knobs, the values get saved if you save it on the UI
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206405098854954