### PR TITLE
fix save flow for anon users

### DIFF
--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -405,7 +405,8 @@ class BasePage:
                     )
 
                     if self.tab == RecipeTabs.run:
-                        self._render_options_button_with_dialog()
+                        if self.request.user and not self.request.user.is_anonymous:
+                            self._render_options_button_with_dialog()
                         self._render_share_button()
                         self._render_save_button()
                     else:
@@ -778,7 +779,7 @@ class BasePage:
             return False
 
     def _saved_options_modal(self):
-        assert self.request.user
+        assert self.request.user and not self.request.user.is_anonymous
 
         is_latest_version = self.current_pr.saved_run == self.current_sr
 
@@ -841,7 +842,7 @@ This will also delete all the associated versions.
             self._render_version_history()
 
     def _unsaved_options_modal(self):
-        assert self.request.user
+        assert self.request.user and not self.request.user.is_anonymous
 
         gui.write(
             "Like this AI workflow? Duplicate and then customize it for your use case."

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -1681,7 +1681,6 @@ This will also delete all the associated versions.
         ).update(run_status=STARTING_STATE, uid=self.request.user.uid)
         if updated_count >= 1:
             # updated now
-            self.dump_state_to_sr(self._get_validated_state(), self.current_sr)
             self.call_runner_task(self.current_sr)
         elif self.get_run_state(self.current_sr.to_dict()) == RecipeRunState.standby:
             # updated by a different thread, we just refresh_from_db


### PR DESCRIPTION
### Q/A checklist

- [x] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [x] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [x] Do a self code review of the changes - Read the diff at least twice.  
- [x] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [x] The relevant pages still run when you press submit
- [x] The API for those pages still work (API tab)
- [x] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [x] Do your UI changes (if applicable) look acceptable on mobile?
- [x] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

