### PR TITLE
refactor ux to doc_search_settings_widgets

### DIFF
--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -1910,9 +1910,9 @@ class BasePage:
         pass
 
     def submit_and_redirect(
-        self, unsaved_model_state: dict[str, typing.Any] = None
+        self, unsaved_state: dict[str, typing.Any] = None
     ) -> typing.NoReturn | None:
-        sr = self.on_submit(unsaved_model_state=unsaved_model_state)
+        sr = self.on_submit(unsaved_state=unsaved_state)
         if not sr:
             return
         raise gui.RedirectException(self.app_url(run_id=sr.run_id, uid=sr.uid))
@@ -1942,11 +1942,11 @@ class BasePage:
         )
         raise gui.RedirectException(pr.get_app_url())
 
-    def on_submit(self, unsaved_model_state: dict[str, typing.Any] = None):
+    def on_submit(self, unsaved_state: dict[str, typing.Any] = None):
         sr = self.create_and_validate_new_run(enable_rate_limits=True)
         if not sr:
             return
-        self.call_runner_task(sr, unsaved_model_state=unsaved_model_state)
+        self.call_runner_task(sr, unsaved_state=unsaved_state)
         return sr
 
     def should_submit_after_login(self) -> bool:
@@ -2062,7 +2062,7 @@ class BasePage:
         self,
         sr: SavedRun,
         deduct_credits: bool = True,
-        unsaved_model_state: dict[str, typing.Any] = None,
+        unsaved_state: dict[str, typing.Any] = None,
     ):
         from celeryapp.tasks import runner_task
 
@@ -2072,7 +2072,7 @@ class BasePage:
             run_id=sr.run_id,
             uid=sr.uid,
             channel=self.realtime_channel_name(sr.run_id, sr.uid),
-            unsaved_state=self._unsaved_state() | (unsaved_model_state or {}),
+            unsaved_state=self._unsaved_state() | (unsaved_state or {}),
             deduct_credits=deduct_credits,
         )
 

--- a/daras_ai_v2/doc_search_settings_widgets.py
+++ b/daras_ai_v2/doc_search_settings_widgets.py
@@ -123,20 +123,31 @@ def keyword_instructions_widget():
     )
 
 
-def cache_knowledge_widget():
+def cache_knowledge_widget(self):
     gui.write("###### Cache")
     gui.caption(
         f"""
         By default we embed your knowledge files & links and cache their contents for fast responses. 
         """
     )
-
-    gui.checkbox(
-        "Always Check for Updates",
-        help="With each incoming message, documents and links will be checked for changes and re-indexed. Slower but useful for dynamic webpages, Google Sheets, Docs, etc that change often.",
-        tooltip_placement="right",
-        key="check_document_updates",
-    )
+    col1, col2 = gui.columns(2, style={"alignItems": "center"})
+    with col1:
+        gui.checkbox(
+            "Always Check for Updates",
+            help="With each incoming message, documents and links will be checked for changes and re-indexed. Slower but useful for dynamic webpages, Google Sheets, Docs, etc that change often.",
+            tooltip_placement="bottom",
+            key="check_document_updates",
+        )
+    with col2:
+        with gui.tooltip(
+            "Clear the knowledge cache and re-index all knowledge base files and links."
+        ):
+            if gui.button(
+                "♻️ Refresh Cache",
+                type="tertiary",
+            ):
+                unsaved_model_state = {"check_document_updates": True}
+                self.submit_and_redirect(unsaved_model_state=unsaved_model_state)
 
 
 def doc_extract_selector(current_user: AppUser | None):

--- a/daras_ai_v2/doc_search_settings_widgets.py
+++ b/daras_ai_v2/doc_search_settings_widgets.py
@@ -123,6 +123,22 @@ def keyword_instructions_widget():
     )
 
 
