### PR TITLE
fix: text changes on workspace creation / invitation flow

### DIFF
--- a/routers/workspace.py
+++ b/routers/workspace.py
@@ -13,7 +13,7 @@ from fastapi.responses import RedirectResponse
 from furl import furl
 
 from app_users.models import AppUser
-from daras_ai_v2 import settings, urls
+from daras_ai_v2 import settings
 from daras_ai_v2.fastapi_tricks import get_route_path
 from daras_ai_v2.meta_content import raw_build_meta_tags
 from handles.models import Handle, COMMON_EMAIL_DOMAINS
@@ -97,7 +97,7 @@ def render_create_workspace_form(
 ):
     from daras_ai_v2.profiles import render_handle_input, update_handle
 
-    gui.write("#### Create New Workspace")
+    gui.write("#### Create Gooey.AI Workspace")
     gui.caption(
         "Workspaces allow you to collaborate with team members with a shared payment method."
     )
@@ -109,7 +109,8 @@ def render_create_workspace_form(
     gui.write("###### Your workspace's URL")
     with gui.div(className="d-flex align-items-start gap-2"):
         with gui.div(className="mt-2 pt-1"):
-            gui.html(urls.remove_scheme(settings.APP_BASE_URL).rstrip("/"))
+            # rstrip("/") + "/" to preserve exactly one trailing slash
+            gui.html(settings.APP_BASE_URL.rstrip("/") + "/")
         with gui.div(className="d-block d-lg-flex gap-3 w-100"):
             # separate div for input & error msg for handle field
             if "handle_name" not in gui.session_state:
@@ -180,7 +181,7 @@ def get_default_workspace_name_for_user(user: AppUser) -> str:
 def render_invite_team_form(
     workspace: Workspace, user: AppUser, selected_plan: int | None, next_url: str
 ):
-    gui.write("### Invite Team Members")
+    gui.write(f"### Invite members to {workspace.display_name()} on Gooey.AI")
     gui.caption(
         "This workspace is private and only members can access its workflows and shared billing."
     )


### PR DESCRIPTION
### Q/A checklist

- [ ] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [ ] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [ ] Do a self code review of the changes - Read the diff at least twice.  
- [ ] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [ ] The relevant pages still run when you press submit
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
- [ ] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210204130582028