### PR TITLE
fix: set upper bound on max_tokens parameter for LLMs

### DIFF
--- a/daras_ai_v2/language_model.py
+++ b/daras_ai_v2/language_model.py
@@ -68,6 +68,7 @@ class LLMSpec(typing.NamedTuple):
     model_id: str | tuple
     llm_api: LLMApis
     context_window: int
+    max_output_tokens: int = 4096
     price: int = 1
     is_chat_model: bool = True
     is_vision_model: bool = False
@@ -83,6 +84,7 @@ class LargeLanguageModels(Enum):
         model_id="o3-mini-2025-01-31",
         llm_api=LLMApis.openai,
         context_window=200_000,
+        max_output_tokens=100_000,
         price=13,
         is_vision_model=False,
         supports_json=True,
@@ -95,6 +97,7 @@ class LargeLanguageModels(Enum):
         model_id="o1-2024-12-17",
         llm_api=LLMApis.openai,
         context_window=200_000,
+        max_output_tokens=100_000,
         price=50,
         is_vision_model=True,
         supports_json=True,
@@ -107,6 +110,7 @@ class LargeLanguageModels(Enum):
         model_id="o1-preview-2024-09-12",
         llm_api=LLMApis.openai,
         context_window=128_000,
+        max_output_tokens=32_768,
         price=50,
         is_vision_model=False,
         supports_json=False,
@@ -120,6 +124,7 @@ class LargeLanguageModels(Enum):
         model_id="o1-mini-2024-09-12",
         llm_api=LLMApis.openai,
         context_window=128_000,
+        max_output_tokens=65_536,
         price=13,
         is_vision_model=False,
         supports_json=False,
@@ -132,6 +137,7 @@ class LargeLanguageModels(Enum):
         model_id="gpt-4o-2024-08-06",
         llm_api=LLMApis.openai,
         context_window=128_000,
+        max_output_tokens=16_384,
         price=10,
         is_vision_model=True,
         supports_json=True,
@@ -142,6 +148,7 @@ class LargeLanguageModels(Enum):
         model_id="gpt-4o-mini",
         llm_api=LLMApis.openai,
         context_window=128_000,
+        max_output_tokens=16_384,
         price=1,
         is_vision_model=True,
         supports_json=True,
@@ -151,6 +158,7 @@ class LargeLanguageModels(Enum):
         model_id="chatgpt-4o-latest",
         llm_api=LLMApis.openai,
         context_window=128_000,
+        max_output_tokens=16_384,
         price=10,
         is_vision_model=True,
     )
@@ -193,6 +201,7 @@ class LargeLanguageModels(Enum):
         model_id=("openai-gpt-4-prod-ca-1", "gpt-4"),
         llm_api=LLMApis.openai,
         context_window=8192,
+        max_output_tokens=8192,
         price=10,
     )
     gpt_4_32k = LLMSpec(
@@ -233,6 +242,7 @@ class LargeLanguageModels(Enum):
         model_id="accounts/fireworks/models/deepseek-r1",
         llm_api=LLMApis.fireworks,
         context_window=128_000,
+        max_output_tokens=8192,
         supports_json=True,
     )
 
@@ -374,22 +384,23 @@ class LargeLanguageModels(Enum):
         is_deprecated=True,
     )
 
+    # https://cloud.google.com/vertex-ai/docs/generative-ai/learn/models
     gemini_2_flash = LLMSpec(
         label="Gemini 2 Flash (Google)",
         model_id="gemini-2.0-flash-001",
         llm_api=LLMApis.gemini,
         context_window=1_048_576,
+        max_output_tokens=8192,
         price=20,
         is_vision_model=True,
         supports_json=True,
     )
