### PR TITLE
show last ran time instead of updated_at always

### DIFF
--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -358,11 +358,7 @@ class BasePage:
                     with gui.nav_item(url, active=tab == self.tab):
                         gui.html(tab.title)
 
-            if (
-                self.current_pr
-                and not self.current_pr.is_root()
-                and self.tab == RecipeTabs.run
-            ):
+            if self.current_pr and self.tab == RecipeTabs.run:
                 with gui.div(
                     className="container-margin-reset d-none d-md-block",
                     style=dict(
@@ -490,8 +486,17 @@ class BasePage:
             gui.html("Unpublished changes")
 
     def _render_saved_timestamp(self, pr: PublishedRun):
+        last_run_at = gui.session_state.get(
+            StateKeys.updated_at, datetime.datetime.today()
+        )
+
+        if isinstance(last_run_at, str):
+            last_run_at = datetime.datetime.fromisoformat(last_run_at)
+
         with gui.tag("span", className="text-muted"):
-            gui.write(f"{get_relative_time(pr.updated_at)}")
+            gui.write(
+                f"{get_relative_time(pr.updated_at if pr.is_root() else last_run_at)}"
+            )
 
     def _render_options_button_with_dialog(self):
         ref = gui.use_alert_dialog(key="options-modal")

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -358,7 +358,7 @@ class BasePage:
                     with gui.nav_item(url, active=tab == self.tab):
                         gui.html(tab.title)
 
-                    self._render_saved_timestamp(self.current_pr, self.current_sr)
+                    self._render_saved_timestamp()
         with gui.nav_tab_content():
             self.render_selected_tab()
 
@@ -475,9 +475,16 @@ class BasePage:
         ):
             gui.html("Unpublished changes")
 
-    def _render_saved_timestamp(self, pr: PublishedRun, sr: SavedRun):
-        if self.current_pr and self.tab == RecipeTabs.run:
-            with gui.div(
+    def _render_saved_timestamp(self):
+        sr, pr = self.current_sr_pr
+        if not (pr and self.tab == RecipeTabs.run):
+            return
+        if pr.saved_run_id == sr.id or pr.is_root():
+            dt = pr.updated_at
+        else:
+            dt = sr.updated_at
+        with (
+            gui.div(
                 className="container-margin-reset d-none d-md-block",
                 style=dict(
                     position="absolute",
@@ -485,12 +492,10 @@ class BasePage:
                     right="0",
                     transform="translateY(-50%)",
                 ),
-            ):
-                show_last_saved = pr.saved_run == sr or pr.is_root()
-                with gui.tag("span", className="text-muted"):
-                    gui.write(
-                        f"{get_relative_time(pr.updated_at if show_last_saved else sr.updated_at)}"
-                    )
+            ),
+            gui.tag("span", className="text-muted"),
+        ):
+            gui.write(get_relative_time(dt))
 
     def _render_options_button_with_dialog(self):
         ref = gui.use_alert_dialog(key="options-modal")

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -368,7 +368,7 @@ class BasePage:
                         transform="translateY(-50%)",
                     ),
                 ):
-                    self._render_saved_timestamp(self.current_pr)
+                    self._render_saved_timestamp(self.current_pr, self.current_sr)
         with gui.nav_tab_content():
             self.render_selected_tab()
 
@@ -485,17 +485,10 @@ class BasePage:
         ):
             gui.html("Unpublished changes")
 
-    def _render_saved_timestamp(self, pr: PublishedRun):
-        last_run_at = gui.session_state.get(
-            StateKeys.updated_at, datetime.datetime.today()
-        )
-
-        if isinstance(last_run_at, str):
-            last_run_at = datetime.datetime.fromisoformat(last_run_at)
-
+    def _render_saved_timestamp(self, pr: PublishedRun, sr: SavedRun):
         with gui.tag("span", className="text-muted"):
             gui.write(
-                f"{get_relative_time(pr.updated_at if pr.is_root() else last_run_at)}"
+                f"{get_relative_time(pr.updated_at if pr.is_root() else sr.updated_at)}"
             )
 
     def _render_options_button_with_dialog(self):

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -358,16 +358,6 @@ class BasePage:
                     with gui.nav_item(url, active=tab == self.tab):
                         gui.html(tab.title)
 
-            if self.current_pr and self.tab == RecipeTabs.run:
-                with gui.div(
-                    className="container-margin-reset d-none d-md-block",
-                    style=dict(
-                        position="absolute",
-                        top="50%",
-                        right="0",
-                        transform="translateY(-50%)",
-                    ),
-                ):
                     self._render_saved_timestamp(self.current_pr, self.current_sr)
         with gui.nav_tab_content():
             self.render_selected_tab()
@@ -486,10 +476,20 @@ class BasePage:
             gui.html("Unpublished changes")
 
     def _render_saved_timestamp(self, pr: PublishedRun, sr: SavedRun):
-        with gui.tag("span", className="text-muted"):
-            gui.write(
-                f"{get_relative_time(pr.updated_at if pr.is_root() else sr.updated_at)}"
-            )
+        if self.current_pr and self.tab == RecipeTabs.run:
+            with gui.div(
+                className="container-margin-reset d-none d-md-block",
+                style=dict(
+                    position="absolute",
+                    top="50%",
+                    right="0",
+                    transform="translateY(-50%)",
+                ),
+            ):
+                with gui.tag("span", className="text-muted"):
+                    gui.write(
+                        f"{get_relative_time(pr.updated_at if pr.is_root() else sr.updated_at)}"
+                    )
 
     def _render_options_button_with_dialog(self):
         ref = gui.use_alert_dialog(key="options-modal")

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -486,9 +486,10 @@ class BasePage:
                     transform="translateY(-50%)",
                 ),
             ):
+                show_last_saved = pr.saved_run == sr or pr.is_root()
                 with gui.tag("span", className="text-muted"):
                     gui.write(
-                        f"{get_relative_time(pr.updated_at if pr.is_root() else sr.updated_at)}"
+                        f"{get_relative_time(pr.updated_at if show_last_saved else sr.updated_at)}"
                     )
 
     def _render_options_button_with_dialog(self):


### PR DESCRIPTION
### Q/A checklist

- [x] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [x] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [x] Do a self code review of the changes - Read the diff at least twice.  
- [x] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [x] The relevant pages still run when you press submit
- [x] The API for those pages still work (API tab)
- [x] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [x] Do your UI changes (if applicable) look acceptable on mobile?
- [x] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

