### PR TITLE
Add non-api pages to test_public_endpoints

### DIFF
--- a/tests/test_public_endpoints.py
+++ b/tests/test_public_endpoints.py
@@ -3,7 +3,7 @@ from starlette.routing import Route
 from starlette.testclient import TestClient
 
 from bots.models import PublishedRun, Workflow
-from daras_ai_v2.all_pages import all_api_pages
+from daras_ai_v2.all_pages import all_api_pages, all_hidden_pages
 from daras_ai_v2.tabs_widget import MenuTabs
 from routers import facebook_api
 from routers.slack_api import slack_connect_redirect_shortcuts, slack_connect_redirect
@@ -43,7 +43,7 @@ def _test_get_path(path):
 
 @pytest.mark.django_db
 def test_all_slugs(threadpool_subtest):
-    for page_cls in all_api_pages:
+    for page_cls in all_api_pages + all_hidden_pages:
         for slug in page_cls.slug_versions:
             for tab in MenuTabs.paths.values():
                 url = f"/{slug}/{tab}"


### PR DESCRIPTION
Task: https://app.asana.com/0/1203067047205953/1206721472788032

New tests pass:
![image](https://github.com/GooeyAI/gooey-server/assets/97496861/529441e0-a92e-43fc-99d3-08153f7f4399)

### Q/A checklist

- [ ] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [ ] Do a self code review of the changes 
- [ ] Carefully think about the stuff that might break because of this change
- [ ] The relevant pages still run when you press submit
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
