### PR TITLE
functions:  charge 1 credit in /functions and no credit from another workflow

### DIFF
--- a/bots/admin.py
+++ b/bots/admin.py
@@ -438,7 +438,7 @@ class SavedRunAdmin(admin.ModelAdmin):
             page = Workflow(sr.workflow).page_cls(
                 request=SimpleNamespace(user=AppUser.objects.get(uid=sr.uid))
             )
-            page.call_runner_task(sr)
+            page.call_runner_task(sr, deduct_credits=False)
         self.message_user(
             request,
             f"Started re-running {queryset.count()} tasks in the background.",

--- a/bots/models.py
+++ b/bots/models.py
@@ -363,6 +363,7 @@ class SavedRun(models.Model):
         request_body: dict,
         enable_rate_limits: bool = False,
         parent_pr: "PublishedRun" = None,
+        deduct_credits: bool = True,
     ) -> tuple["celery.result.AsyncResult", "SavedRun"]:
         from routers.api import submit_api_call
 
@@ -384,6 +385,7 @@ class SavedRun(models.Model):
                     user=current_user,
                     request_body=request_body,
                     enable_rate_limits=enable_rate_limits,
+                    deduct_credits=deduct_credits,
                 ),
             )
 
@@ -1818,12 +1820,14 @@ class PublishedRun(models.Model):
         current_user: AppUser,
         request_body: dict,
         enable_rate_limits: bool = False,
+        deduct_credits: bool = True,
     ) -> tuple["celery.result.AsyncResult", "SavedRun"]:
         return self.saved_run.submit_api_call(
             current_user=current_user,
             request_body=request_body,
             enable_rate_limits=enable_rate_limits,
             parent_pr=self,
+            deduct_credits=deduct_credits,
         )
 
 

--- a/celeryapp/tasks.py
+++ b/celeryapp/tasks.py
@@ -41,6 +41,7 @@ def runner_task(
     uid: str,
     channel: str,
     unsaved_state: dict[str, typing.Any] = None,
+    deduct_credits: bool = True,
 ) -> int:
     start_time = time()
     error_msg = None
@@ -107,7 +108,8 @@ def runner_task(
 
     # run completed successfully, deduct credits
     else:
-        sr.transaction, sr.price = page.deduct_credits(gui.session_state)
+        if deduct_credits:
+            sr.transaction, sr.price = page.deduct_credits(gui.session_state)
 
     # save everything, mark run as completed
     finally:

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -1686,7 +1686,7 @@ class BasePage:
             }
         )
 
-    def call_runner_task(self, sr: SavedRun):
+    def call_runner_task(self, sr: SavedRun, deduct_credits: bool = True):
         from celeryapp.tasks import runner_task, post_runner_tasks
 
         chain = (
@@ -1697,6 +1697,7 @@ class BasePage:
                 uid=sr.uid,
                 channel=self.realtime_channel_name(sr.run_id, sr.uid),
                 unsaved_state=self._unsaved_state(),
+                deduct_credits=deduct_credits,
             )
             | post_runner_tasks.s()
         )

--- a/daras_ai_v2/safety_checker.py
+++ b/daras_ai_v2/safety_checker.py
@@ -33,6 +33,7 @@ def safety_checker_text(text_input: str):
         .submit_api_call(
             current_user=billing_account,
             request_body=dict(variables=dict(input=text_input)),
+            deduct_credits=False,
         )
     )
 

--- a/functions/recipe_functions.py
+++ b/functions/recipe_functions.py
@@ -53,6 +53,7 @@ def call_recipe_functions(
             request_body=dict(
                 variables=sr.state.get("variables", {}) | variables | fn_vars,
             ),
+            deduct_credits=False,
         )
 
         CalledFunction.objects.create(

--- a/recipes/Functions.py
+++ b/recipes/Functions.py
@@ -10,6 +10,7 @@ from daras_ai_v2.base import BasePage
 from daras_ai_v2.exceptions import raise_for_status
 from daras_ai_v2.field_render import field_title_desc
 from daras_ai_v2.prompt_vars import variables_input
+from functions.models import CalledFunction
 
 
 class ConsoleLogs(BaseModel):
@@ -82,6 +83,14 @@ class FunctionsPage(BasePage):
             language="javascript",
             height=300,
         )
+
+    def get_price_roundoff(self, state: dict) -> float:
+        try:
+            # called from another workflow don't charge any credits
+            CalledFunction.objects.get(function_run=self.get_current_sr())
+            return 0
+        except CalledFunction.DoesNotExist:
+            return self.price
 
     def render_variables(self):
         variables_input(

--- a/recipes/Functions.py
+++ b/recipes/Functions.py
@@ -86,12 +86,12 @@ class FunctionsPage(BasePage):
         )
 
     def get_price_roundoff(self, state: dict) -> float:
-        try:
-            # called from another workflow don't charge any credits
-            CalledFunction.objects.get(function_run=self.get_current_sr())
+        if CalledFunction.objects.filter(function_run=self.get_current_sr()).exists():
             return 0
-        except CalledFunction.DoesNotExist:
-            return self.price
+        return super().get_price_roundoff(state)
+
+    def additional_notes(self):
+        return "\nFunctions are free if called from another workflow."
 
     def render_variables(self):
         variables_input(

--- a/recipes/Functions.py
+++ b/recipes/Functions.py
@@ -23,6 +23,7 @@ class FunctionsPage(BasePage):
     workflow = Workflow.FUNCTIONS
     slug_versions = ["functions", "tools", "function", "fn", "functions"]
     show_settings = False
+    price = 1
 
     class RequestModel(BaseModel):
         code: str = Field(

--- a/routers/api.py
+++ b/routers/api.py
@@ -332,6 +332,7 @@ def submit_api_call(
     query_params: dict,
     retention_policy: RetentionPolicy = None,
     enable_rate_limits: bool = False,
+    deduct_credits: bool = True,
 ) -> tuple[BasePage, "celery.result.AsyncResult", str, str]:
     # init a new page for every request
     self = page_cls(request=SimpleNamespace(user=user))
@@ -357,7 +358,7 @@ def submit_api_call(
     except ValidationError as e:
         raise RequestValidationError(e.raw_errors, body=gui.session_state) from e
     # submit the task
-    result = self.call_runner_task(sr)
+    result = self.call_runner_task(sr, deduct_credits=deduct_credits)
     return self, result, sr.run_id, sr.uid
 
 


### PR DESCRIPTION
### Q/A checklist

- [x] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [x] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [x] Do a self code review of the changes - Read the diff at least twice.  
- [x] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [x] The relevant pages still run when you press submit
- [x] The API for those pages still work (API tab)
- [x] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [x] Do your UI changes (if applicable) look acceptable on mobile?
- [x] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205803182950144