### PR TITLE
replace inline styles with gui.styled()

### DIFF
--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -484,20 +484,10 @@ class BasePage:
                     self._unsaved_options_modal()
 
     def render_social_buttons(self):
-        with gui.div(
-            className="d-flex align-items-start right-action-icons gap-lg-2 gap-1"
+        with (
+            gui.styled("& .btn { padding: 6px }"),
+            gui.div(className="d-flex align-items-start gap-lg-2 gap-1"),
         ):
-            gui.html(
-                # styling for buttons in this div
-                """
-                <style>
-                .right-action-icons .btn {
-                    padding: 6px;
-                }
-                </style>
-                """.strip()
-            )
-
             if self.tab == RecipeTabs.run:
                 if self.is_logged_in():
                     self._render_options_button_with_dialog()
@@ -625,17 +615,6 @@ class BasePage:
 
     def _render_save_button(self):
         with gui.div(className="d-flex justify-content-end"):
-            gui.html(
-                """
-                <style>
-                    .save-button-menu .gui-input label p { color: black; }
-                    .published-options-menu {
-                        z-index: 1;
-                    }
-                </style>
-                """
-            )
-
             if self.can_user_edit_published_run(self.current_pr):
                 icon, label = icons.save, "Update"
             elif self._has_request_changed():
@@ -1166,15 +1145,6 @@ class BasePage:
         version: PublishedRunVersion,
         older_version: PublishedRunVersion | None,
     ):
-        gui.html(
-            """
-            <style>
-            .disable-p-margin p {
-                margin-bottom: 0;
-            }
-            </style>
-            """
-        )
         url = self.app_url(
             example_id=version.published_run.published_run_id,
             run_id=version.saved_run.run_id,
@@ -1190,7 +1160,7 @@ class BasePage:
                             version.changed_by, responsive=False, show_as_link=False
                         )
                 else:
-                    gui.write("###### Deleted User", className="disable-p-margin")
+                    gui.write("###### Deleted User", className="container-margin-reset")
                 with gui.tag("h6", className="mb-0"):
                     gui.html(
                         "Loading...",
@@ -1199,7 +1169,7 @@ class BasePage:
                             date_options={"month": "short", "day": "numeric"},
                         ),
                     )
-            with gui.div(className="disable-p-margin"):
+            with gui.div(className="container-margin-reset"):
                 is_first_version = not older_version
                 if is_first_version:
                     with gui.tag("span", className="badge bg-secondary px-3"):
@@ -1562,40 +1532,36 @@ class BasePage:
         if not photo and not name:
             return
 
-        responsive_image_size = (
-            f"calc({image_size} * 0.67)" if responsive else image_size
-        )
-
-        # new class name so that different ones don't conflict
-        class_name = f"author-image-{image_size}"
         if responsive:
-            class_name += "-responsive"
+            responsive_image_size = f"calc({image_size} * 0.67)"
+        else:
+            responsive_image_size = image_size
 
         linkto = link and gui.link(to=link) or gui.dummy()
         with linkto, gui.div(className="d-flex align-items-center"):
             if photo:
-                gui.html(
-                    f"""
-                    <style>
-                    .{class_name} {{
-                        width: {responsive_image_size};
-                        height: {responsive_image_size};
-                        margin-right: 6px;
-                        border-radius: 50%;
-                        object-fit: cover;
-                        pointer-events: none;
-                    }}
-
-                    @media (min-width: 1024px) {{
-                        .{class_name} {{
-                            width: {image_size};
-                            height: {image_size};
-                        }}
-                    }}
-                    </style>
-                """
-                )
-                gui.image(photo, className=class_name)
+                with gui.styled(
+                    """
+                    @media (min-width: 1024px) {
+                        & {
+                            width: %(image_size)s;
+                            height: %(image_size)s;
+                        }
+                    }
+                    """
+                    % dict(image_size=image_size)
+                ):
+                    gui.image(
+                        photo,
+                        style=dict(
+                            width=responsive_image_size,
+                            height=responsive_image_size,
+                            marginRight="6px",
+                            borderRadius="50%",
+                            objectFit="cover",
+                            pointerEvents="none",
+                        ),
+                    )
 
             if name:
                 name_style = {"fontSize": text_size} if text_size else {}

--- a/daras_ai_v2/breadcrumbs.py
+++ b/daras_ai_v2/breadcrumbs.py
@@ -32,28 +32,27 @@ class TitleBreadCrumbs(typing.NamedTuple):
 
 
 def render_breadcrumbs(breadcrumbs: TitleBreadCrumbs, *, is_api_call: bool = False):
-    gui.html(
-        """
-        <style>
-        @media (min-width: 1024px) {
-            .fs-lg-5 {
-                font-size: 1.25rem !important;
-            }
-        }
-        </style>
-        """
-    )
-
     if not (breadcrumbs.root_title or breadcrumbs.published_title):
         # avoid empty space when breadcrumbs are not rendered
         return
 
