### PR TITLE
support facebook video url download via yt-dlp

### DIFF
--- a/daras_ai_v2/asr.py
+++ b/daras_ai_v2/asr.py
@@ -1,6 +1,5 @@
 import multiprocessing
 import os.path
-import os.path
 import tempfile
 import typing
 from enum import Enum
@@ -753,12 +752,12 @@ def run_asr(
     import google.cloud.speech_v2 as cloud_speech
     from google.api_core.client_options import ClientOptions
     from google.cloud.texttospeech_v1 import AudioEncoding
-    from daras_ai_v2.vector_search import is_yt_url
+    from daras_ai_v2.vector_search import is_yt_dlp_able_url
     import langcodes
 
     selected_model = AsrModels[selected_model]
     output_format = AsrOutputFormat[output_format]
-    if is_yt_url(audio_url):
+    if is_yt_dlp_able_url(audio_url):
         audio_url, size = download_youtube_to_wav_url(audio_url)
     elif is_gdrive_url(furl(audio_url)):
         meta: dict[str, str] = gdrive_metadata(url_to_gdrive_file_id(furl(audio_url)))

--- a/daras_ai_v2/asr.py
+++ b/daras_ai_v2/asr.py
@@ -1046,7 +1046,7 @@ def download_youtube_to_wav(youtube_url: str) -> bytes:
             "yt-dlp", "-v",
             "--no-playlist",
             "--max-downloads", "1",
-            "--format", "bestaudio",
+            "--format", "bestaudio/best",
             "--output", infile,
             *proxy_args,
             youtube_url,

--- a/recipes/DocExtract.py
+++ b/recipes/DocExtract.py
@@ -3,7 +3,6 @@ import threading
 import typing
 
 import gooey_gui as gui
-
 import requests
 from aifail import retry_if
 from django.db.models import IntegerChoices
@@ -58,6 +57,7 @@ from daras_ai_v2.vector_search import (
     get_pdf_num_pages,
     doc_url_to_text_pages,
     doc_or_yt_url_to_metadatas,
+    is_yt_dlp_able_url,
 )
 from files.models import FileMetadata
 from recipes.DocSearch import render_documents
@@ -352,7 +352,7 @@ def col_i2a(col: int) -> str:
 
 
 def extract_info(url: str) -> list[dict | None]:
-    if is_yt_url(url):
+    if is_yt_dlp_able_url(url):
         return yt_dlp_get_video_entries(url)
 
     # assume it's a direct link
@@ -449,7 +449,7 @@ def process_source(
     )
 
     content_url = existing_values[Columns.content_url.value]
-    is_yt = is_yt_url(webpage_url)
+    is_yt = is_yt_dlp_able_url(webpage_url)
     is_pdf = doc_meta and "application/pdf" in doc_meta.mime_type
     is_video = doc_meta and (
         "video/" in doc_meta.mime_type or "audio/" in doc_meta.mime_type
@@ -557,10 +557,6 @@ def update_cell(spreadsheet_id: str, row: int, col: int, value: str):
         body={"values": [[value]]},
         valueInputOption="RAW",
     ).execute()
-
-
-def is_yt_url(url: str) -> bool:
-    return "youtube.com" in url or "youtu.be" in url
 
 
 threadlocal = threading.local()

--- a/tests/test_yt_dlp.py
+++ b/tests/test_yt_dlp.py
@@ -1,0 +1,24 @@
+import pytest
+
+from daras_ai_v2.vector_search import is_yt_dlp_able_url
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        # youtube video links
+        ("https://www.youtube.com/watch?v=vtB1J_zCv8I", True),
+        ("https://youtu.be/vtB1J_zCv8I?si=UUGHp_zxzg8YT4sW", True),
+        # facebook video links
+        ("https://www.facebook.com/watch/?v=724258088377627", True),
+        ("https://fb.watch/uMRczAWxcU/", True),
+        ("https://www.facebook.com/unheardkashmir/videos/724258088377627", True),
+        ("https://www.facebook.com/share/v/qmq7SvGX4Y5smixX/", True),
+        # other fb links
+        ("https://www.facebook.com/GooeyAI", False),
+        ("https://www.facebook.com/share/p/KtodMirKmiGqhyfZ/", False),
+        ("https://www.facebook.com/marketplace/item/7206063666166896/", False),
+    ],
+)
+def test_is_yt_dlp_able_url(url, expected):
+    assert is_yt_dlp_able_url(url) == expected


### PR DESCRIPTION
### Q/A checklist

- [ ] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [ ] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [ ] Do a self code review of the changes - Read the diff at least twice.  
- [ ] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [ ] The relevant pages still run when you press submit
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
- [ ] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

