### PR TITLE
fix SERP search location code gui->st

### DIFF
--- a/daras_ai_v2/serp_search_locations.py
+++ b/daras_ai_v2/serp_search_locations.py
@@ -244,7 +244,7 @@ class SerpSearchLocation(TextChoices):
     SAINT_VINCENT_AND_THE_GRENADINES = "vc", "Saint Vincent and the Grenadines"
     SAMOA = "ws", "Samoa"
     SAN_MARINO = "sm", "San Marino"
-    SAO_TOME_AND_PRINCIPE = "gui", "Sao Tome and Principe"
+    SAO_TOME_AND_PRINCIPE = "st", "Sao Tome and Principe"
     SAUDI_ARABIA = "sa", "Saudi Arabia"
     SENEGAL = "sn", "Senegal"
     SERBIA_AND_MONTENEGRO = "rs", "Serbia and Montenegro"


### PR DESCRIPTION
Looks like an accidental typo when a global s/st/gui was done

### Q/A checklist

- [x] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [x] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [x] Do a self code review of the changes - Read the diff at least twice.  
- [x] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [x] The relevant pages still run when you press submit
- [x] The API for those pages still work (API tab)
- [x] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [x] Do your UI changes (if applicable) look acceptable on mobile?
- [x] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

