### PR TITLE
show "Help Guide" button on root workflows

### DIFF
--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -73,6 +73,7 @@ from widgets.author import (
     render_author_as_breadcrumb,
     render_author_from_user,
 )
+from widgets.base_header import render_help_button
 from widgets.publish_form import clear_publish_form
 from widgets.saved_workflow import render_saved_workflow_preview
 from widgets.workflow_image import (
@@ -507,27 +508,14 @@ class BasePage:
 
     def render_social_buttons(self):
         with (
-            gui.styled(
-                "& .btn { padding: 6px } & a:hover { text-decoration: underline !important; }"
-            ),
-            gui.div(className="d-flex align-items-center gap-lg-2 gap-1"),
+            gui.styled("& .btn { padding: 6px }"),
+            gui.div(className="d-flex gap-lg-2 gap-1"),
         ):
-
             publish_dialog_ref = gui.use_alert_dialog(key="publish-modal")
+
             if self.tab == RecipeTabs.run:
-                meta = self.workflow.get_or_create_metadata()
-                if self.current_pr.is_root() and meta.help_url:
-                    with gui.div(className="me-1 container-margin-reset"):
-                        with gui.link(
-                            to=meta.help_url,
-                            target="_blank",
-                            style={"color": "gray"},
-                            className="mb-0 text-decoration-none",
-                        ):
-                            gui.write(
-                                f'<span style="color:initial">{icons.help_guide}</span> <span class="d-none d-lg-inline">Help Guide</span>',
-                                unsafe_allow_html=True,
-                            )
+                if self.current_pr.is_root():
+                    render_help_button(self.workflow)
                 if self.is_logged_in():
                     self._render_options_button_with_dialog()
                 render_share_button(
@@ -1453,9 +1441,9 @@ class BasePage:
         with gui.div(**self.get_submit_container_props()):
             gui.write("---")
             col1, col2 = gui.columns([2, 1], responsive=False)
-            col2.node.props[
-                "className"
-            ] += " d-flex justify-content-end align-items-center"
+            col2.node.props["className"] += (
+                " d-flex justify-content-end align-items-center"
+            )
             col1.node.props["className"] += " d-flex flex-column justify-content-center"
             with col1:
                 self.render_run_cost()

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -510,9 +510,17 @@ class BasePage:
             gui.styled("& .btn { padding: 6px }"),
             gui.div(className="d-flex align-items-start gap-lg-2 gap-1"),
         ):
+           
             publish_dialog_ref = gui.use_alert_dialog(key="publish-modal")
-
             if self.tab == RecipeTabs.run:
+                meta = self.workflow.get_or_create_metadata()
+                if self.current_pr.is_root() and meta.help_url:
+                    with gui.div(className="me-1"):
+                            if gui.button(
+                                f'<span style="color:initial">{icons.help_guide}</span> <span class="d-none d-lg-inline">Help Guide</span>',
+                                type="tertiary",
+                            ):
+                                gui.js(f'window.open("{meta.help_url}", "_blank")')
                 if self.is_logged_in():
                     self._render_options_button_with_dialog()
                 render_share_button(

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -507,20 +507,25 @@ class BasePage:
 
     def render_social_buttons(self):
         with (
-            gui.styled("& .btn { padding: 6px }"),
-            gui.div(className="d-flex align-items-start gap-lg-2 gap-1"),
+            gui.styled("& .btn { padding: 6px } & a:hover { text-decoration: underline !important; }"),
+            gui.div(className="d-flex align-items-center gap-lg-2 gap-1"),
         ):
-           
+
             publish_dialog_ref = gui.use_alert_dialog(key="publish-modal")
             if self.tab == RecipeTabs.run:
                 meta = self.workflow.get_or_create_metadata()
                 if self.current_pr.is_root() and meta.help_url:
-                    with gui.div(className="me-1"):
-                            if gui.button(
+                    with gui.div(className="me-1 container-margin-reset"):
+                        with gui.link(
+                            to=meta.help_url,
+                            target="_blank",
+                            style={"color": "gray"},
+                            className="mb-0 text-decoration-none",
+                        ):
+                            gui.write(
                                 f'<span style="color:initial">{icons.help_guide}</span> <span class="d-none d-lg-inline">Help Guide</span>',
-                                type="tertiary",
-                            ):
-                                gui.js(f'window.open("{meta.help_url}", "_blank")')
+                                unsafe_allow_html=True,
+                            )
                 if self.is_logged_in():
                     self._render_options_button_with_dialog()
                 render_share_button(
@@ -1446,9 +1451,9 @@ class BasePage:
         with gui.div(**self.get_submit_container_props()):
             gui.write("---")
             col1, col2 = gui.columns([2, 1], responsive=False)
-            col2.node.props["className"] += (
-                " d-flex justify-content-end align-items-center"
-            )
+            col2.node.props[
+                "className"
+            ] += " d-flex justify-content-end align-items-center"
             col1.node.props["className"] += " d-flex flex-column justify-content-center"
             with col1:
                 self.render_run_cost()

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -507,7 +507,9 @@ class BasePage:
 
     def render_social_buttons(self):
         with (
-            gui.styled("& .btn { padding: 6px } & a:hover { text-decoration: underline !important; }"),
+            gui.styled(
+                "& .btn { padding: 6px } & a:hover { text-decoration: underline !important; }"
+            ),
             gui.div(className="d-flex align-items-center gap-lg-2 gap-1"),
         ):
 

--- a/daras_ai_v2/icons.py
+++ b/daras_ai_v2/icons.py
@@ -59,3 +59,5 @@ card_icons = {
 }
 
 integrations_img = "https://storage.googleapis.com/dara-c1b52.appspot.com/daras_ai/media/c3ba2392-d6b9-11ee-a67b-6ace8d8c9501/image.png"
+
+help_guide = '<i class="fa-duotone fa-solid fa-life-ring"></i>'

--- a/widgets/base_header.py
+++ b/widgets/base_header.py
@@ -1,0 +1,22 @@
+import gooey_gui as gui
+
+from bots.models import Workflow
+from daras_ai_v2 import icons
+
+
+def render_help_button(workflow: Workflow):
+    meta = workflow.get_or_create_metadata()
+    if not meta.help_url:
+        return
+
+    with (
+        gui.link(to=meta.help_url, target="_blank"),
+        gui.tag(
+            "button",
+            type="button",
+            className="btn btn-theme btn-tertiary m-0",
+        ),
+    ):
+        gui.html(
+            f'{icons.help_guide} <span class="text-muted d-none d-lg-inline">Help Guide</span>'
+        )


### PR DESCRIPTION
### Q/A checklist

- [x] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [x] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [x] Do a self code review of the changes - Read the diff at least twice.  
- [x] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [x] The relevant pages still run when you press submit
- [x] The API for those pages still work (API tab)
- [x] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [x] Do your UI changes (if applicable) look acceptable on mobile?
- [x] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208834359568782