### PR TITLE
fix header on workflow pages: breadcrumb alignment, title, and responsive share buton

### DIFF
--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -414,7 +414,7 @@ class BasePage:
         if not workspace:
             return
 
-        with gui.breadcrumbs(divider="▶"):
+        with gui.breadcrumbs(divider=""):
             with gui.tag("li", className="breadcrumb-item"):
                 self.render_workspace_author(workspace)
 
@@ -426,6 +426,9 @@ class BasePage:
                 "li",
                 className="breadcrumb-item d-flex align-items-center container-margin-reset",
             ):
+                with gui.tag("small", className="text-muted pe-2"):
+                    gui.html(icons.chevron_right)
+
                 if user := self.current_sr_user:
                     full_name = user.full_name()
                     link = user.handle and user.handle.get_app_url()

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -368,7 +368,9 @@ class BasePage:
         request_changed = self._has_request_changed()
 
         with gui.div(className="d-flex justify-content-between align-items-start mt-4"):
-            with gui.div():
+            left, right = gui.div(), gui.div()
+
+            with left:
                 if tbreadcrumbs.has_breadcrumbs():
                     with gui.div(
                         className="d-block d-lg-flex align-items-center pt-2 mb-2"
@@ -384,14 +386,16 @@ class BasePage:
                         self._render_author_as_breadcrumb(
                             is_example=is_example, is_root_example=is_root_example
                         )
+                else:
+                    self._render_title(tbreadcrumbs.h1_title)
 
-                self._render_title(tbreadcrumbs.h1_title)
-
-            with gui.div(className="d-flex align-items-center"):
+            with right, gui.div(className="d-flex align-items-center"):
                 if request_changed or (can_save and not is_example):
                     self._render_unpublished_changes_indicator()
-
                 self.render_social_buttons()
+
+        if tbreadcrumbs.has_breadcrumbs():
+            self._render_title(tbreadcrumbs.h1_title)
 
         if self.tab != RecipeTabs.run:
             return

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -462,7 +462,9 @@ class BasePage:
         gui.write(f"# {title}")
 
     def _render_unpublished_changes_indicator(self):
-        with gui.tag("span", className="d-none d-sm-inline-block text-muted"):
+        with gui.tag(
+            "span", className="d-none d-sm-inline-block text-muted text-nowrap"
+        ):
             gui.html("Unpublished changes")
 
     def _render_options_button_with_dialog(self):
@@ -488,7 +490,7 @@ class BasePage:
                     padding: 6px;
                 }
                 </style>
-                """
+                """.strip()
             )
 
             if self.tab == RecipeTabs.run:

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -367,29 +367,24 @@ class BasePage:
         can_save = self.can_user_save_run(sr, pr)
         request_changed = self._has_request_changed()
 
