### PR TITLE
feat: show demo pill in saved workflow list

### DIFF
--- a/widgets/saved_workflow.py
+++ b/widgets/saved_workflow.py
@@ -111,8 +111,7 @@ def render_saved_workflow_preview(
                                         className="border border-dark ms-2",
                                     )
 
-                                for bot in demo_bots:
-                                    platform_id = bot[1]
+                                for _, platform_id in demo_bots:
                                     platform = Platform(platform_id)
                                     label = (
                                         f"{platform.get_icon()} {platform.get_title()}"

--- a/widgets/saved_workflow.py
+++ b/widgets/saved_workflow.py
@@ -7,7 +7,7 @@ import typing
 import gooey_gui as gui
 from furl import furl
 
-from bots.models import PublishedRun, Workflow
+from bots.models import PublishedRun, Workflow, Platform
 from daras_ai.image_input import truncate_text_words
 from daras_ai.text_format import format_number_with_suffix
 from daras_ai_v2 import icons
@@ -15,6 +15,7 @@ from daras_ai_v2.breadcrumbs import get_title_breadcrumbs
 from daras_ai_v2.meta_preview_url import meta_preview_url
 from daras_ai_v2.utils import get_relative_time
 from widgets.author import render_author_from_workspace, render_author_from_user
+from widgets.demo_button import get_demo_bots
 
 if typing.TYPE_CHECKING:
     from daras_ai_v2.base import BasePage
@@ -74,7 +75,7 @@ def render_saved_workflow_preview(
     output_url = (
         page_cls.preview_image(published_run.saved_run.state) or published_run.photo_url
     )
-
+    demo_bots = get_demo_bots(published_run)
     with gui.div(className="position-relative py-2 pe-0"):
         with (
             gui.styled(WORKFLOW_PREVIEW_STYLE),
@@ -106,6 +107,18 @@ def render_saved_workflow_preview(
                                 if workflow_pill:
                                     gui.pill(
                                         workflow_pill,
+                                        unsafe_allow_html=True,
+                                        className="border border-dark ms-2",
+                                    )
+
+                                for bot in demo_bots:
+                                    platform_id = bot[1]
+                                    platform = Platform(platform_id)
+                                    label = (
+                                        f"{platform.get_icon()} {platform.get_title()}"
+                                    )
+                                    gui.pill(
+                                        label,
                                         unsafe_allow_html=True,
                                         className="border border-dark ms-2",
                                     )


### PR DESCRIPTION
### Q/A checklist

- [x] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [x] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [x] Do a self code review of the changes - Read the diff at least twice.  
- [x] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [x] The relevant pages still run when you press submit
- [x] The API for those pages still work (API tab)
- [x] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [x] Do your UI changes (if applicable) look acceptable on mobile?
- [x] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

