### PR TITLE
deprecate epicdream animation model

### DIFF
--- a/recipes/DeforumSD.py
+++ b/recipes/DeforumSD.py
@@ -25,7 +25,11 @@ MODEL_ESTIMATED_TIME_PER_FRAME = 2.4  # seconds
 
 class AnimationModels(TextChoices):
     protogen_2_2 = ("Protogen_V2.2.ckpt", "Protogen V2.2 (darkstorm2150)")
-    epicdream = ("epicdream.safetensors", "epiCDream (epinikion)")
+    epicdream = ("epicdream.safetensors", "epiCDream [Deprecated] (epinikion)")
+
+    @classmethod
+    def _deprecated(cls):
+        return {cls.epicdream}
 
 
 class _AnimationPrompt(TypedDict):
@@ -270,6 +274,11 @@ class DeforumSDPage(BasePage):
     def run(self, state: dict):
         request: DeforumSDPage.RequestModel = self.RequestModel.parse_obj(state)
         model = AnimationModels[request.selected_model]
+
+        if model in AnimationModels._deprecated():
+            raise UserError(
+                f"The selected model `{model}` is deprecated. Please select a different model."
+            )
 
         yield f"Running {model.label}..."
 


### PR DESCRIPTION
### Q/A checklist

- [ ] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [ ] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [ ] Do a self code review of the changes - Read the diff at least twice.  
- [ ] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [ ] The relevant pages still run when you press submit
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
- [ ] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Prevented selection and use of deprecated animation models by displaying an error if a deprecated model is chosen.
- **Style**
	- Updated the label for the deprecated "epicdream" animation model to clearly indicate its deprecated status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->