-    with gui.breadcrumbs():
+    with (
+        gui.styled(
+            """
+            @media (min-width: 1024px) {
+                & a {
+                    font-size: 1.25rem !important;
+                }
+            }
+            """
+        ),
+        gui.breadcrumbs(),
+    ):
         if breadcrumbs.root_title:
             gui.breadcrumb_item(
                 breadcrumbs.root_title.title,
                 link_to=breadcrumbs.root_title.url,
-                className="text-muted fs-lg-5",
+                className="text-muted",
             )
         if breadcrumbs.published_title:
             gui.breadcrumb_item(

--- a/daras_ai_v2/variables_widget.py
+++ b/daras_ai_v2/variables_widget.py
@@ -169,15 +169,17 @@ def render_list_item(
         gui.write(f"**{value_type}**", className="text-muted small")
 
         if schema.get("role") == "system":
-            gui.caption(
+            gui.write(
                 "System provided",
                 help="This variable is automatically provided by the system. ",
+                className="text-muted small",
             )
         if is_template_var:
-            gui.caption(
+            gui.write(
                 "Template variable",
                 help="Your instruction or other prompts reference this variable. "
                 "Add a value and tap Run to test a sample value.",
+                className="text-muted small",
             )
 
         gui.div(className="flex-grow-1")
@@ -188,9 +190,14 @@ def render_list_item(
             key=dialog_ref.open_btn_key,
         )
 
-    item["value"] = json_value_editor(entry_key, value, value_type)
+    with (
+        gui.styled(".gui-input:has(&) { margin-bottom: 0 }")
+        if description
+        else gui.dummy()
+    ):
+        item["value"] = json_value_editor(entry_key, value, value_type)
 
-    gui.caption(description, style=dict(marginTop="-5px", display="relative"))
+    gui.markdown(description, className="text-muted small")
 
 
 def json_value_editor(entry_key: str, value, value_type: "JsonTypes"):

--- a/poetry.lock
+++ b/poetry.lock
@@ -1554,13 +1554,13 @@ yaml = ["PyYAML"]
 
 [[package]]
 name = "gooey-gui"
-version = "0.5.2"
+version = "0.5.3"
 description = ""
 optional = false
 python-versions = "<4.0,>=3.10"
 files = [
-    {file = "gooey_gui-0.5.2-py3-none-any.whl", hash = "sha256:7f7bfc9341aa72816e243bcf32ab6783542f74ef238ece6172073c1e69761958"},
-    {file = "gooey_gui-0.5.2.tar.gz", hash = "sha256:4eb449055ecd76f5aab65eae6f6cd2bebc82c0e20f0df836e3c60ed1d1d71697"},
+    {file = "gooey_gui-0.5.3-py3-none-any.whl", hash = "sha256:5d4271d98435d1a1a2d33c30bb89dfeb3627301cf5c07e31c015ac1ac9e3122d"},
+    {file = "gooey_gui-0.5.3.tar.gz", hash = "sha256:ad00cb212ef57405965ddb352bc2e39cc250830b482be0ed7354c1b9e3fb761c"},
 ]
 
 [package.dependencies]
@@ -3111,16 +3111,6 @@ files = [
     {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win32.whl", hash = "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686"},
-    { file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc" },
-    { file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823" },
-    { file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11" },
-    { file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd" },
-    { file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939" },
-    { file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c" },
-    { file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c" },
-    { file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1" },
-    { file = "MarkupSafe-2.1.3-cp312-cp312-win32.whl", hash = "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007" },
-    { file = "MarkupSafe-2.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb" },
     {file = "MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707"},
@@ -4741,7 +4731,6 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
-    { file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290" },
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -4749,16 +4738,8 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
-    { file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b" },
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
-    { file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28" },
-    { file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9" },
-    { file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef" },
-    { file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0" },
-    { file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4" },
-    { file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54" },
-    { file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df" },
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -4775,7 +4756,6 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
-    { file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6" },
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -4783,7 +4763,6 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
-    { file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5" },
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -6660,8 +6639,8 @@ description = "Library for developers to extract data from Microsoft Excel (tm) 
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 files = [
-    { file = "xlrd-2.0.1-py2.py3-none-any.whl", hash = "sha256:6a33ee89877bd9abc1158129f6e94be74e2679636b8a205b43b85206c3f0bbdd" },
-    { file = "xlrd-2.0.1.tar.gz", hash = "sha256:f72f148f54442c6b056bf931dbc34f986fd0c3b0b6b5a58d013c9aef274d0c88" },
+    {file = "xlrd-2.0.1-py2.py3-none-any.whl", hash = "sha256:6a33ee89877bd9abc1158129f6e94be74e2679636b8a205b43b85206c3f0bbdd"},
+    {file = "xlrd-2.0.1.tar.gz", hash = "sha256:f72f148f54442c6b056bf931dbc34f986fd0c3b0b6b5a58d013c9aef274d0c88"},
 ]
 
 [package.extras]
@@ -6806,4 +6785,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "9170f572d44b88c2ec704b28d4012ba1f1f4969e4cdb6b8bb81392977f69c6e6"
+content-hash = "f62f86d69cbcf93af2ffd87ee8099feb696873ea886145e57e54463ea5973d8d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ anthropic = "^0.34.1"
 azure-cognitiveservices-speech = "^1.37.0"
 twilio = "^9.2.3"
 sentry-sdk = {version = "1.45.0", extras = ["loguru"]}
-gooey-gui = "^0.5.2"
+gooey-gui = "^0.5.3"
 django-safedelete = "^1.4.0"
 numexpr = "^2.10.1"
 django-csp = "^3.8"


### PR DESCRIPTION
### Q/A checklist

- [ ] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [ ] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [ ] Do a self code review of the changes - Read the diff at least twice.  
- [ ] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [ ] The relevant pages still run when you press submit
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
- [ ] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

