### PR TITLE
add new llama models

### DIFF
--- a/daras_ai_v2/language_model.py
+++ b/daras_ai_v2/language_model.py
@@ -176,46 +176,76 @@ class LargeLanguageModels(Enum):
     )
 
     # https://console.groq.com/docs/models
+    llama3_2_90b_vision = LLMSpec(
+        label="Llama 3.2 90B + Vision (Meta AI)",
+        model_id="llama-3.2-90b-vision-preview",
+        llm_api=LLMApis.groq,
+        context_window=8192,
+        price=1,
+        supports_json=True,
+        is_vision_model=True,
+    )
+    llama3_2_11b_vision = LLMSpec(
+        label="Llama 3.2 11B + Vision (Meta AI)",
+        model_id="llama-3.2-11b-vision-preview",
+        llm_api=LLMApis.groq,
+        context_window=8192,
+        price=1,
+        supports_json=True,
+        is_vision_model=True,
+    )
+
+    llama3_2_3b = LLMSpec(
+        label="Llama 3.2 3B (Meta AI)",
+        model_id="llama-3.2-3b-preview",
+        llm_api=LLMApis.groq,
+        context_window=8192,
+        price=1,
+        supports_json=True,
+    )
+    llama3_2_1b = LLMSpec(
+        label="Llama 3.2 1B (Meta AI)",
+        model_id="llama-3.2-1b-preview",
+        llm_api=LLMApis.groq,
+        context_window=8192,
+        price=1,
+        supports_json=True,
+    )
+
+    llama3_1_70b = LLMSpec(
+        label="Llama 3.1 70B (Meta AI)",
+        model_id="llama-3.1-70b-versatile",
+        llm_api=LLMApis.groq,
+        context_window=32_768,
+        price=1,
+        supports_json=True,
+    )
+    llama3_1_8b = LLMSpec(
+        label="Llama 3.1 8B (Meta AI)",
+        model_id="llama-3.1-8b-instant",
+        llm_api=LLMApis.groq,
+        context_window=8192,
+        price=1,
+        supports_json=True,
+    )
+
     llama3_70b = LLMSpec(
-        label="Llama 3 70b (Meta AI)",
+        label="Llama 3 70B (Meta AI)",
         model_id="llama3-70b-8192",
         llm_api=LLMApis.groq,
         context_window=8192,
         price=1,
         supports_json=True,
     )
-    llama_3_groq_70b_tool_use = LLMSpec(
-        label="Llama 3 Groq 70b Tool Use",
-        model_id="llama3-groq-70b-8192-tool-use-preview",
-        llm_api=LLMApis.groq,
-        context_window=8192,
-        price=1,
-        supports_json=True,
-    )
     llama3_8b = LLMSpec(
-        label="Llama 3 8b (Meta AI)",
+        label="Llama 3 8B (Meta AI)",
         model_id="llama3-8b-8192",
         llm_api=LLMApis.groq,
         context_window=8192,
         price=1,
         supports_json=True,
     )
-    llama_3_groq_8b_tool_use = LLMSpec(
-        label="Llama 3 Groq 8b Tool Use",
-        model_id="llama3-groq-8b-8192-tool-use-preview",
-        llm_api=LLMApis.groq,
-        context_window=8192,
-        price=1,
-        supports_json=True,
-    )
-    llama2_70b_chat = LLMSpec(
-        label="Llama 2 70b Chat [Deprecated] (Meta AI)",
-        model_id="llama2-70b-4096",
-        llm_api=LLMApis.groq,
-        context_window=4096,
-        price=1,
-        is_deprecated=True,
-    )
+
     mixtral_8x7b_instruct_0_1 = LLMSpec(
         label="Mixtral 8x7b Instruct v0.1 (Mistral)",
         model_id="mixtral-8x7b-32768",
@@ -338,6 +368,48 @@ class LargeLanguageModels(Enum):
         price=1,
         is_chat_model=False,
     )