-        with gui.div(className="d-flex justify-content-between align-items-start mt-4"):
-            left, right = gui.div(), gui.div()
-
-            with left:
-                if tbreadcrumbs.has_breadcrumbs():
-                    with gui.div(
-                        className="d-block d-lg-flex align-items-center pt-2 mb-2"
-                    ):
-                        with gui.div(className="me-3 mb-1 mb-lg-0"):
-                            render_breadcrumbs(
-                                tbreadcrumbs,
-                                is_api_call=(
-                                    sr.is_api_call and self.tab == RecipeTabs.run
-                                ),
-                            )
-
-                        self._render_author_as_breadcrumb(
-                            is_example=is_example, is_root_example=is_root_example
+        with gui.div(className="d-flex justify-content-between align-items-start mt-3"):
+            if tbreadcrumbs.has_breadcrumbs():
+                with gui.div(
+                    className="d-block d-lg-flex align-items-center pt-2 mb-2"
+                ):
+                    with gui.div(className="me-3 mb-1 mb-lg-0"):
+                        render_breadcrumbs(
+                            tbreadcrumbs,
+                            is_api_call=(sr.is_api_call and self.tab == RecipeTabs.run),
                         )
-                else:
-                    self._render_title(tbreadcrumbs.h1_title)
 
-            with right, gui.div(className="d-flex align-items-center"):
+                    self._render_author_as_breadcrumb(
+                        is_example=is_example, is_root_example=is_root_example
+                    )
+            else:
+                self._render_title(tbreadcrumbs.h1_title)
+
+            with gui.div(className="d-flex align-items-center my-auto"):
                 if request_changed or (can_save and not is_example):
                     self._render_unpublished_changes_indicator()
                 self.render_social_buttons()
@@ -414,21 +409,21 @@ class BasePage:
         if not workspace:
             return
 
-        with gui.breadcrumbs(divider=""):
-            with gui.tag("li", className="breadcrumb-item"):
+        with gui.div(
+            className="d-flex gap-2 align-items-center", style=dict(listStyle="none")
+        ):
+            with gui.tag("li"):
                 self.render_workspace_author(workspace)
 
             # don't render the user's name for examples and personal workspaces
             if is_example or workspace.is_personal:
                 return
 
-            with gui.tag(
-                "li",
-                className="breadcrumb-item d-flex align-items-center container-margin-reset",
-            ):
-                with gui.tag("small", className="text-muted pe-2"):
-                    gui.html(icons.chevron_right)
+            gui.html(icons.chevron_right)
 
+            with gui.tag(
+                "li", className="d-flex align-items-center container-margin-reset"
+            ):
                 if user := self.current_sr_user:
                     full_name = user.full_name()
                     link = user.handle and user.handle.get_app_url()

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -510,7 +510,9 @@ class BasePage:
             dialog = gui.use_alert_dialog(key="share-modal")
             icon = PublishedRunVisibility(self.current_pr.visibility).get_icon()
             if gui.button(
-                f"{icon} Share", className="mb-0 ms-lg-2 px-lg-4", type="secondary"
+                f'{icon} <span class="d-none d-lg-inline">Share</span>',
+                className="mb-0 ms-lg-2 px-lg-4",
+                type="secondary",
             ):
                 dialog.set_open(True)
 

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -513,6 +513,7 @@ class BasePage:
             not self.current_pr.is_root()
             and self.current_pr.saved_run_id == self.current_sr.id
             and self.can_user_edit_published_run(self.current_pr)
+            and not self._has_request_changed()
         ):
             dialog = gui.use_alert_dialog(key="share-modal")
             icon = PublishedRunVisibility(self.current_pr.visibility).get_icon()

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -367,31 +367,31 @@ class BasePage:
         can_save = self.can_user_save_run(sr, pr)
         request_changed = self._has_request_changed()
 
-        with gui.div(className="d-flex justify-content-between mt-4"):
-            with gui.div(className="d-lg-flex d-block align-items-center"):
-                if not tbreadcrumbs.has_breadcrumbs() and not self.current_sr_user:
-                    self._render_title(tbreadcrumbs.h1_title)
+        with gui.div(className="d-flex justify-content-between align-items-start mt-4"):
+            with gui.div():
+                if tbreadcrumbs.has_breadcrumbs():
+                    with gui.div(
+                        className="d-block d-lg-flex align-items-center pt-2 mb-2"
+                    ):
+                        with gui.div(className="me-3 mb-1 mb-lg-0"):
+                            render_breadcrumbs(
+                                tbreadcrumbs,
+                                is_api_call=(
+                                    sr.is_api_call and self.tab == RecipeTabs.run
+                                ),
+                            )
 
