### PR TITLE
add cache knowledge checkbox

### DIFF
--- a/daras_ai_v2/doc_search_settings_widgets.py
+++ b/daras_ai_v2/doc_search_settings_widgets.py
@@ -71,7 +71,7 @@ def bulk_documents_uploader(
             accept=accept,
             accept_multiple_files=True,
         )
-    gui.checkbox("Submit Links in Bulk", key=f"__custom_checkbox_{key}")
+    gui.checkbox("Show as Links", key=f"__custom_checkbox_{key}")
     documents = gui.session_state.setdefault(key, [])
     try:
         documents = list(_expand_gdrive_folders(documents))

--- a/recipes/VideoBots.py
+++ b/recipes/VideoBots.py
@@ -172,6 +172,7 @@ class VideoBotsPage(BasePage):
         "max_context_words": 200,
         "scroll_jump": 5,
         "use_url_shortener": False,
+        "check_document_updates": False,
         "dense_weight": 1.0,
         "translation_model": DEFAULT_TRANSLATION_MODEL,
     }
@@ -218,6 +219,7 @@ class VideoBotsPage(BasePage):
 
         citation_style: typing.Literal[tuple(e.name for e in CitationStyles)] | None
         use_url_shortener: bool | None
+        check_document_updates: bool | None
 
         asr_model: typing.Literal[tuple(e.name for e in AsrModels)] | None = Field(
             title="Speech-to-Text Provider",
@@ -582,7 +584,21 @@ PS. This is the workflow that we used to create RadBots - a collection of Turing
             )
 
             citation_style_selector()
-            gui.checkbox("🔗 Shorten Citation URLs", key="use_url_shortener")
+            gui.checkbox("🔗 Shorten citation links", key="use_url_shortener")
+
+            gui.write("###### Cache")
+            gui.caption(
+                f"""
+                By default we embed your knowledge files & links and cache their contents for fast responses. 
+                """
+            )
+
+            gui.checkbox(
+                "Always Check for Updates",
+                help="With each incoming message, documents and links will be checked for changes and re-indexed. Slower but useful for dynamic webpages, Google Sheets, Docs, etc that change often.",
+                tooltip_placement="right",
+                key="check_document_updates",
+            )
 
             doc_extract_selector(self.request.user)
 


### PR DESCRIPTION
### Q/A checklist

- [ ] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [ ] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [ ] Do a self code review of the changes - Read the diff at least twice.  
- [ ] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [ ] The relevant pages still run when you press submit
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
- [ ] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

