### PR TITLE
Enable code highlight on re-render

### DIFF
--- a/gooey_ui/components/__init__.py
+++ b/gooey_ui/components/__init__.py
@@ -101,16 +101,29 @@ def newline():
 
 
 def markdown(
-    body: str | None, *, line_clamp: int = None, unsafe_allow_html=False, **props
+    body: str | None,
+    *,
+    line_clamp: int = None,
+    unsafe_allow_html=False,
+    key: str | None = None,
+    **props,
 ):
     if body is None:
         return _node("markdown", body="", **props)
     if not unsafe_allow_html:
         body = html_lib.escape(body)
+    if key is None:
+        key = md5_values("markdown", body, line_clamp, props)
     props["className"] = (
         props.get("className", "") + " gui-html-container gui-md-container"
     )
-    return _node("markdown", body=dedent(body).strip(), lineClamp=line_clamp, **props)
+    return _node(
+        "markdown",
+        body=dedent(body).strip(),
+        lineClamp=line_clamp,
+        key=key,
+        **props,
+    )
 
 
 def _node(name: str, **props):


### PR DESCRIPTION
Related gooey-ui PR: https://github.com/GooeyAI/gooey-ui/pull/24

This change is needed because React needs a uniqueness key to re-render the correct component. The default was failing on adding a highlighting step to the markdown parser in UI.

This PR sets this key from the backend.

### Q/A checklist

- [x] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [ ] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [x] Do a self code review of the changes - Read the diff at least twice.  
- [x] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [x] The relevant pages still run when you press submit
- [x] The API for those pages still work (API tab)
- [x] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [x] Do your UI changes (if applicable) look acceptable on mobile?
- [x] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```