-                if tbreadcrumbs:
-                    with gui.tag("div", className="me-3 mb-1 mb-lg-0 py-2 py-lg-0"):
-                        render_breadcrumbs(
-                            tbreadcrumbs,
-                            is_api_call=(sr.is_api_call and self.tab == RecipeTabs.run),
+                        self._render_author_as_breadcrumb(
+                            is_example=is_example, is_root_example=is_root_example
                         )
 
-                self._render_author_as_breadcrumb(
-                    is_example=is_example, is_root_example=is_root_example
-                )
+                self._render_title(tbreadcrumbs.h1_title)
 
             with gui.div(className="d-flex align-items-center"):
                 if request_changed or (can_save and not is_example):
                     self._render_unpublished_changes_indicator()
 
                 self.render_social_buttons()
-
-        if tbreadcrumbs.has_breadcrumbs() or self.current_sr_user:
-            # only render title here if the above row was not empty
-            self._render_title(tbreadcrumbs.h1_title)
 
         if self.tab != RecipeTabs.run:
             return
@@ -462,11 +462,8 @@ class BasePage:
         gui.write(f"# {title}")
 
     def _render_unpublished_changes_indicator(self):
-        with gui.div(
-            className="d-none d-lg-flex h-100 align-items-center text-muted ms-2"
-        ):
-            with gui.tag("span", className="d-inline-block"):
-                gui.html("Unpublished changes")
+        with gui.tag("span", className="d-none d-sm-inline-block text-muted"):
+            gui.html("Unpublished changes")
 
     def _render_options_button_with_dialog(self):
         ref = gui.use_alert_dialog(key="options-modal")

--- a/daras_ai_v2/breadcrumbs.py
+++ b/daras_ai_v2/breadcrumbs.py
@@ -36,15 +36,8 @@ def render_breadcrumbs(breadcrumbs: TitleBreadCrumbs, *, is_api_call: bool = Fal
         """
         <style>
         @media (min-width: 1024px) {
-            .breadcrumb-item-large {
+            .fs-lg-5 {
                 font-size: 1.25rem !important;
-            }
-        }
-
-        @media (max-width: 1024px) {
-            .breadcrumb-item-large {
-                font-size: 0.85rem !important;
-                padding-top: 6px;
             }
         }
         </style>
@@ -60,13 +53,13 @@ def render_breadcrumbs(breadcrumbs: TitleBreadCrumbs, *, is_api_call: bool = Fal
             gui.breadcrumb_item(
                 breadcrumbs.root_title.title,
                 link_to=breadcrumbs.root_title.url,
-                className="text-muted breadcrumb-item-large",
+                className="text-muted fs-lg-5",
             )
         if breadcrumbs.published_title:
             gui.breadcrumb_item(
                 breadcrumbs.published_title.title,
                 link_to=breadcrumbs.published_title.url,
-                className="breadcrumb-item-large",
+                className="fs-lg-5",
             )
 
         if is_api_call:

--- a/daras_ai_v2/icons.py
+++ b/daras_ai_v2/icons.py
@@ -30,6 +30,7 @@ home = '<i class="fa-regular fa-home"></i>'
 notes = '<i class="fa-regular fa-money-check-pen"></i>'
 lock = '<i class="fa-solid fa-lock"></i>'
 globe = '<i class="fa-regular fa-globe"></i>'
+chevron_right = '<i class="fa-solid fa-chevron-right"></i>'
 
 # brands
 github = '<i class="fa-brands fa-github"></i>'

--- a/daras_ai_v2/icons.py
+++ b/daras_ai_v2/icons.py
@@ -30,7 +30,7 @@ home = '<i class="fa-regular fa-home"></i>'
 notes = '<i class="fa-regular fa-money-check-pen"></i>'
 lock = '<i class="fa-solid fa-lock"></i>'
 globe = '<i class="fa-regular fa-globe"></i>'
-chevron_right = '<i class="fa-solid fa-chevron-right"></i>'
+chevron_right = '<i class="fa-sharp-duotone fa-solid fa-sm fa-chevron-right"></i>'
 
 # brands
 github = '<i class="fa-brands fa-github"></i>'


### PR DESCRIPTION
- **fix alignment in header on workflow pages**
- **add text-nowrap on "unpublished changes" indicator**
- **fix bug where 'Share' modal disappears when form input changes**
- **hide text on 'share' button on smaller screens**
- **fix: make title occupy full-width under breadcrumbs+buttons row**

### Q/A checklist

- [ ] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [ ] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [ ] Do a self code review of the changes - Read the diff at least twice.  
- [ ] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [ ] The relevant pages still run when you press submit
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
- [ ] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

