### PR TITLE
bug fix: `state->variables->$key` value is changed on first render

### DIFF
--- a/daras_ai_v2/prompt_vars.py
+++ b/daras_ai_v2/prompt_vars.py
@@ -72,26 +72,27 @@ def variables_input(
 
         col1, col2 = gui.columns([11, 1], responsive=False)
         with col1:
-            value = old_vars.get(name)
+            displayed_value = stored_value = old_vars.get(name)
             try:
-                new_text_value = gui.session_state[var_key]
+                displayed_value = gui.session_state[var_key]
             except KeyError:
-                if value is None:
-                    value = ""
-                is_json = isinstance(value, (dict, list))
+                if stored_value is None:
+                    displayed_value = ""
+                is_json = isinstance(stored_value, (dict, list))
                 if is_json:
-                    value = json.dumps(value, indent=2)
-                gui.session_state[var_key] = str(value)
+                    displayed_value = json.dumps(stored_value, indent=2)
+                gui.session_state[var_key] = str(displayed_value)
             else:
                 try:
-                    value = json.loads(new_text_value)
-                    is_json = isinstance(value, (dict, list))
-                    if not is_json:
-                        value = new_text_value
+                    stored_value = json.loads(displayed_value)
                 except json.JSONDecodeError:
                     is_json = False
-                    value = new_text_value
-            new_vars[name] = value
+                else:
+                    is_json = isinstance(stored_value, (dict, list))
+                if not is_json:
+                    stored_value = displayed_value
+
+            new_vars[name] = stored_value
 
             gui.text_area(
                 "**```" + name + "```**" + (" (JSON)" if is_json else ""),


### PR DESCRIPTION
`state->variables->$key` has the stored state variables that are used
during the workflow run. in the widget used to accept input from the user,
this was being overwritten to this same value. this PR fixes that.

### Q/A checklist

- [ ] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [ ] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [ ] Do a self code review of the changes - Read the diff at least twice.  
- [ ] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [ ] The relevant pages still run when you press submit
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
- [ ] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

