### PR TITLE
fix redirects for team workspaces: billing/members to saved

### DIFF
--- a/workspaces/widgets.py
+++ b/workspaces/widgets.py
@@ -13,7 +13,7 @@ SWITCH_WORKSPACE_KEY = "--switch-workspace"
 
 def global_workspace_selector(user: AppUser, session: dict):
     from daras_ai_v2.base import BasePage
-    from routers.account import members_route, profile_route
+    from routers.account import members_route, profile_route, saved_route
 
     try:
         del user.cached_workspaces  # invalidate cache on every re-render
@@ -24,7 +24,7 @@ def global_workspace_selector(user: AppUser, session: dict):
     if switch_workspace_id := gui.session_state.pop(SWITCH_WORKSPACE_KEY, None):
         try:
             if str(session[SESSION_SELECTED_WORKSPACE]) == switch_workspace_id:
-                raise gui.RedirectException(get_route_path(members_route))
+                raise gui.RedirectException(get_route_path(saved_route))
         except KeyError:
             pass
         set_current_workspace(session, int(switch_workspace_id))
@@ -102,7 +102,7 @@ def global_workspace_selector(user: AppUser, session: dict):
         else:
             gui.html('<hr class="my-1"/>')
             with gui.link(
-                to=get_route_path(members_route),
+                to=get_route_path(saved_route),
                 className="text-decoration-none d-block bg-hover-light px-3 my-1 py-1",
                 style=dict(height=row_height),
             ):


### PR DESCRIPTION
### Q/A checklist

- [x] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [x] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [x] Do a self code review of the changes - Read the diff at least twice.  
- [x] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [x] The relevant pages still run when you press submit
- [x] The API for those pages still work (API tab)
- [x] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [x] Do your UI changes (if applicable) look acceptable on mobile?
- [x] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

