### PR TITLE
local setup: Add auto-reload for Celery

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -17,6 +17,6 @@ admin: poetry run python manage.py runserver 127.0.0.1:8000
 
 dashboard: poetry run streamlit run Home.py --server.port 8501 --server.headless true
 
-celery: poetry run python manage.py runscript celery
+celery: poetry run python manage.py runscript celery --script-args="-P threads -c 16 -l DEBUG"
 
 ui: cd ../gooey-ui/; PORT=3000 npm run dev

--- a/Procfile
+++ b/Procfile
@@ -17,6 +17,6 @@ admin: poetry run python manage.py runserver 127.0.0.1:8000
 
 dashboard: poetry run streamlit run Home.py --server.port 8501 --server.headless true
 
-celery: poetry run celery -A celeryapp worker -P threads -c 16 -l DEBUG
+celery: poetry run python manage.py runscript celery
 
 ui: cd ../gooey-ui/; PORT=3000 npm run dev

--- a/scripts/celery.py
+++ b/scripts/celery.py
@@ -1,17 +1,19 @@
 import shlex
 import subprocess
+import sys
 
 from django.utils import autoreload
 
 
-def restart_celery():
-    celery_cmd = "celery -A celeryapp worker -P threads -c 48 -l DEBUG"
-    subprocess.call(["pkill", "-f", celery_cmd])
-    cmd = f"poetry run {celery_cmd}"
-    subprocess.call(shlex.split(cmd))
+def restart_celery(celery_args):
+    celery_base_cmd = "celery -A celeryapp worker"
+    subprocess.call(["pkill", "-f", celery_base_cmd])
+    cmd = ["poetry", "run"] + shlex.split(celery_base_cmd) + shlex.split(celery_args)
+    print("Running command: ", cmd, file=sys.stderr)
+    subprocess.call(cmd)
 
 
-def run():
-    print("Starting celery worker with autoreload...")
+def run(celery_args=""):
+    print("Starting celery worker with autoreload...", file=sys.stderr)
 
-    autoreload.run_with_reloader(restart_celery)
+    autoreload.run_with_reloader(lambda: restart_celery(celery_args))

--- a/scripts/celery.py
+++ b/scripts/celery.py
@@ -1,0 +1,17 @@
+import shlex
+import subprocess
+
+from django.utils import autoreload
+
+
+def restart_celery():
+    celery_cmd = "celery -A celeryapp worker -P threads -c 48 -l DEBUG"
+    subprocess.call(["pkill", "-f", celery_cmd])
+    cmd = f"poetry run {celery_cmd}"
+    subprocess.call(shlex.split(cmd))
+
+
+def run():
+    print("Starting celery worker with autoreload...")
+
+    autoreload.run_with_reloader(restart_celery)


### PR DESCRIPTION
- Add autoreload for Celery
- Take celery args from Procfile as script-args

### Q/A checklist

- [x] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [x] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [x] Do a self code review of the changes - Read the diff at least twice.  
- [x] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [x] The relevant pages still run when you press submit
- [x] The API for those pages still work (API tab)
- [x] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [x] Do your UI changes (if applicable) look acceptable on mobile?
- [x] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207220056279067