### PR TITLE
Fix backwards compatibility issues with the new example id url format

### DIFF
--- a/routers/root.py
+++ b/routers/root.py
@@ -611,16 +611,17 @@ def render_page(
     query_params = st.get_query_params()
     # if the old query param format is provided, redirect to the new format
     # because features like login relies on the new format
-    if query_params.get("example_id"):
+    example_id, run_id, uid = extract_query_params(query_params)
+    if query_params.pop("example_id", None):
         return RedirectResponse(
-            tab.url_path(
-                page_slug,
-                f"{run_slug}-{example_id}" if run_slug else run_slug,
-                example_id=query_params["example_id"],
+            page_cls.app_url(
+                tab=tab,
+                example_id=example_id,
+                run_id=run_id,
+                uid=uid,
+                query_params=query_params,
             )
         )
-    example_id = example_id or query_params.get("example_id")
-    _, run_id, uid = extract_query_params(query_params)
     page = page_cls(tab=tab, request=request, run_user=get_run_user(request, uid))
     if not st.session_state:
         sr = page.get_sr_from_query_params(example_id, run_id, uid)


### PR DESCRIPTION
Task: https://app.asana.com/0/1203067047205953/1207256048063190

### Q/A checklist
- [ ] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [ ] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [ ] Do a self code review of the changes - Read the diff at least twice.  
- [ ] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [ ] The relevant pages still run when you press submit
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
- [ ] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```
