### PR TITLE
Refactor functions-related code to render prompt functions without using current_workspace

### DIFF
--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -1208,10 +1208,9 @@ This will also delete all the associated versions.
         )
 
     @cached_property
-    def current_workspace(self) -> typing.Optional["Workspace"]:
-        return self.request.user and get_current_workspace(
-            self.request.user, self.request.session
-        )
+    def current_workspace(self) -> "Workspace":
+        assert self.request.user, "User must be logged in to get their workspace"
+        return get_current_workspace(self.request.user, self.request.session)
 
     @cached_property
     def current_sr_user(self) -> AppUser | None:

--- a/daras_ai_v2/workflow_url_input.py
+++ b/daras_ai_v2/workflow_url_input.py
@@ -127,9 +127,7 @@ def init_workflow_selector(
         internal_state.setdefault("--added_workflows", {})[url] = title
 
 
-def url_to_runs(
-    url: str,
-) -> tuple[typing.Type[BasePage], SavedRun, PublishedRun | None]:
+def url_to_runs(url: str) -> tuple[typing.Type[BasePage], SavedRun, PublishedRun]:
     from daras_ai_v2.all_pages import page_slug_map, normalize_slug
 
     assert url, "URL is required"

--- a/functions/models.py
+++ b/functions/models.py
@@ -1,10 +1,14 @@
 import typing
+from functools import cached_property
 
 from django.db import models
 from pydantic import BaseModel, Field
 
 from daras_ai_v2.custom_enum import GooeyEnum
 from daras_ai_v2.pydantic_validation import FieldHttpUrl
+
+if typing.TYPE_CHECKING:
+    from bots.models import SavedRun, PublishedRun
 
 
 class _TriggerData(typing.NamedTuple):
@@ -27,6 +31,21 @@ class RecipeFunction(BaseModel):
         title="Trigger",
         description="When to run this function. `pre` runs before the recipe, `post` runs after the recipe.",
     )
+
+    @cached_property
+    def _runs(self) -> tuple["SavedRun", "PublishedRun"]:
+        from daras_ai_v2.workflow_url_input import url_to_runs
+
+        _, sr, pr = url_to_runs(self.url)
+        return sr, pr
+
+    @property
+    def sr(self) -> "SavedRun":
+        return self._runs[0]
+
+    @property
+    def pr(self) -> "PublishedRun":
+        return self._runs[1]
 
 
 class CalledFunctionResponse(BaseModel):

--- a/functions/recipe_functions.py
+++ b/functions/recipe_functions.py
@@ -31,11 +31,9 @@ def call_recipe_functions(
     trigger: FunctionTrigger,
 ) -> typing.Generator[typing.Union[str, tuple[str, "LLMTool"]], None, None]:
     request = request_model.parse_obj(state)
-
-    if not request.functions:
-        return
-
-    functions = [fun for fun in request.functions if fun.trigger == trigger]
+    functions = request.functions and [
+        fun for fun in request.functions if fun.trigger == trigger
+    ]
     if not functions:
         return
 


### PR DESCRIPTION
### Q/A checklist

- [ ] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [ ] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [ ] Do a self code review of the changes - Read the diff at least twice.  
- [ ] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [ ] The relevant pages still run when you press submit
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
- [ ] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

