### PR TITLE
Ghana NLP ASR v2

### DIFF
--- a/daras_ai_v2/asr.py
+++ b/daras_ai_v2/asr.py
@@ -202,8 +202,7 @@ MMS_SUPPORTED = {
 GHANA_NLP_SUPPORTED = {'en': 'English', 'tw': 'Twi', 'gaa': 'Ga', 'ee': 'Ewe', 'fat': 'Fante', 'dag': 'Dagbani',
                        'gur': 'Gurene', 'yo': 'Yoruba', 'ki': 'Kikuyu', 'luo': 'Luo', 'mer': 'Kimeru'}  # fmt: skip
 GHANA_NLP_MAXLEN = 500
-GHANA_API_AUTH_HEADERS = {"Ocp-Apim-Subscription-Key": str(settings.GHANA_NLP_SUBKEY)}
-GHANA_ASR_V1_SUPPORTED = {
+GHANA_NLP_ASR_V2_SUPPORTED = {
     "tw": "Twi",
     "gaa": "Ga",
     "dag": "Dagbani",
@@ -229,7 +228,7 @@ class AsrModels(Enum):
     mms_1b_all = "Massively Multilingual Speech (MMS) (Facebook Research)"
 
     seamless_m4t = "Seamless M4T [Deprecated] (Facebook Research)"
-    ghana_nlp_asr_v1 = "Ghana NLP ASR v1"
+    ghana_nlp_asr_v2 = "Ghana NLP ASR v2"
 
     def supports_auto_detect(self) -> bool:
         return self not in {
@@ -237,7 +236,7 @@ class AsrModels(Enum):
             self.gcp_v1,
             self.mms_1b_all,
             self.seamless_m4t_v2,
-            self.ghana_nlp_asr_v1,
+            self.ghana_nlp_asr_v2,
         }
 
     @classmethod
@@ -274,7 +273,7 @@ asr_supported_languages = {
     AsrModels.seamless_m4t_v2: SEAMLESS_v2_ASR_SUPPORTED,
     AsrModels.azure: AZURE_SUPPORTED,
     AsrModels.mms_1b_all: MMS_SUPPORTED,
-    AsrModels.ghana_nlp_asr_v1: GHANA_ASR_V1_SUPPORTED,
+    AsrModels.ghana_nlp_asr_v2: GHANA_NLP_ASR_V2_SUPPORTED,
 }
 
 
@@ -901,9 +900,9 @@ def run_asr(
             ),
             # queue_prefix="gooey-gpu/short" if is_short else "gooey-gpu/long",
         )
-    elif selected_model == AsrModels.ghana_nlp_asr_v1:
+    elif selected_model == AsrModels.ghana_nlp_asr_v2:
         r = requests.post(
-            f"https://translation-api.ghananlp.org/asr/v1/transcribe?language={language}",
+            f"https://translation-api.ghananlp.org/asr/v2/transcribe?language={language}",
             headers={
                 "Content-Type": "audio/wav",
                 "Cache-Control": "no-cache",
@@ -912,7 +911,7 @@ def run_asr(
             data=requests.get(audio_url).content,
         )
         raise_for_status(r)
-        data = dict(text=r.json())
+        data = r.json()
     # call one of the self-hosted models
     else:
         kwargs = {}

--- a/daras_ai_v2/asr.py
+++ b/daras_ai_v2/asr.py
@@ -902,6 +902,8 @@ def run_asr(
             # queue_prefix="gooey-gpu/short" if is_short else "gooey-gpu/long",
         )
     elif selected_model == AsrModels.ghana_nlp_asr_v2:
+        audio_r = requests.get(audio_url)
+        raise_for_status(audio_r)
         r = requests.post(
             furl(
                 "https://translation-api.ghananlp.org/asr/v2/transcribe",
@@ -912,7 +914,7 @@ def run_asr(
                 "Cache-Control": "no-cache",
                 **GHANA_API_AUTH_HEADERS,
             },
-            data=requests.get(audio_url).content,
+            data=audio_r.content,
         )
         raise_for_status(r)
         data = r.json()

--- a/daras_ai_v2/asr.py
+++ b/daras_ai_v2/asr.py
@@ -903,7 +903,7 @@ def run_asr(
         )
     elif selected_model == AsrModels.ghana_nlp_asr_v2:
         audio_r = requests.get(audio_url)
-        raise_for_status(audio_r)
+        raise_for_status(audio_r, is_user_url=True)
         r = requests.post(
             furl(
                 "https://translation-api.ghananlp.org/asr/v2/transcribe",

--- a/daras_ai_v2/asr.py
+++ b/daras_ai_v2/asr.py
@@ -202,6 +202,7 @@ MMS_SUPPORTED = {
 GHANA_NLP_SUPPORTED = {'en': 'English', 'tw': 'Twi', 'gaa': 'Ga', 'ee': 'Ewe', 'fat': 'Fante', 'dag': 'Dagbani',
                        'gur': 'Gurene', 'yo': 'Yoruba', 'ki': 'Kikuyu', 'luo': 'Luo', 'mer': 'Kimeru'}  # fmt: skip
 GHANA_NLP_MAXLEN = 500
+GHANA_API_AUTH_HEADERS = {"Ocp-Apim-Subscription-Key": str(settings.GHANA_NLP_SUBKEY)}
 GHANA_NLP_ASR_V2_SUPPORTED = {
     "tw": "Twi",
     "gaa": "Ga",
@@ -902,11 +903,14 @@ def run_asr(
         )
     elif selected_model == AsrModels.ghana_nlp_asr_v2:
         r = requests.post(
-            f"https://translation-api.ghananlp.org/asr/v2/transcribe?language={language}",
+            furl(
+                "https://translation-api.ghananlp.org/asr/v2/transcribe",
+                query_params=dict(language=language),
+            ),
             headers={
                 "Content-Type": "audio/wav",
                 "Cache-Control": "no-cache",
-                "Ocp-Apim-Subscription-Key": str(settings.GHANA_NLP_SUBKEY),
+                **GHANA_API_AUTH_HEADERS,
             },
             data=requests.get(audio_url).content,
         )

--- a/daras_ai_v2/asr.py
+++ b/daras_ai_v2/asr.py
@@ -203,6 +203,15 @@ GHANA_NLP_SUPPORTED = {'en': 'English', 'tw': 'Twi', 'gaa': 'Ga', 'ee': 'Ewe', '
                        'gur': 'Gurene', 'yo': 'Yoruba', 'ki': 'Kikuyu', 'luo': 'Luo', 'mer': 'Kimeru'}  # fmt: skip
 GHANA_NLP_MAXLEN = 500
 GHANA_API_AUTH_HEADERS = {"Ocp-Apim-Subscription-Key": str(settings.GHANA_NLP_SUBKEY)}
+GHANA_ASR_V1_SUPPORTED = {
+    "tw": "Twi",
+    "gaa": "Ga",
+    "dag": "Dagbani",
+    "yo": "Yoruba",
+    "ee": "Ewe",
+    "ki": "Kikuyu",
+}
+
 
 class AsrModels(Enum):
     whisper_large_v2 = "Whisper Large v2 (openai)"
@@ -220,6 +229,7 @@ class AsrModels(Enum):
     mms_1b_all = "Massively Multilingual Speech (MMS) (Facebook Research)"
 
     seamless_m4t = "Seamless M4T [Deprecated] (Facebook Research)"
+    ghana_nlp_asr_v1 = "Ghana NLP ASR v1"
 
     def supports_auto_detect(self) -> bool:
         return self not in {
@@ -227,6 +237,7 @@ class AsrModels(Enum):
             self.gcp_v1,
             self.mms_1b_all,
             self.seamless_m4t_v2,
+            self.ghana_nlp_asr_v1,
         }
 
     @classmethod
@@ -263,6 +274,7 @@ asr_supported_languages = {
     AsrModels.seamless_m4t_v2: SEAMLESS_v2_ASR_SUPPORTED,
     AsrModels.azure: AZURE_SUPPORTED,
     AsrModels.mms_1b_all: MMS_SUPPORTED,
+    AsrModels.ghana_nlp_asr_v1: GHANA_ASR_V1_SUPPORTED,
 }
 
 
@@ -889,6 +901,18 @@ def run_asr(
             ),
             # queue_prefix="gooey-gpu/short" if is_short else "gooey-gpu/long",
         )
+    elif selected_model == AsrModels.ghana_nlp_asr_v1:
+        r = requests.post(
+            f"https://translation-api.ghananlp.org/asr/v1/transcribe?language={language}",
+            headers={
+                "Content-Type": "audio/wav",
+                "Cache-Control": "no-cache",
+                "Ocp-Apim-Subscription-Key": str(settings.GHANA_NLP_SUBKEY),
+            },
+            data=requests.get(audio_url).content,
+        )
+        raise_for_status(r)
+        data = dict(text=r.json())
     # call one of the self-hosted models
     else:
         kwargs = {}


### PR DESCRIPTION
### Q/A checklist

- [x] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [x] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [x] Do a self code review of the changes - Read the diff at least twice.  
- [x] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [x] The relevant pages still run when you press submit
- [x] The API for those pages still work (API tab)
- [x] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [x] Do your UI changes (if applicable) look acceptable on mobile?
- [x] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

