### PR TITLE
improve: add "(copy)" to title by default when "Save as New" is pressed

### DIFF
--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -38,9 +38,7 @@ from bots.models import (
 from daras_ai.image_input import truncate_text_words
 from daras_ai_v2 import icons, settings
 from daras_ai_v2.api_examples_widget import api_example_generator
-from daras_ai_v2.breadcrumbs import (
-    get_title_breadcrumbs,
-)
+from daras_ai_v2.breadcrumbs import get_title_breadcrumbs
 from widgets.base_header import render_breadcrumbs_with_author, render_header_title
 from daras_ai_v2.copy_to_clipboard_button_widget import copy_to_clipboard_button
 from daras_ai_v2.crypto import get_random_doc_id
@@ -807,8 +805,11 @@ class BasePage:
             # neither action was taken - nothing to do now
             return
 
-        is_root_published_run = user_can_edit and pr.is_root()
-        if not is_root_published_run:
+        if pressed_save_as_new and published_run_title == pr.title:
+            published_run_title = f"{published_run_title} (Copy)"
+
+        editing_root_published_run = pressed_save and user_can_edit and pr.is_root()
+        if not editing_root_published_run:
             try:
                 self._validate_published_run_title(published_run_title)
             except TitleValidationError as e:


### PR DESCRIPTION
### Q/A checklist

- [x] I have tested my UI changes on mobile and they look acceptable
- [x] I have tested changes to the workflows in both the API and the UI
- [x] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [x] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
