### PR TITLE
rollback using openai sdk for claude 4 models

### DIFF
--- a/daras_ai_v2/language_model.py
+++ b/daras_ai_v2/language_model.py
@@ -658,7 +658,7 @@ class LargeLanguageModels(Enum):
     claude_4_sonnet = LLMSpec(
         label="Claude 4 Sonnet (Anthropic)",
         model_id="claude-4-sonnet-20250514",
-        llm_api=LLMApis.openai,
+        llm_api=LLMApis.anthropic,
         context_window=200_000,
         max_output_tokens=64_000,
         price=15,
@@ -668,7 +668,7 @@ class LargeLanguageModels(Enum):
     claude_4_opus = LLMSpec(
         label="Claude 4 Opus (Anthropic)",
         model_id="claude-4-opus-20250514",
-        llm_api=LLMApis.openai,
+        llm_api=LLMApis.anthropic,
         context_window=200_000,
         max_output_tokens=64_000,
         price=15,
@@ -1758,12 +1758,6 @@ def get_openai_client(model: str):
             api_key=settings.SARVAM_API_KEY,
             max_retries=0,
             base_url="https://api.sarvam.ai/v1",
-        )
-    elif model.startswith("claude-4-"):
-        client = openai.OpenAI(
-            api_key=settings.ANTHROPIC_API_KEY,
-            max_retries=0,
-            base_url="https://api.anthropic.com/v1",
         )
     elif model.startswith("google/"):
         client = openai.OpenAI(

--- a/daras_ai_v2/text_splitter.py
+++ b/daras_ai_v2/text_splitter.py
@@ -43,7 +43,7 @@ threadlocal = threading.local()
 def default_length_function(text: str, model: str = "gpt-4") -> int:
     if any(
         model.startswith(prefix)
-        for prefix in ["o3-", "gpt-4.5-", "gpt-4.1-", "sarvam-", "claude-", "google/"]
+        for prefix in ["o3-", "gpt-4.5-", "gpt-4.1-", "sarvam-", "google/"]
     ):
         model = "gpt-4o"
     try:


### PR DESCRIPTION
### Q/A checklist

- [ ] If you add new dependencies, did you update the lock file?
```bash
poetry lock --no-update
```
- [ ] Run tests 
```bash
ulimit -n unlimited && ./scripts/run-tests.sh
```
- [ ] Do a self code review of the changes - Read the diff at least twice.  
- [ ] Carefully think about the stuff that might break because of this change - this sounds obvious but it's easy to forget to do "Go to references" on each function you're changing and see if it's used in a way you didn't expect. 
- [ ] The relevant pages still run when you press submit
- [ ] The API for those pages still work (API tab)
- [ ] The public API interface doesn't change if you didn't want it to (check API tab > docs page)
- [ ] Do your UI changes (if applicable) look acceptable on mobile?
- [ ] Ensure you have not regressed the import time unless you have a good reason to do so. 
You can visualize this using tuna:
```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```
To measure import time for a specific library:
```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```
To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:
```python
def my_function():
    import pandas as pd
    ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