-
-    # https://cloud.google.com/vertex-ai/docs/generative-ai/learn/models
     gemini_1_5_flash = LLMSpec(
         label="Gemini 1.5 Flash (Google)",
         model_id="gemini-1.5-flash",
         llm_api=LLMApis.gemini,
         context_window=1_048_576,
+        max_output_tokens=8192,
         price=15,
         is_vision_model=True,
         supports_json=True,
@@ -399,6 +410,7 @@ class LargeLanguageModels(Enum):
         model_id="gemini-1.5-pro",
         llm_api=LLMApis.gemini,
         context_window=2_097_152,
+        max_output_tokens=8192,
         price=15,
         is_vision_model=True,
         supports_json=True,
@@ -408,6 +420,7 @@ class LargeLanguageModels(Enum):
         model_id="gemini-1.0-pro-vision",
         llm_api=LLMApis.gemini,
         context_window=2048,
+        max_output_tokens=8192,
         price=25,
         is_vision_model=True,
         is_chat_model=False,
@@ -441,6 +454,7 @@ class LargeLanguageModels(Enum):
         model_id="claude-3-5-sonnet-20240620",
         llm_api=LLMApis.anthropic,
         context_window=200_000,
+        max_output_tokens=8192,
         price=15,
         is_vision_model=True,
         supports_json=True,
@@ -596,6 +610,7 @@ class LargeLanguageModels(Enum):
         self.model_id = spec.model_id
         self.llm_api = spec.llm_api
         self.context_window = spec.context_window
+        self.max_output_tokens = spec.max_output_tokens
         self.price = spec.price
         self.is_deprecated = spec.is_deprecated
         self.is_chat_model = spec.is_chat_model
@@ -678,6 +693,7 @@ def run_language_model(
     ), "Pleave provide exactly one of { prompt, messages }"
 
     model: LargeLanguageModels = LargeLanguageModels[str(model)]
+    max_tokens = min(max_tokens, model.max_output_tokens)
     if model.is_chat_model:
         if prompt and not messages:
             # convert text prompt to chat messages

--- a/daras_ai_v2/language_model.py
+++ b/daras_ai_v2/language_model.py
@@ -1185,7 +1185,7 @@ def run_openai_chat(
 
         # reserved tokens for reasoning...
         # https://platform.openai.com/docs/guides/reasoning#allocating-space-for-reasoning
-        max_completion_tokens += 25_000
+        max_completion_tokens = max(25_000, max_completion_tokens)
     else:
         max_tokens = max_completion_tokens
         max_completion_tokens = NOT_GIVEN

--- a/daras_ai_v2/language_model.py
+++ b/daras_ai_v2/language_model.py
@@ -718,7 +718,8 @@ def run_language_model(
     ), "Pleave provide exactly one of { prompt, messages }"
 
     model: LargeLanguageModels = LargeLanguageModels[str(model)]
-    max_tokens = min(max_tokens, model.max_output_tokens)
+    if model.max_output_tokens:
+        max_tokens = min(max_tokens, model.max_output_tokens)
     if model.is_chat_model:
         if prompt and not messages:
             # convert text prompt to chat messages

--- a/daras_ai_v2/language_model.py
+++ b/daras_ai_v2/language_model.py
@@ -201,7 +201,6 @@ class LargeLanguageModels(Enum):
         model_id=("openai-gpt-4-prod-ca-1", "gpt-4"),
         llm_api=LLMApis.openai,
         context_window=8192,
-        max_output_tokens=8192,
         price=10,
     )
     gpt_4_32k = LLMSpec(

--- a/daras_ai_v2/language_model.py
+++ b/daras_ai_v2/language_model.py
@@ -68,7 +68,7 @@ class LLMSpec(typing.NamedTuple):
     model_id: str | tuple
     llm_api: LLMApis
     context_window: int
-    max_output_tokens: int = 4096
+    max_output_tokens: int | None = None
     price: int = 1
     is_chat_model: bool = True
     is_vision_model: bool = False
@@ -171,6 +171,7 @@ class LargeLanguageModels(Enum):
         ),
         llm_api=LLMApis.openai,
         context_window=128_000,
+        max_output_tokens=4096,
         price=6,
         is_vision_model=True,
         supports_json=True,
@@ -180,6 +181,7 @@ class LargeLanguageModels(Enum):
         model_id="gpt-4-vision-preview",
         llm_api=LLMApis.openai,
         context_window=128_000,
+        max_output_tokens=4096,
         price=6,
         is_vision_model=True,
         is_deprecated=True,
@@ -191,6 +193,7 @@ class LargeLanguageModels(Enum):
         model_id=("openai-gpt-4-turbo-prod-ca-1", "gpt-4-1106-preview"),
         llm_api=LLMApis.openai,
         context_window=128_000,
+        max_output_tokens=4096,
         price=5,
         supports_json=True,
     )
@@ -201,6 +204,7 @@ class LargeLanguageModels(Enum):
         model_id=("openai-gpt-4-prod-ca-1", "gpt-4"),
         llm_api=LLMApis.openai,
         context_window=8192,
