### PR TITLE
use bot branding from web integration when available

### DIFF
--- a/recipes/VideoBots.py
+++ b/recipes/VideoBots.py
@@ -797,6 +797,28 @@ PS. This is the workflow that we used to create RadBots - a collection of Turing
                 )
             )
 
+        # fill branding with bot integration data if available
+        bot_integration = BotIntegration.objects.filter(
+            published_run=self.current_pr,
+            platform=Platform.WEB,
+        ).first()
+        if bot_integration:
+            bot_branding = dict(
+                name=bot_integration.name,
+                photoUrl=bot_integration.photo_url,
+                title=bot_integration.name,
+                byLine=bot_integration.by_line,
+                conversationStarters=bot_integration.conversation_starters,
+                description=bot_integration.descripton,
+                websiteUrl=bot_integration.website_url,
+            )
+        else:
+            bot_branding = dict(
+                name=self.current_pr.title,
+                photoUrl=self.current_pr.photo_url,
+                title=self.current_pr.title,
+            )
+
         gui.html(
             # language=html
             f"""
@@ -847,9 +869,7 @@ if (typeof GooeyEmbed !== "undefined" && GooeyEmbed.controller) {
                 enablePhotoUpload=True,
                 enableConversations=False,
                 branding=dict(
-                    name=self.current_pr.title,
-                    photoUrl=self.current_pr.photo_url,
-                    title="Preview",
+                    **bot_branding,
                     showPoweredByGooey=False,
                 ),
                 fillParent=True,


### PR DESCRIPTION
### Q/A checklist

- [ ] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [ ] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [ ] Do a self code review of the changes - Read the diff at least twice.  
- [ ] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [ ] The relevant pages still run when you press submit
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
- [ ] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

