### PR TITLE
Add onedrive/sharepoint authorization error template

### DIFF
--- a/templates/authorization_error.html
+++ b/templates/authorization_error.html
@@ -1,0 +1,61 @@
+{% extends 'base.html' %}
+
+{% block title %}Authorization Error{% endblock title %}
+
+{% block content %}
+<div style="text-align: center; margin: 2rem 0;">
+
+  <h1>Authorization Error</h1>
+  <div class="container border p-2">
+    <pre class="text-danger">{{ error }}</pre>
+    <pre class="text-center mx-4 mb-4 bg-light">
+      {{ error_description or "An error occurred during authentication." }}
+    </pre>
+  </div>
+
+  <div style="margin-top: 2rem; display: flex; gap: 2rem; justify-content: center;">
+    <a
+      href="{{ redirect_url | default('/') }}"style="
+        display: inline-block;
+        text-decoration: none;
+        padding: 12px;
+        background-color: #fff;
+        color: #000;
+        border-radius: 6px;
+        transition: all 0.1s ease;"
+      onmouseover="
+        this.style.borderColor='#000';
+        this.style.color='#000';
+        this.style.backgroundColor='#FEF1F5'"
+      onmouseout="
+        this.style.borderColor='#c9c9c9';
+        this.style.color='#c9c9c9';
+        this.style.backgroundColor='#FFF';"
+    > Back to Run
+    </a>
+          <a
+      href="{{ retry_url }}"
+      style="
+        display: inline-block;
+        text-decoration: none;
+        padding: 12px;
+        border: 1px solid #000;
+        background-color: #000;
+        color: #fff;
+        border-radius: 6px;
+        transition: all 0.1s ease;"
+      onmouseover="
+        this.style.backgroundColor='#3EFFEA';
+        this.style.color='#000';
+        this.style.borderColor='#000';"
+      onmouseout="
+        this.style.backgroundColor='#000';
+        this.style.color='#fff';
+        this.style.borderColor='#000';"
+
+    > Retry Authorization
+    </a>
+  </div>
+</div>
+
+{% endblock content %}


### PR DESCRIPTION
### Q/A checklist

- [ ] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [ ] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [ ] Do a self code review of the changes - Read the diff at least twice.  
- [ ] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [ ] The relevant pages still run when you press submit
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
- [ ] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

