### PR TITLE
truncate related workflows description text

### DIFF
--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -89,6 +89,7 @@ from payments.auto_recharge import (
 )
 from routers.account import AccountTabs
 from routers.root import RecipeTabs
+from daras_ai.image_input import truncate_text_words
 
 DEFAULT_META_IMG = (
     # Small
@@ -989,14 +990,12 @@ class BasePage:
                 st.markdown(
                     f"###### {root_run.title or page.title}",
                 )
-            with st.link(
-                to=page.app_url(), className="text-decoration-none cursor-pointer"
-            ):
+            with st.link(to=page.app_url(), className="text-decoration-none"):
                 st.caption(
-                    root_run.notes or page.preview_description(state),
-                    className="text-decoration-none",
-                    line_clamp=7,
-                    line_clamp_expand=False,
+                    truncate_text_words(
+                        root_run.notes or page.preview_description(state),
+                        maxlen=210,
+                    ),
                 )
 
         grid_layout(4, page_clses, _render)

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -980,22 +980,19 @@ class BasePage:
             state = root_run.saved_run.to_dict()
             preview_image = page.get_explore_image()
 
-            with st.link(to=page.app_url()):
+            with st.link(to=page.app_url(), className="text-decoration-none"):
                 st.html(
                     # language=html
                     f"""
 <div class="w-100 mb-2" style="height:150px; background-image: url({preview_image}); background-size:cover; background-position-x:center; background-position-y:30%; background-repeat:no-repeat;"></div>
                     """
                 )
-                st.markdown(
-                    f"###### {root_run.title or page.title}",
-                )
-            with st.link(to=page.app_url(), className="text-decoration-none"):
+                st.markdown(f"###### {root_run.title or page.title}")
                 st.caption(
                     truncate_text_words(
                         root_run.notes or page.preview_description(state),
                         maxlen=210,
-                    ),
+                    )
                 )
 
         grid_layout(4, page_clses, _render)

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -986,8 +986,18 @@ class BasePage:
 <div class="w-100 mb-2" style="height:150px; background-image: url({preview_image}); background-size:cover; background-position-x:center; background-position-y:30%; background-repeat:no-repeat;"></div>
                     """
                 )
-                st.markdown(f"###### {root_run.title or page.title}")
-            st.caption(root_run.notes or page.preview_description(state))
+                st.markdown(
+                    f"###### {root_run.title or page.title}",
+                )
+            with st.link(
+                to=page.app_url(), className="text-decoration-none cursor-pointer"
+            ):
+                st.caption(
+                    root_run.notes or page.preview_description(state),
+                    className="text-decoration-none",
+                    line_clamp=7,
+                    line_clamp_expand=False,
+                )
 
         grid_layout(4, page_clses, _render)
 

--- a/gooey_ui/components/__init__.py
+++ b/gooey_ui/components/__init__.py
@@ -99,7 +99,6 @@ def markdown(
     body: str | None,
     *,
     line_clamp: int = None,
-    line_clamp_expand: bool = True,
     unsafe_allow_html=False,
     **props,
 ):
@@ -114,7 +113,6 @@ def markdown(
         "markdown",
         body=dedent(body).strip(),
         lineClamp=line_clamp,
-        lineClampExpand=line_clamp_expand,
         **props,
     )
 

--- a/gooey_ui/components/__init__.py
+++ b/gooey_ui/components/__init__.py
@@ -96,7 +96,12 @@ def newline():
 
 
 def markdown(
-    body: str | None, *, line_clamp: int = None, unsafe_allow_html=False, **props
+    body: str | None,
+    *,
+    line_clamp: int = None,
+    line_clamp_expand: bool = True,
+    unsafe_allow_html=False,
+    **props,
 ):
     if body is None:
         return _node("markdown", body="", **props)
@@ -105,7 +110,13 @@ def markdown(
     props["className"] = (
         props.get("className", "") + " gui-html-container gui-md-container"
     )
-    return _node("markdown", body=dedent(body).strip(), lineClamp=line_clamp, **props)
+    return _node(
+        "markdown",
+        body=dedent(body).strip(),
+        lineClamp=line_clamp,
+        lineClampExpand=line_clamp_expand,
+        **props,
+    )
 
 
 def _node(name: str, **props):


### PR DESCRIPTION
### Q/A checklist

- [x] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [x] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [x] Do a self code review of the changes - Read the diff at least twice.  
- [x] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [x] The relevant pages still run when you press submit
- [x] The API for those pages still work (API tab)
- [x] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [x] Do your UI changes (if applicable) look acceptable on mobile?
- [x] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

