### PR TITLE
fix copy-link button behaviour in share dialog

### DIFF
--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -39,10 +39,7 @@ from daras_ai.text_format import format_number_with_suffix
 from daras_ai_v2 import settings, urls, icons
 from daras_ai_v2.api_examples_widget import api_example_generator
 from daras_ai_v2.breadcrumbs import render_breadcrumbs, get_title_breadcrumbs
-from daras_ai_v2.copy_to_clipboard_button_widget import (
-    copy_text_to_clipboard,
-    copy_to_clipboard_button,
-)
+from daras_ai_v2.copy_to_clipboard_button_widget import copy_to_clipboard_button
 from daras_ai_v2.crypto import get_random_doc_id
 from daras_ai_v2.db import ANONYMOUS_USER_COOKIE
 from daras_ai_v2.exceptions import InsufficientCredits
@@ -531,13 +528,6 @@ class BasePage:
         )
 
     def _render_share_modal(self, dialog: gui.AlertDialogRef):
-        copy_link_button_key = "copy-link-in-share-modal"
-        if gui.session_state.pop(copy_link_button_key, None):
-            # we don't render the modal, only execute the copy-link action
-            copy_text_to_clipboard(self.current_app_url(self.tab))
-            dialog.set_open(False)
-            return
-
         with gui.alert_dialog(
             ref=dialog, modal_title=f"#### Share: {self.current_pr.title}"
         ):
@@ -606,11 +596,11 @@ class BasePage:
                         return self._render_publish_dialog(ref=ref)
 
             with gui.div(className="d-flex justify-content-between pt-4"):
-                gui.button(
+                copy_to_clipboard_button(
                     label=f"{icons.link} Copy Link",
-                    key=copy_link_button_key,
-                    className="py-2 px-3 m-0",
+                    value=self.current_app_url(self.tab),
                     type="secondary",
+                    className="py-2 px-3 m-0",
                 )
                 if gui.button("Done", type="primary", className="py-2 px-5 m-0"):
                     dialog.set_open(False)

--- a/daras_ai_v2/copy_to_clipboard_button_widget.py
+++ b/daras_ai_v2/copy_to_clipboard_button_widget.py
@@ -1,4 +1,3 @@
-import json
 import typing
 from html import escape
 
@@ -39,13 +38,4 @@ def copy_to_clipboard_button(
     {label}
 </button>
         """,
-    )
-
-
-def copy_text_to_clipboard(text):
-    gui.js(
-        # language="javascript"
-        f"""
-        navigator.clipboard.writeText({json.dumps(text)});
-        """
     )


### PR DESCRIPTION
### Q/A checklist

- [ ] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [ ] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [ ] Do a self code review of the changes - Read the diff at least twice.  
- [ ] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [ ] The relevant pages still run when you press submit
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
- [ ] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

