### PR TITLE
Make Dalle2 on ai-photo-editor respect the text prompt

### DIFF
--- a/daras_ai_v2/stable_diffusion.py
+++ b/daras_ai_v2/stable_diffusion.py
@@ -383,11 +383,18 @@ def img2img(
 
             edge = _get_dall_e_img_size(width, height)
             image = resize_img_pad(init_image_bytes, (edge, edge))
+            image = rgb_img_to_rgba(image)
+            mask = io.BytesIO()
+            Image.new("RGBA", (edge, edge), (0, 0, 0, 0)).save(mask, format="PNG")
+            mask = mask.getvalue()
 
             client = OpenAI()
             with capture_openai_content_policy_violation():
-                response = client.images.create_variation(
+                response = client.images.edit(
+                    model="dall-e-2",
+                    prompt=prompt,
                     image=image,
+                    mask=mask,
                     n=num_outputs,
                     size=f"{edge}x{edge}",
                     response_format="b64_json",

--- a/recipes/Img2Img.py
+++ b/recipes/Img2Img.py
@@ -10,7 +10,6 @@ from daras_ai_v2.base import BasePage
 from daras_ai_v2.img_model_settings_widgets import img_model_settings
 from daras_ai_v2.loom_video_widget import youtube_video
 from daras_ai_v2.stable_diffusion import (
-    InpaintingModels,
     Img2ImgModels,
     img2img,
     SD_IMG_MAX_SIZE,
@@ -102,15 +101,14 @@ class Img2ImgPage(BasePage):
             upload_meta=dict(resize=f"{SD_IMG_MAX_SIZE[0] * SD_IMG_MAX_SIZE[1]}@>"),
         )
 
-        if st.session_state.get("selected_model") != InpaintingModels.dall_e.name:
-            st.text_area(
-                """
-                #### Prompt
-                Describe your edits 
-                """,
-                key="text_prompt",
-                placeholder="Iron man",
-            )
+        st.text_area(
+            """
+            #### Prompt
+            Describe your edits 
+            """,
+            key="text_prompt",
+            placeholder="Iron man",
+        )
 
     def validate_form_v2(self):
         input_image = st.session_state.get("input_image")


### PR DESCRIPTION
Task: https://app.asana.com/0/1203067047205953/1207233861691428

### Q/A checklist

- [x] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [x] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [x] Do a self code review of the changes - Read the diff at least twice.  
- [x] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [x] The relevant pages still run when you press submit
- [x] The API for those pages still work (API tab)
- [x] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [x] Do your UI changes (if applicable) look acceptable on mobile?
- [x] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```
