### PR TITLE
show "Public" visibility for already public published runs in team workspace

### DIFF
--- a/bots/models.py
+++ b/bots/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import typing
 from multiprocessing.pool import ThreadPool
@@ -40,14 +42,14 @@ class PublishedRunVisibility(models.IntegerChoices):
     INTERNAL = 3
 
     @classmethod
-    def choices_for_workspace(
-        cls, workspace: typing.Optional["Workspace"]
-    ) -> typing.Iterable["PublishedRunVisibility"]:
-        if not workspace or workspace.is_personal:
-            return [cls.UNLISTED, cls.PUBLIC]
+    def choices_for_pr(
+        cls, pr: PublishedRun
+    ) -> typing.Iterable[PublishedRunVisibility]:
+        if not pr.workspace or pr.workspace.is_personal:
+            return {cls.UNLISTED, cls.PUBLIC, PublishedRunVisibility(pr.visibility)}
         else:
             # TODO: Add cls.PUBLIC when team-handles are added
-            return [cls.UNLISTED, cls.INTERNAL]
+            return {cls.UNLISTED, cls.INTERNAL, PublishedRunVisibility(pr.visibility)}
 
     @classmethod
     def get_default_for_workspace(cls, workspace: typing.Optional["Workspace"]):

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -560,6 +560,10 @@ class BasePage:
                 for enum in PublishedRunVisibility.choices_for_workspace(
                     self.current_pr.workspace
                 )
+            } | {
+                str(self.current_pr.visibility): PublishedRunVisibility(
+                    self.current_pr.visibility
+                ).help_text(self.current_pr.workspace)
             }
             published_run_visibility = PublishedRunVisibility(
                 int(

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -557,12 +557,7 @@ class BasePage:
 
             options = {
                 str(enum.value): enum.help_text(self.current_pr.workspace)
-                for enum in [
-                    *PublishedRunVisibility.choices_for_workspace(
-                        self.current_pr.workspace
-                    ),
-                    PublishedRunVisibility(self.current_pr.visibility),
-                ]
+                for enum in PublishedRunVisibility.choices_for_pr(self.current_pr)
             }
             published_run_visibility = PublishedRunVisibility(
                 int(

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -557,13 +557,12 @@ class BasePage:
 
             options = {
                 str(enum.value): enum.help_text(self.current_pr.workspace)
-                for enum in PublishedRunVisibility.choices_for_workspace(
-                    self.current_pr.workspace
-                )
-            } | {
-                str(self.current_pr.visibility): PublishedRunVisibility(
-                    self.current_pr.visibility
-                ).help_text(self.current_pr.workspace)
+                for enum in [
+                    *PublishedRunVisibility.choices_for_workspace(
+                        self.current_pr.workspace
+                    ),
+                    PublishedRunVisibility(self.current_pr.visibility),
+                ]
             }
             published_run_visibility = PublishedRunVisibility(
                 int(


### PR DESCRIPTION
selectively enables showing "Public" visibility for public examples

### Q/A checklist

- [x] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [x] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [x] Do a self code review of the changes - Read the diff at least twice.  
- [x] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [x] The relevant pages still run when you press submit
- [x] The API for those pages still work (API tab)
- [x] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [x] Do your UI changes (if applicable) look acceptable on mobile?
- [x] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

