### PR TITLE
fix unlisted visibility on save

### DIFF
--- a/bots/models.py
+++ b/bots/models.py
@@ -49,6 +49,13 @@ class PublishedRunVisibility(models.IntegerChoices):
             # TODO: Add cls.PUBLIC when team-handles are added
             return [cls.UNLISTED, cls.INTERNAL]
 
+    @classmethod
+    def get_default_for_workspace(cls, workspace: typing.Optional["Workspace"]):
+        if not workspace or workspace.is_personal:
+            return cls.UNLISTED
+        else:
+            return cls.INTERNAL
+
     def help_text(self, workspace: typing.Optional["Workspace"] = None):
         from routers.account import profile_route, saved_route
 
@@ -1674,7 +1681,7 @@ class PublishedRunQuerySet(models.QuerySet):
         workspace: typing.Optional["Workspace"],
         title: str,
         notes: str,
-        visibility: PublishedRunVisibility,
+        visibility: PublishedRunVisibility | None = None,
     ):
         return get_or_create_lazy(
             PublishedRun,
@@ -1701,13 +1708,16 @@ class PublishedRunQuerySet(models.QuerySet):
         workspace: typing.Optional["Workspace"],
         title: str,
         notes: str,
-        visibility: PublishedRunVisibility,
+        visibility: PublishedRunVisibility | None = None,
     ):
         workspace_id = (
             workspace
             and workspace.id
             or PublishedRun._meta.get_field("workspace").get_default()
         )
+        if not visibility:
+            visibility = PublishedRunVisibility.get_default_for_workspace(workspace)
+
         with transaction.atomic():
             pr = self.create(
                 workflow=workflow,
@@ -1840,7 +1850,7 @@ class PublishedRun(models.Model):
         workspace: "Workspace",
         title: str,
         notes: str,
-        visibility: PublishedRunVisibility,
+        visibility: PublishedRunVisibility | None = None,
     ) -> "PublishedRun":
         return PublishedRun.objects.create_with_version(
             workflow=Workflow(self.workflow),
@@ -1863,13 +1873,14 @@ class PublishedRun(models.Model):
         *,
         user: AppUser | None,
         saved_run: SavedRun,
-        visibility: PublishedRunVisibility,
+        visibility: PublishedRunVisibility | None = None,
         title: str = "",
         notes: str = "",
         change_notes: str = "",
     ):
         assert saved_run.workflow == self.workflow
 
+        visibility = visibility or self.visibility
         with transaction.atomic():
             version = PublishedRunVersion(
                 published_run=self,

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -815,7 +815,7 @@ class BasePage:
                 workspace=selected_workspace,
                 title=published_run_title.strip(),
                 notes=published_run_description.strip(),
-                visibility=PublishedRunVisibility.UNLISTED,
+                visibility=self._get_default_pr_visibility(selected_workspace),
             )
         else:
             if not self.can_user_edit_published_run(self.current_pr):
@@ -875,6 +875,14 @@ class BasePage:
     def _get_default_pr_title(self):
         recipe_title = self.get_root_pr().title or self.title
         return f"{self.request.user.first_name_possesive()} {recipe_title}"
+
+    def _get_default_pr_visibility(self, workspace: Workspace | None = None):
+        if not workspace:
+            workspace = self.current_workspace
+        if workspace and not workspace.is_personal:
+            return PublishedRunVisibility.INTERNAL
+        else:
+            return PublishedRunVisibility.UNLISTED
 
     def _validate_published_run_title(self, title: str):
         if slugify(title) in settings.DISALLOWED_TITLE_SLUGS:
@@ -975,7 +983,7 @@ class BasePage:
                 workspace=self.current_workspace,
                 title=title,
                 notes=notes,
-                visibility=PublishedRunVisibility.UNLISTED,
+                visibility=self._get_default_pr_visibility(),
             )
             raise gui.RedirectException(
                 self.app_url(example_id=duplicate_pr.published_run_id)
@@ -989,7 +997,7 @@ class BasePage:
                 workspace=self.current_workspace,
                 title=title,
                 notes=notes,
-                visibility=PublishedRunVisibility.UNLISTED,
+                visibility=self._get_default_pr_visibility(),
             )
             raise gui.RedirectException(
                 self.app_url(example_id=new_pr.published_run_id)
@@ -1017,7 +1025,7 @@ class BasePage:
                 workspace=self.current_workspace,
                 title=f"{self.request.user.first_name_possesive()} {pr.title}",
                 notes=pr.notes,
-                visibility=PublishedRunVisibility(PublishedRunVisibility.UNLISTED),
+                visibility=self._get_default_pr_visibility(),
             )
             raise gui.RedirectException(
                 self.app_url(example_id=duplicate_pr.published_run_id)
@@ -1938,7 +1946,7 @@ class BasePage:
             workspace=self.current_workspace,
             title=self._get_default_pr_title(),
             notes=self.current_pr.notes,
-            visibility=PublishedRunVisibility(PublishedRunVisibility.UNLISTED),
+            visibility=self._get_default_pr_visibility(),
         )
         raise gui.RedirectException(pr.get_app_url())
 

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -825,7 +825,7 @@ class BasePage:
                 saved_run=sr,
                 title=published_run_title.strip(),
                 notes=published_run_description.strip(),
