### PR TITLE
fix default notes and visibility for forked published runs

### DIFF
--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -658,8 +658,10 @@ class BasePage:
         with gui.div(className="mt-4"):
             if is_update_mode:
                 title = pr.title or self.title
+                notes = pr.notes
             else:
                 title = self._get_default_pr_title()
+                notes = ""
             published_run_title = gui.text_input(
                 "###### Title",
                 key="published_run_title",
@@ -668,7 +670,7 @@ class BasePage:
             published_run_notes = gui.text_area(
                 "###### Notes",
                 key="published_run_notes",
-                value=(pr.notes or self.preview_description(gui.session_state) or ""),
+                value=notes,
             )
 
         self._render_admin_options(sr, pr)
@@ -712,7 +714,7 @@ class BasePage:
                 user=self.request.user,
                 title=published_run_title.strip(),
                 notes=published_run_notes.strip(),
-                visibility=PublishedRunVisibility(pr.visibility),
+                visibility=PublishedRunVisibility.UNLISTED,
             )
         else:
             updates = dict(
@@ -813,12 +815,18 @@ This will also delete all the associated versions.
                 self.current_pr.delete()
                 raise gui.RedirectException(self.app_url())
 
+        title = f"{self.current_pr.title} (Copy)"
+        if self.current_pr.is_root():
+            notes = ""
+        else:
+            notes = self.current_pr.notes
+
         if duplicate_button:
             duplicate_pr = self.current_pr.duplicate(
                 user=self.request.user,
-                title=f"{self.current_pr.title} (Copy)",
-                notes=self.current_pr.notes,
-                visibility=PublishedRunVisibility(PublishedRunVisibility.UNLISTED),
+                title=title,
+                notes=notes,
+                visibility=PublishedRunVisibility.UNLISTED,
             )
             raise gui.RedirectException(
                 self.app_url(example_id=duplicate_pr.published_run_id)
@@ -829,9 +837,9 @@ This will also delete all the associated versions.
                 published_run_id=get_random_doc_id(),
                 saved_run=self.current_sr,
                 user=self.request.user,
-                title=f"{self.current_pr.title} (Copy)",
-                notes=self.current_pr.notes,
-                visibility=PublishedRunVisibility(PublishedRunVisibility.UNLISTED),
+                title=title,
+                notes=notes,
+                visibility=PublishedRunVisibility.UNLISTED,
             )
             raise gui.RedirectException(
                 self.app_url(example_id=new_pr.published_run_id)


### PR DESCRIPTION
### Q/A checklist

- [ ] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [ ] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [ ] Do a self code review of the changes - Read the diff at least twice.  
- [ ] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [ ] The relevant pages still run when you press submit
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
- [ ] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

