### PR TITLE
fix seo bug: don't change PR name on updating ASR

### DIFF
--- a/recipes/VideoBots.py
+++ b/recipes/VideoBots.py
@@ -316,13 +316,18 @@ Translation Glossary for LLM Language (English) -> User Langauge
     def get_run_title(cls, sr: SavedRun, pr: PublishedRun | None) -> str:
         import langcodes
 
+        title = super().get_run_title(sr, pr)
+        root_title = cls.get_recipe_title()
+        if title != root_title:
+            return title
+
         try:
             lang = langcodes.Language.get(
                 sr.state.get("user_language") or sr.state.get("asr_language") or ""
             ).display_name()
         except (KeyError, langcodes.LanguageTagError):
             lang = None
-        title = super().get_run_title(sr, pr)
+
         return " ".join(filter(None, [lang, title]))
 
     @classmethod

--- a/recipes/asr_page.py
+++ b/recipes/asr_page.py
@@ -95,6 +95,11 @@ class AsrPage(BasePage):
     def get_run_title(cls, sr: SavedRun, pr: PublishedRun | None) -> str:
         import langcodes
 
+        title = super().get_run_title(sr, pr)
+        root_title = cls.get_recipe_title()
+        if title != root_title:
+            return title
+
         try:
             lang = langcodes.Language.get(sr.state["language"] or "").display_name()
         except (KeyError, langcodes.LanguageTagError):
@@ -102,7 +107,7 @@ class AsrPage(BasePage):
         model = AsrModels.get(sr.state.get("selected_model"))
         lang_or_model = lang or (model and model.value)
 
-        return " ".join(filter(None, [lang_or_model, cls.get_recipe_title()]))
+        return " ".join(filter(None, [lang_or_model, root_title]))
 
     def render_description(self):
         gui.markdown(


### PR DESCRIPTION
### Q/A checklist

- [ ] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [ ] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [ ] Do a self code review of the changes - Read the diff at least twice.  
- [ ] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [ ] The relevant pages still run when you press submit
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
- [ ] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