+        max_output_tokens=8192,
         price=10,
     )
     gpt_4_32k = LLMSpec(
@@ -208,6 +212,7 @@ class LargeLanguageModels(Enum):
         model_id="openai-gpt-4-32k-prod-ca-1",
         llm_api=LLMApis.openai,
         context_window=32_768,
+        max_output_tokens=8192,
         price=20,
     )
 
@@ -225,6 +230,7 @@ class LargeLanguageModels(Enum):
         model_id=("openai-gpt-35-turbo-16k-prod-ca-1", "gpt-3.5-turbo-16k-0613"),
         llm_api=LLMApis.openai,
         context_window=16_384,
+        max_output_tokens=4096,
         price=2,
     )
     gpt_3_5_turbo_instruct = LLMSpec(
@@ -251,6 +257,7 @@ class LargeLanguageModels(Enum):
         model_id="llama-3.3-70b-versatile",
         llm_api=LLMApis.groq,
         context_window=128_000,
+        max_output_tokens=32_768,
         price=1,
         supports_json=True,
     )
@@ -259,6 +266,7 @@ class LargeLanguageModels(Enum):
         model_id="llama-3.2-90b-vision-preview",
         llm_api=LLMApis.groq,
         context_window=128_000,
+        max_output_tokens=8192,
         price=1,
         supports_json=True,
         is_vision_model=True,
@@ -268,6 +276,7 @@ class LargeLanguageModels(Enum):
         model_id="llama-3.2-11b-vision-preview",
         llm_api=LLMApis.groq,
         context_window=128_000,
+        max_output_tokens=8192,
         price=1,
         supports_json=True,
         is_vision_model=True,
@@ -278,6 +287,7 @@ class LargeLanguageModels(Enum):
         model_id="llama-3.2-3b-preview",
         llm_api=LLMApis.groq,
         context_window=128_000,
+        max_output_tokens=8192,
         price=1,
         supports_json=True,
     )
@@ -286,6 +296,7 @@ class LargeLanguageModels(Enum):
         model_id="llama-3.2-1b-preview",
         llm_api=LLMApis.groq,
         context_window=128_000,
+        max_output_tokens=8192,
         price=1,
         supports_json=True,
     )
@@ -295,6 +306,7 @@ class LargeLanguageModels(Enum):
         model_id="accounts/fireworks/models/llama-v3p1-405b-instruct",
         llm_api=LLMApis.fireworks,
         context_window=128_000,
+        max_output_tokens=4096,
         price=1,
         supports_json=True,
     )
@@ -303,6 +315,7 @@ class LargeLanguageModels(Enum):
         model_id="llama-3.1-70b-versatile",
         llm_api=LLMApis.groq,
         context_window=128_000,
+        max_output_tokens=4096,
         price=1,
         supports_json=True,
         is_deprecated=True,
@@ -311,7 +324,8 @@ class LargeLanguageModels(Enum):
         label="Llama 3.1 8B (Meta AI)",
         model_id="llama-3.1-8b-instant",
         llm_api=LLMApis.groq,
-        context_window=128_00,
+        context_window=128_000,
+        max_output_tokens=8192,
         price=1,
         supports_json=True,
     )
@@ -338,6 +352,7 @@ class LargeLanguageModels(Enum):
         model_id="pixtral-large-2411",
         llm_api=LLMApis.mistral,
         context_window=131_000,
+        max_output_tokens=4096,
         is_vision_model=True,
         supports_json=True,
     )
@@ -346,6 +361,7 @@ class LargeLanguageModels(Enum):
         model_id="mistral-large-2411",
         llm_api=LLMApis.mistral,
         context_window=131_000,
+        max_output_tokens=4096,
         supports_json=True,
     )
     mistral_small_24b_instruct = LLMSpec(
@@ -353,6 +369,7 @@ class LargeLanguageModels(Enum):
         model_id="mistral-small-2501",
         llm_api=LLMApis.mistral,
         context_window=32_768,
+        max_output_tokens=4096,
         price=1,
         supports_json=True,
     )
@@ -361,6 +378,7 @@ class LargeLanguageModels(Enum):
         model_id="mixtral-8x7b-32768",
         llm_api=LLMApis.groq,
         context_window=32_768,
+        max_output_tokens=4096,
         price=1,
         supports_json=True,
         is_deprecated=True,