-                visibility=PublishedRunVisibility.UNLISTED,
+                visibility=pr.visibility,
             )
             if not self._has_published_run_changed(published_run=pr, **updates):
                 gui.error("No changes to publish", icon="⚠️")

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -815,7 +815,6 @@ class BasePage:
                 workspace=selected_workspace,
                 title=published_run_title.strip(),
                 notes=published_run_description.strip(),
-                visibility=self._get_default_pr_visibility(selected_workspace),
             )
         else:
             if not self.can_user_edit_published_run(self.current_pr):
@@ -825,7 +824,6 @@ class BasePage:
                 saved_run=sr,
                 title=published_run_title.strip(),
                 notes=published_run_description.strip(),
-                visibility=pr.visibility,
             )
             if not self._has_published_run_changed(published_run=pr, **updates):
                 gui.error("No changes to publish", icon="⚠️")
@@ -903,12 +901,10 @@ class BasePage:
         saved_run: SavedRun,
         title: str,
         notes: str,
-        visibility: PublishedRunVisibility,
     ):
         return (
             published_run.title != title
             or published_run.notes != notes
-            or published_run.visibility != visibility
             or published_run.saved_run != saved_run
         )
 
@@ -983,7 +979,6 @@ class BasePage:
                 workspace=self.current_workspace,
                 title=title,
                 notes=notes,
-                visibility=self._get_default_pr_visibility(),
             )
             raise gui.RedirectException(
                 self.app_url(example_id=duplicate_pr.published_run_id)
@@ -997,7 +992,6 @@ class BasePage:
                 workspace=self.current_workspace,
                 title=title,
                 notes=notes,
-                visibility=self._get_default_pr_visibility(),
             )
             raise gui.RedirectException(
                 self.app_url(example_id=new_pr.published_run_id)
@@ -1025,7 +1019,6 @@ class BasePage:
                 workspace=self.current_workspace,
                 title=f"{self.request.user.first_name_possesive()} {pr.title}",
                 notes=pr.notes,
-                visibility=self._get_default_pr_visibility(),
             )
             raise gui.RedirectException(
                 self.app_url(example_id=duplicate_pr.published_run_id)
@@ -1467,7 +1460,7 @@ class BasePage:
         workspace: typing.Optional["Workspace"],
         title: str,
         notes: str,
-        visibility: PublishedRunVisibility,
+        visibility: PublishedRunVisibility | None = None,
     ):
         return PublishedRun.objects.create_with_version(
             workflow=cls.workflow,

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -874,14 +874,6 @@ class BasePage:
         recipe_title = self.get_root_pr().title or self.title
         return f"{self.request.user.first_name_possesive()} {recipe_title}"
 
-    def _get_default_pr_visibility(self, workspace: Workspace | None = None):
-        if not workspace:
-            workspace = self.current_workspace
-        if workspace and not workspace.is_personal:
-            return PublishedRunVisibility.INTERNAL
-        else:
-            return PublishedRunVisibility.UNLISTED
-
     def _validate_published_run_title(self, title: str):
         if slugify(title) in settings.DISALLOWED_TITLE_SLUGS:
             raise TitleValidationError(
@@ -1939,7 +1931,6 @@ class BasePage:
             workspace=self.current_workspace,
             title=self._get_default_pr_title(),
             notes=self.current_pr.notes,
-            visibility=self._get_default_pr_visibility(),
         )
         raise gui.RedirectException(pr.get_app_url())
 


### PR DESCRIPTION
- **fix visibility: dont change to unlisted on 'Save'**
- **fix: default visibility for new published runs**

### Q/A checklist

- [ ] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [ ] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [ ] Do a self code review of the changes - Read the diff at least twice.  
- [ ] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [ ] The relevant pages still run when you press submit
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
- [ ] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208916888719869