### PR TITLE
rename _run_openai_chat->run_openai_chat, fix usage in asr.py

### DIFF
--- a/daras_ai_v2/asr.py
+++ b/daras_ai_v2/asr.py
@@ -1112,12 +1112,12 @@ def run_asr(
         raise_for_status(r)
         data = r.json()
     elif selected_model == AsrModels.gpt_4_o_audio:
-        from daras_ai_v2.language_model import _run_openai_chat
+        from daras_ai_v2.language_model import run_openai_chat
 
         audio_r = requests.get(audio_url)
         raise_for_status(audio_r, is_user_url=True)
 
-        return _run_openai_chat(
+        return run_openai_chat(
             model=asr_model_ids[selected_model],
             messages=[
                 {
@@ -1137,7 +1137,7 @@ def run_asr(
                     ],
                 },
             ],
-            max_tokens=4096,
+            max_completion_tokens=4096,
             num_outputs=1,
             temperature=1,
         )[0]["content"]

--- a/daras_ai_v2/language_model.py
+++ b/daras_ai_v2/language_model.py
@@ -775,7 +775,7 @@ def _run_chat_model(
     )
     match api:
         case LLMApis.openai:
-            return _run_openai_chat(
+            return run_openai_chat(
                 model=model,
                 avoid_repetition=avoid_repetition,
                 max_completion_tokens=max_tokens,
@@ -1027,7 +1027,7 @@ def _run_anthropic_chat(
 
 
 @retry_if(openai_should_retry)
-def _run_openai_chat(
+def run_openai_chat(
     *,
     model: str,
     messages: list[ConversationEntry],


### PR DESCRIPTION
### Q/A checklist

- [ ] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [ ] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [ ] Do a self code review of the changes - Read the diff at least twice.  
- [ ] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [ ] The relevant pages still run when you press submit
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
- [ ] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

