### PR TITLE
support LLM generated html buttons in whatsapp and web api

### DIFF
--- a/daras_ai_v2/csv_lines.py
+++ b/daras_ai_v2/csv_lines.py
@@ -1,0 +1,21 @@
+import csv
+from io import StringIO
+
+
+def csv_encode_row(*csv_row) -> str:
+    """
+    Converts a Python list to a CSV-encoded string.
+    """
+    output = StringIO()
+    writer = csv.writer(output)
+    writer.writerow(map(str, csv_row))
+    return output.getvalue().strip()  # Strip to remove trailing newline
+
+
+def csv_decode_row(csv_text: str) -> list[str]:
+    """
+    Converts a CSV-encoded string to a Python list.
+    """
+    input_stream = StringIO(csv_text)
+    reader = csv.reader(input_stream)
+    return next(reader)

--- a/daras_ai_v2/facebook_bots.py
+++ b/daras_ai_v2/facebook_bots.py
@@ -92,6 +92,7 @@ class WhatsappBot(BotInterface):
     def get_interactive_msg_info(self) -> ButtonPressed:
         return ButtonPressed(
             button_id=self.input_message["interactive"]["button_reply"]["id"],
+            button_title=self.input_message["interactive"]["button_reply"]["title"],
             context_msg_id=self.input_message["context"]["id"],
         )
 
@@ -168,7 +169,7 @@ class WhatsappBot(BotInterface):
                 messages = [
                     # interactive text msg + video in header
                     _build_msg_buttons(
-                        buttons,
+                        buttons[i : i + 3],
                         {
                             "body": {
                                 "text": text or "\u200b",
@@ -178,7 +179,9 @@ class WhatsappBot(BotInterface):
                                 "video": {"link": video},
                             },
                         },
-                    ),
+                    )
+                    # wa allows max 3 buttons per message
+                    for i in range(0, len(buttons), 3)
                 ]
             else:
                 messages = [
@@ -195,13 +198,15 @@ class WhatsappBot(BotInterface):
             # interactive text msg
             messages = [
                 _build_msg_buttons(
-                    buttons,
+                    buttons[i : i + 3],
                     {
                         "body": {
                             "text": text or "\u200b",
-                        }
+                        },
                     },
-                ),
+                )
+                # wa allows max 3 buttons per message
+                for i in range(0, len(buttons), 3)
             ]
         elif text:
             # simple text msg
@@ -209,7 +214,7 @@ class WhatsappBot(BotInterface):
                 {
                     "type": "text",
                     "text": {
-                        "body": text,
+                        "body": text or "\u200b",
                         "preview_url": True,
                     },
                 },

--- a/routers/bots_api.py
+++ b/routers/bots_api.py
@@ -14,7 +14,7 @@ from bots.models import Platform, Conversation, BotIntegration, Message, SavedRu
 from celeryapp.tasks import err_msg_for_exc
 from daras_ai_v2 import settings
 from daras_ai_v2.base import RecipeRunState, StateKeys
-from daras_ai_v2.bots import BotInterface, msg_handler, ButtonPressed
+from daras_ai_v2.bots import BotInterface, msg_handler, ButtonPressed, parse_html
 from daras_ai_v2.redis_cache import get_redis_cache
 from daras_ai_v2.search_ref import SearchReference
 from recipes.VideoBots import VideoBotsPage, ReplyButton
@@ -307,6 +307,10 @@ class ApiInterface(BotInterface):
             if self.run_id and self.uid:
                 sr = self.page_cls.get_sr_from_ids(run_id=self.run_id, uid=self.uid)
                 state = sr.to_dict()
+                output = VideoBotsPage.ResponseModel.parse_obj(state)
+                output.output_text = [
+                    parse_html(text, []) for text in output.output_text or []
+                ]
                 self.queue.put(
                     FinalResponse(
                         run_id=self.run_id,
@@ -315,7 +319,7 @@ class ApiInterface(BotInterface):
                         run_time_sec=sr.run_time.total_seconds(),
                         status=self.page_cls.get_run_state(state),
                         detail=state.get(StateKeys.run_status) or "",
-                        output=VideoBotsPage.ResponseModel.parse_obj(state),
+                        output=output,
                     )
                 )
         except Exception as e:
@@ -346,7 +350,7 @@ class ApiInterface(BotInterface):
         )
         return None
 
-    def send_msg(
+    def _send_msg(
         self,
         *,
         text: str | None = None,
@@ -354,7 +358,6 @@ class ApiInterface(BotInterface):
         video: str = None,
         buttons: list[ReplyButton] = None,
         documents: list[str] = None,
-        should_translate: bool = False,
         update_msg_id: str = None,
     ) -> str | None:
         response = MessagePart(

--- a/routers/bots_api.py
+++ b/routers/bots_api.py
@@ -14,7 +14,7 @@ from bots.models import Platform, Conversation, BotIntegration, Message, SavedRu
 from celeryapp.tasks import err_msg_for_exc
 from daras_ai_v2 import settings
 from daras_ai_v2.base import RecipeRunState, StateKeys
-from daras_ai_v2.bots import BotInterface, msg_handler, ButtonPressed, parse_html
+from daras_ai_v2.bots import BotInterface, msg_handler, ButtonPressed, parse_bot_html
 from daras_ai_v2.redis_cache import get_redis_cache
 from daras_ai_v2.search_ref import SearchReference
 from recipes.VideoBots import VideoBotsPage, ReplyButton
@@ -309,7 +309,7 @@ class ApiInterface(BotInterface):
                 state = sr.to_dict()
                 output = VideoBotsPage.ResponseModel.parse_obj(state)
                 output.output_text = [
-                    parse_html(text, []) for text in output.output_text or []
+                    parse_bot_html(text, []) for text in output.output_text or []
                 ]
                 self.queue.put(
                     FinalResponse(


### PR DESCRIPTION
### Q/A checklist

- [ ] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [ ] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [ ] Do a self code review of the changes - Read the diff at least twice.  
- [ ] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [ ] The relevant pages still run when you press submit
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
- [ ] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