+    llama3_8b_cpt_sea_lion_v2_1_instruct = LLMSpec(
+        label="Llama3 8B CPT SEA-LIONv2.1 Instruct (aisingapore)",
+        model_id="aisingapore/llama3-8b-cpt-sea-lionv2.1-instruct",
+        llm_api=LLMApis.self_hosted,
+        context_window=8192,
+        price=1,
+    )
+    sarvam_2b = LLMSpec(
+        label="Sarvam 2B (sarvamai)",
+        model_id="sarvamai/sarvam-2b-v0.5",
+        llm_api=LLMApis.self_hosted,
+        context_window=2048,
+        price=1,
+    )
+
+    llama_3_groq_70b_tool_use = LLMSpec(
+        label="Llama 3 Groq 70b Tool Use [Deprecated]",
+        model_id="llama3-groq-70b-8192-tool-use-preview",
+        llm_api=LLMApis.groq,
+        context_window=8192,
+        price=1,
+        supports_json=True,
+        is_deprecated=True,
+    )
+    llama_3_groq_8b_tool_use = LLMSpec(
+        label="Llama 3 Groq 8b Tool Use [Deprecated]",
+        model_id="llama3-groq-8b-8192-tool-use-preview",
+        llm_api=LLMApis.groq,
+        context_window=8192,
+        price=1,
+        supports_json=True,
+        is_deprecated=True,
+    )
+    llama2_70b_chat = LLMSpec(
+        label="Llama 2 70B Chat [Deprecated] (Meta AI)",
+        model_id="llama2-70b-4096",
+        llm_api=LLMApis.groq,
+        context_window=4096,
+        price=1,
+        is_deprecated=True,
+    )
+
     sea_lion_7b_instruct = LLMSpec(
         label="SEA-LION-7B-Instruct [Deprecated] (aisingapore)",
         model_id="aisingapore/sea-lion-7b-instruct",
@@ -353,20 +425,6 @@ class LargeLanguageModels(Enum):
         context_window=8192,
         price=1,
         is_deprecated=True,
-    )
-    llama3_8b_cpt_sea_lion_v2_1_instruct = LLMSpec(
-        label="Llama3 8B CPT SEA-LIONv2.1 Instruct (aisingapore)",
-        model_id="aisingapore/llama3-8b-cpt-sea-lionv2.1-instruct",
-        llm_api=LLMApis.self_hosted,
-        context_window=8192,
-        price=1,
-    )
-    sarvam_2b = LLMSpec(
-        label="Sarvam 2B (sarvamai)",
-        model_id="sarvamai/sarvam-2b-v0.5",
-        llm_api=LLMApis.self_hosted,
-        context_window=2048,
-        price=1,
     )
 
     # https://platform.openai.com/docs/models/gpt-3

--- a/scripts/init_llm_pricing.py
+++ b/scripts/init_llm_pricing.py
@@ -551,6 +551,63 @@ def run():
     # groq
 
     llm_pricing_create(
+        model_id="llama-3.2-90b-vision-preview",
+        model_name=LargeLanguageModels.llama3_2_90b_vision.name,
+        unit_cost_input=0.90,
+        unit_cost_output=0.90,
+        unit_quantity=10**6,
+        provider=ModelProvider.groq,
+        pricing_url="https://groq.com/pricing/",
+    )
+    llm_pricing_create(
+        model_id="llama-3.2-11b-vision-preview",
+        model_name=LargeLanguageModels.llama3_2_11b_vision.name,
+        unit_cost_input=0.18,
+        unit_cost_output=0.18,
+        unit_quantity=10**6,
+        provider=ModelProvider.groq,
+        pricing_url="https://groq.com/pricing/",
+    )
+
+    llm_pricing_create(
+        model_id="llama-3.2-3b-preview",
+        model_name=LargeLanguageModels.llama3_2_3b.name,
+        unit_cost_input=0.06,
+        unit_cost_output=0.06,
+        unit_quantity=10**6,
+        provider=ModelProvider.groq,
+        pricing_url="https://groq.com/pricing/",
+    )
+    llm_pricing_create(
+        model_id="llama-3.2-1b-preview",
+        model_name=LargeLanguageModels.llama3_2_1b.name,
+        unit_cost_input=0.04,
+        unit_cost_output=0.04,
+        unit_quantity=10**6,
+        provider=ModelProvider.groq,
+        pricing_url="https://groq.com/pricing/",
+    )
+
+    llm_pricing_create(
+        model_id="llama-3.1-70b-versatile",
+        model_name=LargeLanguageModels.llama3_1_70b.name,
+        unit_cost_input=0.59,
+        unit_cost_output=0.79,
+        unit_quantity=10**6,
+        provider=ModelProvider.groq,
+        pricing_url="https://groq.com/pricing/",
+    )
+    llm_pricing_create(
+        model_id="llama-3.1-8b-instant",
+        model_name=LargeLanguageModels.llama3_1_8b.name,
+        unit_cost_input=0.05,
+        unit_cost_output=0.08,
+        unit_quantity=10**6,
+        provider=ModelProvider.groq,
+        pricing_url="https://groq.com/pricing/",
+    )
+
+    llm_pricing_create(
         model_id="llama3-70b-8192",
         model_name=LargeLanguageModels.llama3_70b.name,
         unit_cost_input=0.59,


### PR DESCRIPTION
3.2 90B + Vision
3.2 11B + Vision

3.2 3B
3.2 1B

3.1 70B
3.1 8B

### Q/A checklist

- [ ] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [ ] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [ ] Do a self code review of the changes - Read the diff at least twice.  
- [ ] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [ ] The relevant pages still run when you press submit
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
- [ ] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

