### PR TITLE
Fix migrate existing subs script: fetch 100 subs, set auto_recharge_enabled to False

### DIFF
--- a/payments/models.py
+++ b/payments/models.py
@@ -81,21 +81,18 @@ class Subscription(models.Model):
         return ret
 
     def full_clean(self, *args, **kwargs):
-        if self.plan and self.auto_recharge_enabled:
-            if not self.auto_recharge_balance_threshold:
-                self.auto_recharge_balance_threshold = (
-                    self._get_default_auto_recharge_balance_threshold()
-                )
+        if not self.auto_recharge_balance_threshold:
+            self.auto_recharge_balance_threshold = (
+                self._get_default_auto_recharge_balance_threshold()
+            )
 
-            if not self.monthly_spending_budget:
-                self.monthly_spending_budget = (
-                    self._get_default_monthly_spending_budget()
-                )
+        if not self.monthly_spending_budget:
+            self.monthly_spending_budget = self._get_default_monthly_spending_budget()
 
-            if not self.monthly_spending_notification_threshold:
-                self.monthly_spending_notification_threshold = (
-                    self._get_default_monthly_spending_notification_threshold()
-                )
+        if not self.monthly_spending_notification_threshold:
+            self.monthly_spending_notification_threshold = (
+                self._get_default_monthly_spending_notification_threshold()
+            )
 
         return super().full_clean(*args, **kwargs)
 


### PR DESCRIPTION
* make script run faster using expand=[...] to stripe.Subscription.list
* fetch 100 subs (assuming that there are <100 active subs in stripe)
* set auto_recharge_enabled to False for old users
* set defaults for auto-recharge and limit options even if auto_recharge_enabled is turned off (these
should be the defaults they see if they do turn on auto_recharge_enabled)

### Q/A checklist

- [x] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [x] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [x] Do a self code review of the changes - Read the diff at least twice.  
- [x] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [x] The relevant pages still run when you press submit
- [x] The API for those pages still work (API tab)
- [x] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [x] Do your UI changes (if applicable) look acceptable on mobile?
- [x] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```
