### PR TITLE
feat: support verbosity setting for OpenAI LLMs

### DIFF
--- a/daras_ai_v2/language_model_settings_widgets.py
+++ b/daras_ai_v2/language_model_settings_widgets.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic import BaseModel, Field
 
 import gooey_gui as gui
@@ -16,6 +18,7 @@ class LanguageModelSettings(BaseModel):
         None,
         title="Response Format",
     )
+    verbosity: Literal["low", "medium", "high"] | None = Field(None, title="Verbosity")
 
 
 def language_model_selector(
@@ -115,4 +118,14 @@ Generate multiple responses and choose the best one
                 min_value=1.0,
                 max_value=5.0,
                 step=0.1,
+            )
+
+    col1, col2 = gui.columns(2)
+    if any(llm.llm_api == LLMApis.openai for llm in llms):
+        with col1:
+            gui.selectbox(
+                f"###### {field_title_desc(LanguageModelSettings, 'verbosity')}",
+                options=[None, "low", "medium", "high"],
+                key="verbosity",
+                format_func=lambda s: s and s.capitalize() or BLANK_OPTION,
             )


### PR DESCRIPTION
### Q/A checklist

- [ ] I have tested my UI changes on mobile and they look acceptable
- [ ] I have tested changes to the workflows in both the API and the UI
- [ ] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [ ] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
