### PR TITLE
Fixes the icons on the integration tab

### DIFF
--- a/recipes/VideoBots.py
+++ b/recipes/VideoBots.py
@@ -1206,7 +1206,7 @@ PS. This is the workflow that we used to create RadBots - a collection of Turing
             col1, col2 = st.columns(2, style={"align-items": "center"})
             with col1:
                 st.write("###### Connected To")
-                st.write(f"{icon} {bi}", unsafe_allow_html=True)
+                st.html(f"<p>{icon} {bi}</p>")
             with col2:
                 if test_link:
                     copy_to_clipboard_button(


### PR DESCRIPTION
Before: 
![image](https://github.com/GooeyAI/gooey-server/assets/97496861/884aeb05-92e6-4373-946f-30cd16a4552d)

After:
![image](https://github.com/GooeyAI/gooey-server/assets/97496861/34c2e00d-35cf-4cfb-b47e-51d2eef2fb8e)


### Q/A checklist

- [x] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [x] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [x] Do a self code review of the changes - Read the diff at least twice.  
- [x] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [x] The relevant pages still run when you press submit
- [x] The API for those pages still work (API tab)
- [x] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [x] Do your UI changes (if applicable) look acceptable on mobile?
- [x] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```