@@ -370,6 +388,7 @@ class LargeLanguageModels(Enum):
         model_id="gemma2-9b-it",
         llm_api=LLMApis.groq,
         context_window=8_192,
+        max_output_tokens=4096,
         price=1,
         supports_json=True,
     )
@@ -378,6 +397,7 @@ class LargeLanguageModels(Enum):
         model_id="gemma-7b-it",
         llm_api=LLMApis.groq,
         context_window=8_192,
+        max_output_tokens=4096,
         price=1,
         supports_json=True,
         is_deprecated=True,
@@ -419,7 +439,6 @@ class LargeLanguageModels(Enum):
         model_id="gemini-1.0-pro-vision",
         llm_api=LLMApis.gemini,
         context_window=2048,
-        max_output_tokens=8192,
         price=25,
         is_vision_model=True,
         is_chat_model=False,
@@ -436,6 +455,7 @@ class LargeLanguageModels(Enum):
         model_id="chat-bison",
         llm_api=LLMApis.palm2,
         context_window=4096,
+        max_output_tokens=1024,
         price=10,
     )
     palm2_text = LLMSpec(
@@ -443,6 +463,7 @@ class LargeLanguageModels(Enum):
         model_id="text-bison",
         llm_api=LLMApis.palm2,
         context_window=8192,
+        max_output_tokens=1024,
         price=15,
         is_chat_model=False,
     )
@@ -463,6 +484,7 @@ class LargeLanguageModels(Enum):
         model_id="claude-3-opus-20240229",
         llm_api=LLMApis.anthropic,
         context_window=200_000,
+        max_output_tokens=4096,
         price=75,
         is_vision_model=True,
         supports_json=True,
@@ -472,6 +494,7 @@ class LargeLanguageModels(Enum):
         model_id="claude-3-sonnet-20240229",
         llm_api=LLMApis.anthropic,
         context_window=200_000,
+        max_output_tokens=4096,
         price=15,
         is_vision_model=True,
         supports_json=True,
@@ -481,6 +504,7 @@ class LargeLanguageModels(Enum):
         model_id="claude-3-haiku-20240307",
         llm_api=LLMApis.anthropic,
         context_window=200_000,
+        max_output_tokens=4096,
         price=2,
         is_vision_model=True,
         supports_json=True,
@@ -514,6 +538,7 @@ class LargeLanguageModels(Enum):
         model_id="llama3-groq-70b-8192-tool-use-preview",
         llm_api=LLMApis.groq,
         context_window=8192,
+        max_output_tokens=4096,
         price=1,
         supports_json=True,
         is_deprecated=True,
@@ -523,6 +548,7 @@ class LargeLanguageModels(Enum):
         model_id="llama3-groq-8b-8192-tool-use-preview",
         llm_api=LLMApis.groq,
         context_window=8192,
+        max_output_tokens=4096,
         price=1,
         supports_json=True,
         is_deprecated=True,

--- a/daras_ai_v2/language_model_settings_widgets.py
+++ b/daras_ai_v2/language_model_settings_widgets.py
@@ -49,17 +49,16 @@ def language_model_settings(selected_models: str | list[str] | None = None) -> N
     with col1:
         gui.checkbox("Avoid Repetition", key="avoid_repetition")
 
-    if any(map(lambda llm: llm.supports_json, llms)):
-        with col2:
-            gui.selectbox(
-                f"###### {field_title_desc(LanguageModelSettings, 'response_format_type')}",
-                options=[None, "json_object"],
-                key="response_format_type",
-                format_func={
-                    None: BLANK_OPTION,
-                    "json_object": "JSON Object",
-                }.__getitem__,
-            )
+    with col2:
+        gui.selectbox(
+            f"###### {field_title_desc(LanguageModelSettings, 'response_format_type')}",
+            options=[None, "json_object"],
+            key="response_format_type",
+            format_func={
+                None: BLANK_OPTION,
+                "json_object": "JSON Object",
+            }.__getitem__,
+        )
 
     col1, col2 = gui.columns(2)
     with col1:
@@ -81,7 +80,7 @@ def language_model_settings(selected_models: str | list[str] | None = None) -> N
             step=2,
         )
 
