### PR TITLE
Add language model setting on eval

### DIFF
--- a/recipes/BulkEval.py
+++ b/recipes/BulkEval.py
@@ -22,10 +22,7 @@ from daras_ai_v2.language_model import (
     run_language_model,
     LargeLanguageModels,
 )
-from daras_ai_v2.language_model_settings_widgets import (
-    LanguageModelSettings,
-    language_model_settings,
-)
+from daras_ai_v2.language_model_settings_widgets import LanguageModelSettings
 from daras_ai_v2.prompt_vars import render_prompt_vars
 from recipes.BulkRunner import read_df_any, list_view_editor, del_button
 from recipes.DocSearch import render_documents
@@ -276,8 +273,8 @@ Here's what you uploaded:
             render_inputs=render_agg_inputs,
         )
 
-    def render_settings(self):
-        language_model_settings()
+    # def render_settings(self):
+    #     language_model_settings()
 
     def render_example(self, state: dict):
         render_documents(state)


### PR DESCRIPTION
- Add default for Eval language model and add settings
- Hide LM settings on eval because they are being ignored

### Q/A checklist

- [ ] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [ ] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [ ] Do a self code review of the changes - Read the diff at least twice.  
- [ ] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [ ] The relevant pages still run when you press submit
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
- [ ] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

