### PR TITLE
add typing indicator functionality for WhatsApp bot

### DIFF
--- a/daras_ai_v2/facebook_bots.py
+++ b/daras_ai_v2/facebook_bots.py
@@ -133,7 +133,10 @@ class WhatsappBot(BotInterface):
 
     def mark_read(self):
         wa_mark_read(
-            self.bot_id, self.input_message["id"], access_token=self.access_token
+            bot_number=self.bot_id,
+            message_id=self.input_message["id"],
+            user_msg_id=self.user_msg_id,
+            access_token=self.access_token,
         )
 
     @classmethod
@@ -376,7 +379,9 @@ def send_wa_msgs_raw(
     return msg_id
 
 
-def wa_mark_read(bot_number: str, message_id: str, access_token: str | None = None):
+def wa_mark_read(
+    bot_number: str, message_id: str, user_msg_id: str, access_token: str | None = None
+):
     # send read receipt
     r = requests.post(
         f"https://graph.facebook.com/v16.0/{bot_number}/messages",
@@ -388,6 +393,19 @@ def wa_mark_read(bot_number: str, message_id: str, access_token: str | None = No
         },
     )
     print("wa_mark_read:", r.status_code, r.json())
+
+    # send typing indicator
+    r = requests.post(
+        f"https://graph.facebook.com/v16.0/{bot_number}/messages",
+        headers=get_wa_auth_header(access_token),
+        json={
+            "messaging_product": "whatsapp",
+            "status": "read",
+            "message_id": user_msg_id,
+            "typing_indicator": {"type": "text"},
+        },
+    )
+    print("wa_typing_indicator:", r.status_code, r.json())
 
 
 class FacebookBot(BotInterface):


### PR DESCRIPTION
### Q/A checklist

- [ ] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [x] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [ ] Do a self code review of the changes - Read the diff at least twice.  
- [ ] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [ ] The relevant pages still run when you press submit
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
- [ ] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

