### PR TITLE
Fix social buttons bug on video bots stats page

### DIFF
--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -392,25 +392,7 @@ class BasePage:
                 if request_changed or (can_save and not is_example):
                     self._render_unpublished_changes_indicator()
 
-                with gui.div(className="d-flex align-items-start right-action-icons"):
-                    gui.html(
-                        # styling for buttons in this div
-                        """
-                        <style>
-                        .right-action-icons .btn {
-                            padding: 6px;
-                        }
-                        </style>
-                        """
-                    )
-
-                    if self.tab == RecipeTabs.run:
-                        if self.request.user and not self.request.user.is_anonymous:
-                            self._render_options_button_with_dialog()
-                        self._render_share_button()
-                        self._render_save_button()
-                    else:
-                        self._render_copy_link_button(label="Copy Link")
+                self.render_social_buttons()
 
         if tbreadcrumbs.has_breadcrumbs() or self.current_sr_user:
             # only render title here if the above row was not empty
@@ -472,6 +454,27 @@ class BasePage:
                     self._saved_options_modal()
                 else:
                     self._unsaved_options_modal()
+
+    def render_social_buttons(self):
+        with gui.div(className="d-flex align-items-start right-action-icons"):
+            gui.html(
+                # styling for buttons in this div
+                """
+                <style>
+                .right-action-icons .btn {
+                    padding: 6px;
+                }
+                </style>
+                """
+            )
+
+            if self.tab == RecipeTabs.run:
+                if self.request.user and not self.request.user.is_anonymous:
+                    self._render_options_button_with_dialog()
+                self._render_share_button()
+                self._render_save_button()
+            else:
+                self._render_copy_link_button(label="Copy Link")
 
     def _render_share_button(self):
         if (

--- a/recipes/VideoBotsStats.py
+++ b/recipes/VideoBotsStats.py
@@ -106,8 +106,7 @@ class VideoBotsStatsPage(BasePage):
                 )
 
             with gui.div(className="d-flex align-items-center"):
-                with gui.div(className="d-flex align-items-start right-action-icons"):
-                    self._render_social_buttons(show_button_text=True)
+                self.render_social_buttons()
 
         gui.markdown("# " + self.get_dynamic_meta_title())
 


### PR DESCRIPTION
### Q/A checklist

- [x] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [ ] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [ ] Do a self code review of the changes - Read the diff at least twice.  
- [ ] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [ ] The relevant pages still run when you press submit
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
- [ ] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