+def cache_knowledge_widget():
+    gui.write("###### Cache")
+    gui.caption(
+        f"""
+        By default we embed your knowledge files & links and cache their contents for fast responses. 
+        """
+    )
+
+    gui.checkbox(
+        "Always Check for Updates",
+        help="With each incoming message, documents and links will be checked for changes and re-indexed. Slower but useful for dynamic webpages, Google Sheets, Docs, etc that change often.",
+        tooltip_placement="right",
+        key="check_document_updates",
+    )
+
+
 def doc_extract_selector(current_user: AppUser | None):
     from recipes.DocExtract import DocExtractPage
     from daras_ai_v2.workflow_url_input import workflow_url_input

--- a/recipes/DocSearch.py
+++ b/recipes/DocSearch.py
@@ -1,47 +1,46 @@
 import math
 import typing
 
-from furl import furl
-from pydantic import BaseModel
-
 import gooey_gui as gui
 from bots.models import Workflow
 from daras_ai_v2.base import BasePage
 from daras_ai_v2.doc_search_settings_widgets import (
     bulk_documents_uploader,
-    is_user_uploaded_url,
-    citation_style_selector,
-    doc_search_advanced_settings,
-    query_instructions_widget,
-    doc_extract_selector,
     cache_knowledge_widget,
+    citation_style_selector,
+    doc_extract_selector,
+    doc_search_advanced_settings,
+    is_user_uploaded_url,
+    query_instructions_widget,
 )
 from daras_ai_v2.exceptions import UserError
 from daras_ai_v2.language_model import (
-    run_language_model,
     LargeLanguageModels,
+    run_language_model,
 )
 from daras_ai_v2.language_model_settings_widgets import (
-    language_model_settings,
-    language_model_selector,
     LanguageModelSettings,
+    language_model_selector,
+    language_model_settings,
 )
 from daras_ai_v2.loom_video_widget import youtube_video
-from daras_ai_v2.variables_widget import render_prompt_vars
 from daras_ai_v2.query_generator import generate_final_search_query
 from daras_ai_v2.search_ref import (
-    SearchReference,
-    render_output_with_refs,
     CitationStyles,
+    SearchReference,
     apply_response_formattings_prefix,
     apply_response_formattings_suffix,
+    render_output_with_refs,
 )
+from daras_ai_v2.variables_widget import render_prompt_vars
 from daras_ai_v2.vector_search import (
     DocSearchRequest,
     get_top_k_references,
     references_as_prompt,
     render_sources_widget,
 )
+from furl import furl
+from pydantic import BaseModel
 
 DEFAULT_DOC_SEARCH_META_IMG = "https://storage.googleapis.com/dara-c1b52.appspot.com/daras_ai/media/bcc7aa58-93fe-11ee-a083-02420a0001c8/Search%20your%20docs.jpg.png"
 
@@ -66,7 +65,6 @@ class DocSearchPage(BasePage):
         "selected_model": LargeLanguageModels.text_davinci_003.name,
         "citation_style": CitationStyles.number.name,
         "dense_weight": 1.0,
-        "check_document_updates": False,
     }
 
     class RequestModelBase(DocSearchRequest, BasePage.RequestModel):
@@ -104,9 +102,9 @@ class DocSearchPage(BasePage):
 
     def related_workflows(self) -> list:
         from recipes.EmailFaceInpainting import EmailFaceInpaintingPage
+        from recipes.GoogleGPT import GoogleGPTPage
         from recipes.SEOSummary import SEOSummaryPage
         from recipes.VideoBots import VideoBotsPage