-    if any(map(lambda llm: llm.supports_temperature, llms)):
+    if any(llm.supports_temperature for llm in llms):
         with col2:
             gui.slider(
                 label="""
@@ -105,9 +104,7 @@ How many answers should the copilot generate? Additional answer outputs increase
             min_value=1,
             max_value=4,
         )
-    if llms and any(
-        map(lambda llm: not llm.is_chat_model and llm.llm_api == LLMApis.openai, llms)
-    ):
+    if any(not llm.is_chat_model and llm.llm_api == LLMApis.openai for llm in llms):
         with col2:
             gui.slider(
                 label="""

--- a/daras_ai_v2/language_model_settings_widgets.py
+++ b/daras_ai_v2/language_model_settings_widgets.py
@@ -32,16 +32,24 @@ def language_model_selector(
     )
 
 
-def language_model_settings(selected_model: str = None):
-    try:
-        llm = LargeLanguageModels[selected_model]
-    except KeyError:
-        llm = None
+def language_model_settings(selected_models: str | list[str] | None = None) -> None:
+    if isinstance(selected_models, str):
+        selected_models = [selected_models]
+    elif not selected_models:
+        selected_models = []
+
+    llms = []
+    for model in selected_models:
+        try:
+            llms.append(LargeLanguageModels[model])
+        except KeyError:
+            pass
 
     col1, col2 = gui.columns(2)
     with col1:
         gui.checkbox("Avoid Repetition", key="avoid_repetition")
-    if not llm or llm.supports_json:
+
+    if any(map(lambda llm: llm.supports_json, llms)):
         with col2:
             gui.selectbox(
                 f"###### {field_title_desc(LanguageModelSettings, 'response_format_type')}",
@@ -55,26 +63,36 @@ def language_model_settings(selected_model: str = None):
 
     col1, col2 = gui.columns(2)
     with col1:
-        gui.number_input(
+        if llms:
+            max_output_tokens = min(
+                [llm.max_output_tokens or llm.context_window for llm in llms]
+            )
+        else:
+            max_output_tokens = 4096
+
+        gui.slider(
             label="""
             ###### Max Output Tokens
             The maximum number of tokens to generate in the completion. Increase to generate longer responses.
             """,
             key="max_tokens",
             min_value=10,
-            step=10,
+            max_value=max_output_tokens,
+            step=2,
         )
-    with col2:
-        gui.slider(
-            label="""
-            ###### Creativity (aka Sampling Temperature)
-    
-            Higher values allow the LLM to take more risks. Try values larger than 1 for more creative applications or 0 to ensure that LLM gives the same answer when given the same user input. 
-            """,
-            key="sampling_temperature",
-            min_value=0.0,
-            max_value=2.0,
-        )
+
+    if any(map(lambda llm: llm.supports_temperature, llms)):
+        with col2:
+            gui.slider(
+                label="""
+                ###### Creativity (aka Sampling Temperature)
+
+                Higher values allow the LLM to take more risks. Try values larger than 1 for more creative applications or 0 to ensure that LLM gives the same answer when given the same user input. 
+                """,
+                key="sampling_temperature",
+                min_value=0.0,
+                max_value=2.0,
+            )
 
     col1, col2 = gui.columns(2)
     with col1:
@@ -87,7 +105,9 @@ How many answers should the copilot generate? Additional answer outputs increase
             min_value=1,
             max_value=4,
         )
-    if llm and not llm.is_chat_model and llm.llm_api == LLMApis.openai:
+    if llms and any(
+        map(lambda llm: not llm.is_chat_model and llm.llm_api == LLMApis.openai, llms)
+    ):
         with col2:
             gui.slider(
                 label="""

--- a/recipes/CompareLLM.py
+++ b/recipes/CompareLLM.py
@@ -93,7 +93,9 @@ class CompareLLMPage(BasePage):
         youtube_video("dhexRRDAuY8")
 
     def render_settings(self):
-        language_model_settings()
+        language_model_settings(
+            selected_models=gui.session_state.get("selected_models")
+        )
 
     def run(self, state: dict) -> typing.Iterator[str | None]:
         request: CompareLLMPage.RequestModel = self.RequestModel.parse_obj(state)


### PR DESCRIPTION
### Q/A checklist

- [x] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [x] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [x] Do a self code review of the changes - Read the diff at least twice.  
- [x] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [x] The relevant pages still run when you press submit
- [x] The API for those pages still work (API tab)
- [x] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [x] Do your UI changes (if applicable) look acceptable on mobile?
- [x] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

