### PR TITLE
Don't send integration attempt emails when admins create an integration

### DIFF
--- a/recipes/VideoBots.py
+++ b/recipes/VideoBots.py
@@ -1201,11 +1201,12 @@ PS. This is the workflow that we used to create RadBots - a collection of Turing
                 #         <div {DESCRIPTIONSTYLE}>Connect to an Instagram account you own.</div>
                 #     </div>
                 if redirect_url:
-                    send_integration_attempt_email.delay(
-                        user_id=self.request.user.id,
-                        platform=selected_platform,
-                        run_url=self._get_current_app_url() or "",
-                    )
+                    if not self.is_current_user_admin():
+                        send_integration_attempt_email.delay(
+                            user_id=self.request.user.id,
+                            platform=selected_platform,
+                            run_url=self._get_current_app_url() or "",
+                        )
                     raise RedirectException(redirect_url)
 
             st.newline()


### PR DESCRIPTION
Task: https://app.asana.com/0/1203067047205953/1207048920220454

### Q/A checklist

- [x] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [x] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [x] Do a self code review of the changes - Read the diff at least twice.  
- [x] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [x] The relevant pages still run when you press submit
- [x] The API for those pages still work (API tab)
- [x] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [x] Do your UI changes (if applicable) look acceptable on mobile?
- [x] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```
