### PR TITLE
feat: better version-restore logic by preferring to fetch pr from URL

### DIFF
--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -1481,14 +1481,21 @@ class BasePage:
         cls, example_id: str, run_id: str, uid: str
     ) -> tuple[SavedRun, PublishedRun]:
         if run_id and uid:
-            sr = cls.get_sr_from_ids(run_id, uid)
-            pr = sr.parent_published_run() or cls.get_root_pr()
+            sr = cls.get_sr_from_ids(run_id=run_id, uid=uid)
+            pr = (
+                example_id
+                and cls.get_pr_from_example_id(example_id)
+                or sr.parent_published_run()
+                or cls.get_root_pr()
+            )
         else:
-            if example_id:
-                pr = cls.get_pr_from_example_id(example_id=example_id)
-            else:
-                pr = cls.get_root_pr()
+            pr = (
+                example_id
+                and cls.get_pr_from_example_id(example_id)
+                or cls.get_root_pr()
+            )
             sr = pr.saved_run
+
         return sr, pr
 
     @classmethod

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -124,7 +124,7 @@ class StateKeys:
 class BasePageRequest:
     user: AppUser | None
     session: dict
-    query_params: dict
+    query_params: dict[str, str]
     url: URL | None
 
 
@@ -176,7 +176,7 @@ class BasePage:
         user: AppUser | None = None,
         request_session: dict | None = None,
         request_url: URL | None = None,
-        query_params: dict | None = None,
+        query_params: dict[str, str] | None = None,
     ):
         if request_session is None:
             request_session = {}
@@ -201,8 +201,8 @@ class BasePage:
         self,
         tab: RecipeTabs = RecipeTabs.run,
         *,
-        query_params: dict = None,
-        path_params: dict = None,
+        query_params: dict[str, str] | None = None,
+        path_params: dict | None = None,
     ) -> str:
         if query_params is None:
             query_params = {}
@@ -220,12 +220,12 @@ class BasePage:
     def app_url(
         cls,
         *,
-        tab: RecipeTabs = None,
-        example_id: str = None,
-        run_id: str = None,
-        uid: str = None,
-        query_params: dict = None,
-        path_params: dict = None,
+        tab: RecipeTabs | None = None,
+        example_id: str | None = None,
+        run_id: str | None = None,
+        uid: str | None = None,
+        query_params: dict[str, str] | None = None,
+        path_params: dict | None = None,
     ) -> str:
         if not tab:
             tab = RecipeTabs.run
@@ -1507,7 +1507,7 @@ class BasePage:
             return SavedRun.objects.get(**config)
 
     @classmethod
-    def get_pr_from_example_id(cls, *, example_id: str):
+    def get_pr_from_example_id(cls, example_id: str):
         return PublishedRun.objects.select_related("saved_run", "workspace").get(
             workflow=cls.workflow, published_run_id=example_id
         )

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -1480,20 +1480,16 @@ class BasePage:
     def get_sr_pr_from_query_params(
         cls, example_id: str, run_id: str, uid: str
     ) -> tuple[SavedRun, PublishedRun]:
+        if example_id:
+            example_pr = cls.get_pr_from_example_id(example_id)
+        else:
+            example_pr = None
+
         if run_id and uid:
             sr = cls.get_sr_from_ids(run_id=run_id, uid=uid)
-            pr = (
-                example_id
-                and cls.get_pr_from_example_id(example_id)
-                or sr.parent_published_run()
-                or cls.get_root_pr()
-            )
+            pr = example_pr or sr.parent_published_run() or cls.get_root_pr()
         else:
-            pr = (
-                example_id
-                and cls.get_pr_from_example_id(example_id)
-                or cls.get_root_pr()
-            )
+            pr = example_pr or cls.get_root_pr()
             sr = pr.saved_run
 
         return sr, pr

--- a/daras_ai_v2/query_params_util.py
+++ b/daras_ai_v2/query_params_util.py
@@ -1,18 +1,16 @@
+import typing
+
+
 EXAMPLE_ID_QUERY_PARAM = "example_id"
 RUN_ID_QUERY_PARAM = "run_id"
 USER_ID_QUERY_PARAM = "uid"
 
 
-def extract_query_params(query_params, default=None):
+def extract_query_params(
+    query_params: typing.Mapping[str, str], default: str = ""
+) -> tuple[str, str, str]:
     example_id = query_params.get(EXAMPLE_ID_QUERY_PARAM, default)
     run_id = query_params.get(RUN_ID_QUERY_PARAM, default)
     uid = query_params.get(USER_ID_QUERY_PARAM, default)
-
-    if isinstance(example_id, list):
-        example_id = example_id[0]
-    if isinstance(run_id, list):
-        run_id = run_id[0]
-    if isinstance(uid, list):
-        uid = uid[0]
 
     return example_id, run_id, uid

--- a/daras_ai_v2/workflow_url_input.py
+++ b/daras_ai_v2/workflow_url_input.py
@@ -134,7 +134,9 @@ def url_to_runs(
     page_cls = page_slug_map[normalize_slug(match.matched_params["page_slug"])]
     example_id, run_id, uid = extract_query_params(furl(url).query.params)
     sr, pr = page_cls.get_sr_pr_from_query_params(
-        example_id or match.matched_params.get("example_id"), run_id, uid
+        example_id=example_id or match.matched_params.get("example_id") or "",
+        run_id=run_id,
+        uid=uid,
     )
     return page_cls, sr, pr
 

--- a/routers/root.py
+++ b/routers/root.py
@@ -680,7 +680,7 @@ def render_recipe_page(
         request_session=request.session,
         request_url=request.url,
         # this is because the code still expects example_id to be in the query params
-        query_params=dict(request.query_params) | dict(example_id=example_id),
+        query_params=dict(request.query_params) | dict(example_id=example_id or ""),
     )
 
     if not gui.session_state:


### PR DESCRIPTION
Currently, clicking on a version from a published-run page takes you to the individual saved-run page. The URL is like `https://gooey.ai/copilot/published-run-slug-pr_id_123/?run_id=...&uid=...`, so we can fetch the active published-run from the URL if it is there. This way, the flow of `{icon.save} Update` -> `{icon.save} Save` can be used to update the same published run.

It is not entirely consistent because versions can also contain updates to visibility settings or title/description. These changes are not rolled back with only the saved run. This can be fixed by changing the links and adding a param for the version ID, e.g. a URL such as `https://gooey.ai/copilot/published-run-slug-pr_id_123/version_id_123_here`.

---

- **refactor: stricter typing for extract_query_params**
- **feat: change sr-pr fetching logic to always prefer return pr from URL**

### Q/A checklist

- [x] I have tested my UI changes on mobile and they look acceptable
- [x] I have tested changes to the workflows in both the API and the UI
- [x] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [x] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
