### PR TITLE
fix: remove ui state when header icons are hidden after resizing

### DIFF
--- a/routers/root.py
+++ b/routers/root.py
@@ -787,10 +787,13 @@ def _render_mobile_search_button(request: Request, search_filters: SearchFilters
             onClick=JS_SHOW_MOBILE_SEARCH,
         )
 
-    with gui.div(
-        className="d-md-flex flex-grow-1 justify-content-center align-items-center bg-white top-0 left-0",
-        style={"display": "none", "zIndex": "10"},
-        id="mobile_search_container",
+    with (
+        gui.styled("@media (min-width: 768px) { & { position: static !important; } }"),
+        gui.div(
+            className="d-md-flex flex-grow-1 justify-content-center align-items-center bg-white top-0 left-0",
+            style={"display": "none", "zIndex": "10"},
+            id="mobile_search_container",
+        ),
     ):
         render_search_bar_with_redirect(
             request=request,


### PR DESCRIPTION
### Repro steps:
1. in mobile view, go to workflow page e.g. copilot root
2. press "{magnifying-glass}" search icon
3. now resize to more than 768px width 

### Before
<img width="998" height="876" alt="image" src="https://github.com/user-attachments/assets/1ba2ef78-e627-4815-98a8-19bec8c3cf4d" />

### After
<img width="1035" height="876" alt="image" src="https://github.com/user-attachments/assets/14a4be1d-f77a-41dc-9e4c-58618a3518bf" />


### Q/A checklist

- [ ] I have tested my UI changes on mobile and they look acceptable
- [ ] I have tested changes to the workflows in both the API and the UI
- [ ] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [ ] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
