### PR TITLE
add LLMs: gemini 2.5 pro, gemini 2 flash lite, llama4 maverick, llama4 scout

### DIFF
--- a/daras_ai_v2/language_model.py
+++ b/daras_ai_v2/language_model.py
@@ -294,6 +294,24 @@ class LargeLanguageModels(Enum):
     )
 
     # https://console.groq.com/docs/models
+    llama4_maverick_17b_128e = LLMSpec(
+        label="Llama 4 Maverick Instruct",
+        model_id="accounts/fireworks/models/llama4-maverick-instruct-basic",
+        llm_api=LLMApis.fireworks,
+        context_window=1_000_000,
+        max_output_tokens=16_384,
+        supports_json=True,
+        is_vision_model=True,
+    )
+    llama4_scout_17b_16e = LLMSpec(
+        label="Llama 4 Scout Instruct",
+        model_id="accounts/fireworks/models/llama4-scout-instruct-basic",
+        llm_api=LLMApis.fireworks,
+        context_window=128_000,
+        max_output_tokens=16_384,
+        supports_json=True,
+        is_vision_model=True,
+    )
     llama3_3_70b = LLMSpec(
         label="Llama 3.3 70B",
         model_id="llama-3.3-70b-versatile",
@@ -446,6 +464,26 @@ class LargeLanguageModels(Enum):
     )
 
     # https://cloud.google.com/vertex-ai/docs/generative-ai/learn/models
+    gemini_2_5_pro_preview = LLMSpec(
+        label="Gemini 2.5 Pro Preview (Google)",
+        model_id="gemini-2.5-pro-preview-03-25",
+        llm_api=LLMApis.gemini,
+        context_window=1_048_576,
+        max_output_tokens=64_000,
+        price=20,
+        is_vision_model=True,
+        supports_json=True,
+    )
+    gemini_2_flash_lite = LLMSpec(
+        label="Gemini 2 Flash Lite (Google)",
+        model_id="gemini-2.0-flash-lite",
+        llm_api=LLMApis.gemini,
+        context_window=1_048_576,
+        max_output_tokens=8192,
+        price=20,
+        is_vision_model=True,
+        supports_json=True,
+    )
     gemini_2_flash = LLMSpec(
         label="Gemini 2 Flash (Google)",
         model_id="gemini-2.0-flash-001",

--- a/scripts/init_llm_pricing.py
+++ b/scripts/init_llm_pricing.py
@@ -534,6 +534,24 @@ def run():
     # Gemini
 
     llm_pricing_create(
+        model_id="gemini-2.5-pro-preview-03-25",
+        model_name=LargeLanguageModels.gemini_2_5_pro_preview.name,
+        unit_cost_input=1.25,  # actually 2.5 when len(input) >= 200K
+        unit_cost_output=10,  # actually 15 when len(input) >= 200K
+        unit_quantity=10**6,
+        provider=ModelProvider.google,
+        pricing_url="https://ai.google.dev/gemini-api/docs/pricing#gemini-2.5-pro-preview",
+    )
+    llm_pricing_create(
+        model_id="gemini-2.0-flash-lite",
+        model_name=LargeLanguageModels.gemini_2_flash_lite.name,
+        unit_cost_input=0.075,
+        unit_cost_output=0.30,
+        unit_quantity=10**6,
+        provider=ModelProvider.google,
+        pricing_url="https://ai.google.dev/gemini-api/docs/pricing#gemini-2.0-flash-lite",
+    )
+    llm_pricing_create(
         model_id="gemini-2.0-flash-001",
         model_name=LargeLanguageModels.gemini_2_flash.name,
         unit_cost_input=0.1,
@@ -921,6 +939,25 @@ def run():
         model_name=LargeLanguageModels.mistral_small_24b_instruct.name,
         unit_cost_input=0.90,
         unit_cost_output=0.90,
+        unit_quantity=10**6,
+        provider=ModelProvider.fireworks,
+        pricing_url="https://fireworks.ai/pricing",
+    )
+
+    llm_pricing_create(
+        model_id="accounts/fireworks/models/llama4-scout-instruct-basic",
+        model_name=LargeLanguageModels.llama4_scout_17b_16e.name,
+        unit_cost_input=0.15,
+        unit_cost_output=0.60,
+        unit_quantity=10**6,
+        provider=ModelProvider.fireworks,
+        pricing_url="https://fireworks.ai/pricing",
+    )
+    llm_pricing_create(
+        model_id="accounts/fireworks/models/llama4-maverick-instruct-basic",
+        model_name=LargeLanguageModels.llama4_maverick_17b_128e.name,
+        unit_cost_input=0.22,
+        unit_cost_output=0.88,
         unit_quantity=10**6,
         provider=ModelProvider.fireworks,
         pricing_url="https://fireworks.ai/pricing",


### PR DESCRIPTION
### Q/A checklist

- [ ] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [ ] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [ ] Do a self code review of the changes - Read the diff at least twice.  
- [ ] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [ ] The relevant pages still run when you press submit
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
- [ ] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

