### PR TITLE
Fix stripe bug with handling subscriptions: product.default_price is none

### DIFF
--- a/payments/plans.py
+++ b/payments/plans.py
@@ -282,7 +282,10 @@ class PricingPlan(PricingPlanData, Enum):
 
     def get_stripe_product_id(self) -> str:
         for product in stripe.Product.list(expand=["data.default_price"]).data:
-            if product.default_price.unit_amount == self.monthly_charge * 100:  # cents
+            if (
+                product.default_price
+                and product.default_price.unit_amount == self.monthly_charge * 100
+            ):  # cents
                 return product.id
 
         product = stripe.Product.create(


### PR DESCRIPTION
### Q/A checklist

- [x] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [x] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [x] Do a self code review of the changes - Read the diff at least twice.  
- [x] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [x] The relevant pages still run when you press submit
- [x] The API for those pages still work (API tab)
- [x] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [x] Do your UI changes (if applicable) look acceptable on mobile?
- [x] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```
