### PR TITLE
Publishedrun createdby remains author when lasteditedby changes

### DIFF
--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -258,11 +258,8 @@ class BasePage:
     def _render_header(self):
         current_run = self.get_current_sr()
         published_run = self.get_current_published_run()
-        is_root_example = (
-            published_run
-            and published_run.is_root()
-            and published_run.saved_run == current_run
-        )
+        is_example = published_run and published_run.saved_run == current_run
+        is_root_example = is_example and published_run.is_root()
         tbreadcrumbs = get_title_breadcrumbs(
             self, current_run, published_run, tab=self.tab
         )
@@ -281,7 +278,11 @@ class BasePage:
                             ),
                         )
 
-                author = self.run_user or current_run.get_creator()
+                if is_example:
+                    assert published_run
+                    author = published_run.created_by
+                else:
+                    author = self.run_user or current_run.get_creator()
                 if not is_root_example:
                     self.render_author(
                         author,


### PR DESCRIPTION
Task: https://app.asana.com/0/1203067047205953/1206874223276759

### Q/A checklist

- [x] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [x] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [x] Do a self code review of the changes - Read the diff at least twice.  
- [x] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [x] The relevant pages still run when you press submit
- [x] The API for those pages still work (API tab)
- [x] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [x] Do your UI changes (if applicable) look acceptable on mobile?
- [x] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```
