### PR TITLE
refactor: remove split_output_tab

### DIFF
--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -1100,8 +1100,6 @@ class BasePage:
             tabs.extend([RecipeTabs.saved])
         return tabs
 
-    split_output_tab = False
-
     def render_selected_tab(self):
         match self.tab:
             case RecipeTabs.run:
@@ -1109,10 +1107,7 @@ class BasePage:
                     self.render_deleted_output()
                     return
 
-                with gui.styled(
-                    "& [data-reach-tab-list] {  text-align: center; margin-top: 0 }"
-                    + ("" if self.split_output_tab else RESPONSIVE_OUTPUT_TAB_SPLIT_CSS)
-                ):
+                with gui.styled(OUTPUT_TABS_CSS):
                     output_col, input_col = gui.tabs(
                         [f"{icons.preview} Preview", f"{icons.edit} Edit"]
                     )
@@ -2443,7 +2438,10 @@ class TitleValidationError(Exception):
     pass
 
 
-RESPONSIVE_OUTPUT_TAB_SPLIT_CSS = """
+OUTPUT_TABS_CSS = """
+& [data-reach-tab-list] {  
+    text-align: center; margin-top: 0 
+}
 @media (min-width: 768px) {
     & [data-reach-tab-list] {
         display: none;

--- a/recipes/BulkEval.py
+++ b/recipes/BulkEval.py
@@ -142,8 +142,6 @@ class BulkEvalPage(BasePage):
 
     explore_image = "https://storage.googleapis.com/dara-c1b52.appspot.com/daras_ai/media/aad314f0-9a97-11ee-8318-02420a0001c7/W.I.9.png.png"
 
-    split_output_tab = True
-
     def render_description(self):
         gui.write(
             """

--- a/recipes/BulkRunner.py
+++ b/recipes/BulkRunner.py
@@ -45,8 +45,6 @@ class BulkRunnerPage(BasePage):
     slug_versions = ["bulk-runner", "bulk"]
     price = 1
 
-    split_output_tab = True
-
     class RequestModel(BasePage.RequestModel):
         documents: list[FieldHttpUrl] = Field(
             title="Input Data Spreadsheet",


### PR DESCRIPTION
### Q/A checklist

- [ ] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [ ] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [ ] Do a self code review of the changes - Read the diff at least twice.  
- [ ] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [ ] The relevant pages still run when you press submit
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
- [ ] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

