### PR TITLE
Fix Whatsapp text Integration text & Footer year text

### DIFF
--- a/recipes/VideoBots.py
+++ b/recipes/VideoBots.py
@@ -1569,7 +1569,7 @@ connect_choices = [
     ConnectChoice(
         platform=Platform.WHATSAPP,
         img="https://storage.googleapis.com/dara-c1b52.appspot.com/daras_ai/media/1e49ad50-d6c9-11ee-99c3-02420a000123/thumbs/Digital_Inline_Green_400x400.png",
-        label="Bring your own WhatsApp number to connect. Need a new one? Email [sales@gooey.ai](mailto:sales@gooey.ai) for help.",
+        label="Connect your own new mobile # (that's not already on WhatsApp) or [upgrade to Business](https://gooey.ai/pricing) for a number on us.",
     ),
     ConnectChoice(
         platform=Platform.SLACK,

--- a/routers/root.py
+++ b/routers/root.py
@@ -711,6 +711,7 @@ def page_wrapper(request: Request, className=""):
         "request": request,
         "settings": settings,
         "block_incognito": True,
+        "current_year": datetime.datetime.now().year,
     }
     if request.user and request.user.is_anonymous:
         context["anonymous_user_token"] = auth.create_custom_token(
@@ -735,7 +736,6 @@ def page_wrapper(request: Request, className=""):
         with gui.div(id="main-content", className="container-xxl " + className):
             yield
 
-        context["current_year"] = datetime.datetime.now().year
         gui.html(templates.get_template("footer.html").render(**context))
         gui.html(templates.get_template("login_scripts.html").render(**context))
 

--- a/routers/root.py
+++ b/routers/root.py
@@ -735,6 +735,7 @@ def page_wrapper(request: Request, className=""):
         with gui.div(id="main-content", className="container-xxl " + className):
             yield
 
+        context["current_year"] = datetime.datetime.now().year
         gui.html(templates.get_template("footer.html").render(**context))
         gui.html(templates.get_template("login_scripts.html").render(**context))
 

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -79,7 +79,7 @@
       <span
         class="text-muted gui-html-container gui-md-container"
         style="font-size: 0.9rem"
-        ><p>©{{ current_year if current_year is defined else 2024 }} by Gooey.AI / Dara.network Inc</p>
+        ><p>©{{ current_year or 2024 }} by Gooey.AI / Dara.network Inc</p>
       </span>
     </div>
 

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -79,7 +79,7 @@
       <span
         class="text-muted gui-html-container gui-md-container"
         style="font-size: 0.9rem"
-        ><p>©2023 by Gooey.AI / Dara.network Inc</p>
+        ><p>©{{ current_year if current_year is defined else 2024 }} by Gooey.AI / Dara.network Inc</p>
       </span>
     </div>
 


### PR DESCRIPTION
### Q/A checklist

- [x] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [x] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [x] Do a self code review of the changes - Read the diff at least twice.  
- [x] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [x] The relevant pages still run when you press submit
- [x] The API for those pages still work (API tab)
- [x] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [x] Do your UI changes (if applicable) look acceptable on mobile?
- [x] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

