### PR TITLE
support all non exportable google workspace docs

### DIFF
--- a/daras_ai_v2/gdrive_downloader.py
+++ b/daras_ai_v2/gdrive_downloader.py
@@ -62,7 +62,9 @@ def gdrive_list_urls_of_files_in_folder(f: furl, max_depth: int = 4) -> list[str
     return filter(None, urls)
 
 
-def gdrive_download(f: furl, mime_type: str, export_links: dict) -> tuple[bytes, str]:
+def gdrive_download(
+    f: furl, mime_type: str, export_links: dict = {}
+) -> tuple[bytes, str]:
     from googleapiclient import discovery
     from googleapiclient.http import MediaIoBaseDownload
 

--- a/daras_ai_v2/gdrive_downloader.py
+++ b/daras_ai_v2/gdrive_downloader.py
@@ -1,5 +1,5 @@
 import io
-import mimetypes
+
 from furl import furl
 import requests
 
@@ -71,15 +71,17 @@ def gdrive_download(f: furl, mime_type: str, export_links: dict) -> tuple[bytes,
     # get metadata
     service = discovery.build("drive", "v3")
 
+    docs_export_mimetype = {
+        "application/vnd.google-apps.document": "text/plain",
+        "application/vnd.google-apps.spreadsheet": "text/csv",
+        "application/vnd.google-apps.presentation": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "application/vnd.google-apps.drawing": "application/pdf",
+    }
+
     if f.host != "drive.google.com":
         # export google docs to appropriate type
-        export_mime_type, _, is_google_workspace_doc = docs_export_mimetype(
-            f, mime_type
-        )
-
-        if is_google_workspace_doc and (
-            f_url_export := export_links.get(export_mime_type, None)
-        ):
+        export_mime_type = docs_export_mimetype.get(mime_type, mime_type)
+        if f_url_export := export_links.get(export_mime_type, None):
             r = requests.get(f_url_export)
             file_bytes = r.content
             raise_for_status(r, is_user_url=True)
@@ -99,46 +101,6 @@ def gdrive_download(f: furl, mime_type: str, export_links: dict) -> tuple[bytes,
     file_bytes = file.getvalue()
 
     return file_bytes, mime_type
-
-
-def docs_export_mimetype(f: furl, mime_type) -> tuple[str, str, bool]:
-    """
-    return the mimetype to export google docs - https://developers.google.com/drive/api/guides/ref-export-formats
-
-    Args:
-        f (furl): google docs link
-
-    Returns:
-        tuple[str, str]: (mime_type, extension, is_google_workspace_supported)
-    """
-
-    supported_mimetypes = {
-        "application/vnd.google-apps.spreadsheet",
-        "application/vnd.google-apps.presentation",
-        "application/vnd.google-apps.drawing",
-        "application/vnd.google-apps.document",
-    }
-
-    is_google_workspace_supported = mime_type in supported_mimetypes
-
-    if is_google_workspace_supported:
-        if "document" in f.path.segments:
-            mime_type = "text/plain"
-            ext = ".txt"
-        elif "spreadsheets" in f.path.segments:
-            mime_type = "text/csv"
-            ext = ".csv"
-        elif "presentation" in f.path.segments:
-            mime_type = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-            ext = ".pptx"
-        elif "drawings" in f.path.segments:
-            mime_type = "application/pdf"
-            ext = ".pdf"
-        else:
-            raise ValueError(f"Not sure how to export google docs url: {str(f)!r}")
-    else:
-        ext = f".{mimetypes.guess_extension(mime_type)}" or ""
-    return mime_type, ext, is_google_workspace_supported
 
 
 def gdrive_metadata(file_id: str) -> dict:

--- a/daras_ai_v2/gdrive_downloader.py
+++ b/daras_ai_v2/gdrive_downloader.py
@@ -7,7 +7,7 @@ from daras_ai_v2.exceptions import UserError
 from daras_ai_v2.functional import flatmap_parallel
 from daras_ai_v2.exceptions import raise_for_status
 
-docs_export_mimetype = {
+DOCS_EXPORT_MIMETYPES = {
     "application/vnd.google-apps.document": "text/plain",
     "application/vnd.google-apps.spreadsheet": "text/csv",
     "application/vnd.google-apps.presentation": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
@@ -85,7 +85,7 @@ def gdrive_download(
 
     if f.host != "drive.google.com":
         # export google docs to appropriate type
-        export_mime_type = docs_export_mimetype.get(mime_type, mime_type)
+        export_mime_type = DOCS_EXPORT_MIMETYPES.get(mime_type, mime_type)
         if f_url_export := export_links.get(export_mime_type, None):
             r = requests.get(f_url_export)
             file_bytes = r.content

--- a/daras_ai_v2/vector_search.py
+++ b/daras_ai_v2/vector_search.py
@@ -310,7 +310,7 @@ def doc_url_to_file_metadata(f_url: str) -> FileMetadata:
         etag = meta.get("md5Checksum") or meta.get("modifiedTime")
         mime_type = meta["mimeType"]
         total_bytes = int(meta.get("size") or 0)
-        export_links = meta.get("exportLinks", {})
+        export_links = meta.get("exportLinks", None)
     else:
         try:
             if is_user_uploaded_url(f_url):
@@ -328,7 +328,7 @@ def doc_url_to_file_metadata(f_url: str) -> FileMetadata:
             mime_type = None
             etag = None
             total_bytes = 0
-            export_links = {}
+            export_links = None
         else:
             name = (
                 r.headers.get("content-disposition", "")
@@ -340,7 +340,7 @@ def doc_url_to_file_metadata(f_url: str) -> FileMetadata:
                 etag = etag.strip('"')
             mime_type = get_mimetype_from_response(r)
             total_bytes = int(r.headers.get("content-length") or 0)
-            export_links = {}
+            export_links = None
     # extract filename from url as a fallback
     if not name:
         if is_user_uploaded_url(f_url):

--- a/files/models.py
+++ b/files/models.py
@@ -7,10 +7,7 @@ class FileMetadata(models.Model):
     etag = models.CharField(max_length=255, null=True)
     mime_type = models.CharField(max_length=255, default="", blank=True)
     total_bytes = models.PositiveIntegerField(default=0, blank=True)
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.export_links = {}
+    export_links: dict[str, str] | None = None
 
     def __str__(self):
         ret = f"{self.name or 'Unnamed'} - {self.mime_type}"


### PR DESCRIPTION
### Q/A checklist

- [ ] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [x] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [x] Do a self code review of the changes - Read the diff at least twice.  
- [x] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [x] The relevant pages still run when you press submit
- [x] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
- [ ] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

