### PR TITLE
o1 o3mini validation error - Add "developer" role to ConversationEntry type

### DIFF
--- a/daras_ai_v2/language_model.py
+++ b/daras_ai_v2/language_model.py
@@ -754,7 +754,7 @@ def calc_gpt_tokens(
 
 
 class ConversationEntry(typing_extensions.TypedDict, total=False):
-    role: typing.Literal["user", "system", "assistant", "tool"]
+    role: typing.Literal["user", "system", "assistant", "tool", "developer"]
     content: str | list[ChatCompletionContentPartParam]
 
     tool_calls: typing_extensions.NotRequired[list[ChatCompletionMessageToolCallParam]]

--- a/daras_ai_v2/language_model.py
+++ b/daras_ai_v2/language_model.py
@@ -3,6 +3,7 @@ import json
 import mimetypes
 import re
 import typing
+from copy import deepcopy
 from enum import Enum
 from functools import wraps
 
@@ -754,7 +755,7 @@ def calc_gpt_tokens(
 
 
 class ConversationEntry(typing_extensions.TypedDict, total=False):
-    role: typing.Literal["user", "system", "assistant", "tool", "developer"]
+    role: typing.Literal["user", "system", "assistant", "tool"]
     content: str | list[ChatCompletionContentPartParam]
 
     tool_calls: typing_extensions.NotRequired[list[ChatCompletionMessageToolCallParam]]
@@ -1304,13 +1305,15 @@ def run_openai_chat(
 ) -> list[ConversationEntry] | typing.Generator[list[ConversationEntry], None, None]:
     from openai._types import NOT_GIVEN
 
+    messages_for_completion = deepcopy(messages)
+
     if model in [
         LargeLanguageModels.o1_mini,
         LargeLanguageModels.o1,
         LargeLanguageModels.o3_mini,
     ]:
         # fuck you, openai
-        for entry in messages:
+        for entry in messages_for_completion:
             if entry["role"] == CHATML_ROLE_SYSTEM:
                 if model == LargeLanguageModels.o1_mini:
                     entry["role"] = CHATML_ROLE_USER
@@ -1356,7 +1359,7 @@ def run_openai_chat(
         *[
             _get_chat_completions_create(
                 model=model_id,
-                messages=messages,
+                messages=messages_for_completion,
                 max_tokens=max_tokens,
                 max_completion_tokens=max_completion_tokens,
                 stop=stop or NOT_GIVEN,


### PR DESCRIPTION
- avoid validation error

### Q/A checklist

- [ ] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [ ] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [ ] Do a self code review of the changes - Read the diff at least twice.  
- [ ] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [ ] The relevant pages still run when you press submit
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
- [ ] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

