### PR TITLE
auto-accept workspace invitation for all existing AppUsers. Otherwise send email

### DIFF
--- a/workspaces/models.py
+++ b/workspaces/models.py
@@ -445,29 +445,20 @@ class WorkspaceInviteQuerySet(models.QuerySet):
                 invite.status = WorkspaceInvite.Status.PENDING
                 invite.save(update_fields=["status"])
 
-        should_auto_accept = (
-            workspace.domain_name
-            and workspace.domain_name.lower() == email.split("@")[-1].lower()
-        )
-        if should_auto_accept:
-            try:
-                invitee = AppUser.objects.get(email=invite.email)
-            except AppUser.DoesNotExist:
-                invite.send_email()
-            else:
-                invite.accept(
-                    invitee,
-                    updated_by=current_user or invite.created_by,
-                    auto_accepted=True,
-                )
-                logger.info(
-                    f"User {invitee} auto-accepted invitation to workspace {invite.workspace}"
-                )
-                send_added_to_workspace_email.delay(
-                    invite_id=invite.id, user_id=invitee.id
-                )
-        else:
+        try:
+            invitee = AppUser.objects.get(email=invite.email)
+        except AppUser.DoesNotExist:
             invite.send_email()
+        else:
+            invite.accept(
+                invitee,
+                updated_by=current_user or invite.created_by,
+                auto_accepted=True,
+            )
+            logger.info(
+                f"User {invitee} auto-accepted invitation to workspace {invite.workspace}"
+            )
+            send_added_to_workspace_email.delay(invite_id=invite.id, user_id=invitee.id)
 
         return invite
 


### PR DESCRIPTION
### Q/A checklist

- [ ] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [ ] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [ ] Do a self code review of the changes - Read the diff at least twice.  
- [ ] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [ ] The relevant pages still run when you press submit
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
- [ ] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