-        from recipes.GoogleGPT import GoogleGPTPage
 
         return [
             GoogleGPTPage,

--- a/recipes/DocSearch.py
+++ b/recipes/DocSearch.py
@@ -140,7 +140,7 @@ class DocSearchPage(BasePage):
         citation_style_selector()
         doc_extract_selector(self.request.user)
         query_instructions_widget()
-        cache_knowledge_widget()
+        cache_knowledge_widget(self)
         gui.write("---")
         doc_search_advanced_settings()
 

--- a/recipes/DocSearch.py
+++ b/recipes/DocSearch.py
@@ -14,6 +14,7 @@ from daras_ai_v2.doc_search_settings_widgets import (
     doc_search_advanced_settings,
     query_instructions_widget,
     doc_extract_selector,
+    cache_knowledge_widget,
 )
 from daras_ai_v2.exceptions import UserError
 from daras_ai_v2.language_model import (
@@ -65,12 +66,13 @@ class DocSearchPage(BasePage):
         "selected_model": LargeLanguageModels.text_davinci_003.name,
         "citation_style": CitationStyles.number.name,
         "dense_weight": 1.0,
+        "check_document_updates": False,
     }
 
     class RequestModelBase(DocSearchRequest, BasePage.RequestModel):
         task_instructions: str | None
         query_instructions: str | None
-
+        check_document_updates: bool | None
         selected_model: (
             typing.Literal[tuple(e.name for e in LargeLanguageModels)] | None
         )
@@ -138,6 +140,7 @@ class DocSearchPage(BasePage):
         citation_style_selector()
         doc_extract_selector(self.request.user)
         query_instructions_widget()
+        cache_knowledge_widget()
         gui.write("---")
         doc_search_advanced_settings()
 

--- a/recipes/GoogleGPT.py
+++ b/recipes/GoogleGPT.py
@@ -1,13 +1,14 @@
 import typing
 
+
 from furl import furl
 from pydantic import BaseModel
-
 import gooey_gui as gui
 from bots.models import Workflow
 from daras_ai_v2.base import BasePage
 from daras_ai_v2.doc_search_settings_widgets import (
     query_instructions_widget,
+    cache_knowledge_widget,
     doc_search_advanced_settings,
 )
 from daras_ai_v2.embedding_model import EmbeddingModels
@@ -21,7 +22,6 @@ from daras_ai_v2.language_model_settings_widgets import (
     LanguageModelSettings,
 )
 from daras_ai_v2.loom_video_widget import youtube_video
-from daras_ai_v2.variables_widget import render_prompt_vars
 from daras_ai_v2.query_generator import generate_final_search_query
 from daras_ai_v2.search_ref import (
     SearchReference,
@@ -34,6 +34,7 @@ from daras_ai_v2.serp_search_locations import (
     SerpSearchLocation,
     SerpSearchType,
 )
+from daras_ai_v2.variables_widget import render_prompt_vars
 from daras_ai_v2.vector_search import render_sources_widget
 from recipes.DocSearch import (
     DocSearchRequest,
@@ -75,6 +76,7 @@ class GoogleGPTPage(BasePage):
         max_context_words=200,
         scroll_jump=5,
         dense_weight=1.0,
+        check_document_updates=False,
     )
 
     class RequestModelBase(BasePage.RequestModel):
@@ -87,7 +89,7 @@ class GoogleGPTPage(BasePage):
         selected_model: (
             typing.Literal[tuple(e.name for e in LargeLanguageModels)] | None
         )
-
+        check_document_updates: bool | None
         max_search_urls: int | None
 
         max_references: int | None
@@ -149,6 +151,7 @@ class GoogleGPTPage(BasePage):
         gui.write("---")
         gui.write("##### 🔎 Document Search Settings")
         query_instructions_widget()
+        cache_knowledge_widget()
         gui.write("---")
         doc_search_advanced_settings()
 

--- a/recipes/GoogleGPT.py
+++ b/recipes/GoogleGPT.py
@@ -1,25 +1,22 @@
 import typing
 
-
-from furl import furl
-from pydantic import BaseModel
 import gooey_gui as gui
 from bots.models import Workflow
 from daras_ai_v2.base import BasePage
 from daras_ai_v2.doc_search_settings_widgets import (
-    query_instructions_widget,
     cache_knowledge_widget,
     doc_search_advanced_settings,
+    query_instructions_widget,
 )
 from daras_ai_v2.embedding_model import EmbeddingModels
 from daras_ai_v2.language_model import (
-    run_language_model,
     LargeLanguageModels,
+    run_language_model,
 )
 from daras_ai_v2.language_model_settings_widgets import (
-    language_model_settings,
-    language_model_selector,
     LanguageModelSettings,
+    language_model_selector,
+    language_model_settings,
 )
 from daras_ai_v2.loom_video_widget import youtube_video
 from daras_ai_v2.query_generator import generate_final_search_query
@@ -30,17 +27,20 @@ from daras_ai_v2.search_ref import (
 from daras_ai_v2.serp_search import get_links_from_serp_api
 from daras_ai_v2.serp_search_locations import (
     GoogleSearchMixin,
-    serp_search_settings,
     SerpSearchLocation,
     SerpSearchType,
+    serp_search_settings,
 )
 from daras_ai_v2.variables_widget import render_prompt_vars
 from daras_ai_v2.vector_search import render_sources_widget
+from furl import furl
+from pydantic import BaseModel
+
 from recipes.DocSearch import (
     DocSearchRequest,
-    references_as_prompt,
-    get_top_k_references,
     EmptySearchResults,
+    get_top_k_references,
+    references_as_prompt,
 )
 
 DEFAULT_GOOGLE_GPT_META_IMG = "https://storage.googleapis.com/dara-c1b52.appspot.com/daras_ai/media/85ed60a2-9405-11ee-9747-02420a0001ce/Web%20search%20GPT.jpg.png"
@@ -76,7 +76,6 @@ class GoogleGPTPage(BasePage):
         max_context_words=200,
         scroll_jump=5,
         dense_weight=1.0,
-        check_document_updates=False,
     )
 
     class RequestModelBase(BasePage.RequestModel):
@@ -156,10 +155,10 @@ class GoogleGPTPage(BasePage):
         doc_search_advanced_settings()
 
     def related_workflows(self) -> list:
-        from recipes.SEOSummary import SEOSummaryPage
         from recipes.DocSearch import DocSearchPage
-        from recipes.VideoBots import VideoBotsPage
+        from recipes.SEOSummary import SEOSummaryPage
         from recipes.SocialLookupEmail import SocialLookupEmailPage
+        from recipes.VideoBots import VideoBotsPage
 
         return [
             DocSearchPage,

--- a/recipes/GoogleGPT.py
+++ b/recipes/GoogleGPT.py
@@ -151,7 +151,7 @@ class GoogleGPTPage(BasePage):
         gui.write("---")
         gui.write("##### 🔎 Document Search Settings")
         query_instructions_widget()
-        cache_knowledge_widget()
+        cache_knowledge_widget(self)
         gui.write("---")
         doc_search_advanced_settings()
 

--- a/recipes/VideoBots.py
+++ b/recipes/VideoBots.py
@@ -586,7 +586,7 @@ PS. This is the workflow that we used to create RadBots - a collection of Turing
 
             citation_style_selector()
             gui.checkbox("🔗 Shorten citation links", key="use_url_shortener")
-            cache_knowledge_widget()
+            cache_knowledge_widget(self)
             doc_extract_selector(self.request.user)
 
             gui.write("---")

--- a/recipes/VideoBots.py
+++ b/recipes/VideoBots.py
@@ -55,6 +55,7 @@ from daras_ai_v2.doc_search_settings_widgets import (
     doc_extract_selector,
     bulk_documents_uploader,
     citation_style_selector,
+    cache_knowledge_widget,
     SUPPORTED_SPREADSHEET_TYPES,
 )
 from daras_ai_v2.embedding_model import EmbeddingModels
@@ -585,21 +586,7 @@ PS. This is the workflow that we used to create RadBots - a collection of Turing
 
             citation_style_selector()
             gui.checkbox("🔗 Shorten citation links", key="use_url_shortener")
-
-            gui.write("###### Cache")
-            gui.caption(
-                f"""
-                By default we embed your knowledge files & links and cache their contents for fast responses. 
-                """
-            )
-
-            gui.checkbox(
-                "Always Check for Updates",
-                help="With each incoming message, documents and links will be checked for changes and re-indexed. Slower but useful for dynamic webpages, Google Sheets, Docs, etc that change often.",
-                tooltip_placement="right",
-                key="check_document_updates",
-            )
-
+            cache_knowledge_widget()
             doc_extract_selector(self.request.user)
 
             gui.write("---")


### PR DESCRIPTION
### Q/A checklist

- [ ] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [ ] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [ ] Do a self code review of the changes - Read the diff at least twice.  
- [ ] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [ ] The relevant pages still run when you press submit
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
- [ ] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

