### PR TITLE
fix: filter dropdowns overflow in width

### DIFF
--- a/widgets/workflow_search.py
+++ b/widgets/workflow_search.py
@@ -87,15 +87,17 @@ def render_search_filters(
         else:
             col_class = "col-7"
 
-        with gui.div(className=f"{col_class} d-flex align-items-center gap-2"):
+        with gui.div(className=f"{col_class} d-flex align-items-center"):
             with gui.div(
-                className="col-6" if show_workspace_filter else "col-12 col-md-6"
+                className="col-6 pe-1"
+                if show_workspace_filter
+                else "col-12 col-md-6 pe-md-1"
             ):
                 search_filters.workflow = (
                     render_workflow_filter(value=search_filters.workflow) or ""
                 )
             if show_workspace_filter:
-                with gui.div(className="col-6"):
+                with gui.div(className="col-6 ps-1"):
                     search_filters.workspace = (
                         render_workspace_filter(
                             current_user=current_user,


### PR DESCRIPTION
#### Before
<img width="998" height="637" alt="image" src="https://github.com/user-attachments/assets/1c2fc765-93c7-4443-b20d-a5ff5952cdbe" />

#### After
<img width="998" height="637" alt="image" src="https://github.com/user-attachments/assets/b2492fab-d50b-45f9-9e5b-fd3a185854b4" />


### Q/A checklist

- [x] I have tested my UI changes on mobile and they look acceptable
- [x] I have tested changes to the workflows in both the API and the UI
- [x] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [x] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
