### PR TITLE
Add url_button to workflows on API docs page

### DIFF
--- a/gooey_ui/components/url_button.py
+++ b/gooey_ui/components/url_button.py
@@ -1,0 +1,13 @@
+import gooey_ui as st
+
+
+def url_button(url):
+    st.html(
+        f"""
+<a href='{url}' target='_blank'>
+    <button type="button" class="btn btn-theme btn-tertiary">
+        <i class="fa-regular fa-external-link-square"></i>
+    </button>
+</a>
+        """
+    )

--- a/recipes/BulkRunner.py
+++ b/recipes/BulkRunner.py
@@ -22,6 +22,7 @@ from daras_ai_v2.vector_search import (
     doc_url_to_file_metadata,
     tabular_bytes_to_any_df,
 )
+from gooey_ui.components.url_button import url_button
 from gooeysite.bg_db_conn import get_celery_result_db_safe
 from recipes.DocSearch import render_documents
 
@@ -533,18 +534,6 @@ def render_eval_url_inputs(key: str, del_key: str, d: dict):
     except Exception as e:
         st.error(repr(e))
     d["url"] = url
-
-
-def url_button(url):
-    st.html(
-        f"""
-<a href='{url}' target='_blank'>
-    <button type="button" class="btn btn-theme btn-tertiary">
-        <i class="fa-regular fa-external-link-square"></i>
-    </button>
-</a>
-        """
-    )
 
 
 def edit_button(key: str):

--- a/routers/root.py
+++ b/routers/root.py
@@ -37,6 +37,7 @@ from daras_ai_v2.meta_preview_url import meta_preview_url
 from daras_ai_v2.query_params_util import extract_query_params
 from daras_ai_v2.settings import templates
 from daras_ai_v2.tabs_widget import MenuTabs
+from gooey_ui.components.url_button import url_button
 from routers.api import request_form_files
 
 app = APIRouter()
@@ -280,13 +281,23 @@ Authorization: Bearer GOOEY_API_KEY
         page_cls.workflow.value: page_cls().get_recipe_title()
         for page_cls in all_api_pages
     }
-    workflow = Workflow(
-        st.selectbox(
-            "##### ⚕ API Generator\nChoose a workflow to see how you can interact with it via the API",
-            options=options,
-            format_func=lambda x: options[x],
-        )
+
+    st.write(
+        "##### ⚕ API Generator\nChoose a workflow to see how you can interact with it via the API"
     )
+
+    col1, col2 = st.columns([11, 1], responsive=False)
+    with col1:
+        with st.div(className="pt-1"):
+            workflow = Workflow(
+                st.selectbox(
+                    "",
+                    options=options,
+                    format_func=lambda x: options[x],
+                )
+            )
+    with col2:
+        url_button(workflow.get_app_url("", "", ""))
 
     st.write("###### 📤 Example Request")
 


### PR DESCRIPTION
### Q/A checklist

- [ ] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [ ] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [ ] Do a self code review of the changes - Read the diff at least twice.  
- [ ] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [ ] The relevant pages still run when you press submit
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
- [ ] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206872598964894