### PR TITLE
fix: inconsistent workflow->updated_at between list view & workflow page

### DIFF
--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -596,11 +596,11 @@ class BasePage:
         ):
             self._render_report_button()
             gui.write(get_relative_time(dt))
-            with gui.tooltip(
-                tooltip_content,
+            with (
+                gui.tooltip(tooltip_content),
+                gui.tag("span", className="text-muted d-inline-block"),
             ):
-                with gui.tag("span", className="text-muted d-inline-block"):
-                    gui.html("<i class='fa-regular fa-circle-info'></i>")
+                gui.html(icons.info)
 
     def _render_options_button_with_dialog(self):
         ref = gui.use_alert_dialog(key="options-modal")

--- a/daras_ai_v2/icons.py
+++ b/daras_ai_v2/icons.py
@@ -46,6 +46,7 @@ sparkles = '<i class="fa-solid fa-sparkles"></i>'
 phone = '<i class="fa-solid fa-phone"></i>'
 stars = '<i class="fa-solid fa-stars"></i>'
 filter = '<i class="fa-solid fa-bars-filter"></i>'
+info = "<i class='fa-regular fa-circle-info'></i>"
 
 # brands
 github = '<i class="fa-brands fa-github"></i>'

--- a/widgets/saved_workflow.py
+++ b/widgets/saved_workflow.py
@@ -205,15 +205,14 @@ def render_footer_breadcrumbs(
             ):
                 gui.html(f"{icons.notes} {html.escape(latest_version.change_notes)}")
 
-        updated_at = published_run.saved_run.updated_at
         if (
-            updated_at
-            and isinstance(updated_at, datetime.datetime)
+            published_run.updated_at
+            and isinstance(published_run.updated_at, datetime.datetime)
             and not hide_last_editor
         ):
             with gui.div():
                 gui.write(
-                    f"{icons.time} {get_relative_time(updated_at)}",
+                    f"{icons.time} {get_relative_time(published_run.updated_at)}",
                     unsafe_allow_html=True,
                     className="text-muted",
                 )


### PR DESCRIPTION
### Q/A checklist

- [x] I have tested my UI changes on mobile and they look acceptable
- [x] I have tested changes to the workflows in both the API and the UI
- [x] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [x] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
