### PR TITLE
fix temperature calculation for openai audio & small refactors

### DIFF
--- a/daras_ai_v2/language_model.py
+++ b/daras_ai_v2/language_model.py
@@ -122,8 +122,8 @@ class LargeLanguageModels(Enum):
         label="GPT-5 Chat • openai",
         model_id="gpt-5-chat-latest",
         llm_api=LLMApis.openai,
-        context_window=400_000,
-        max_output_tokens=128_000,
+        context_window=128_000,
+        max_output_tokens=16_384,
         is_vision_model=True,
         supports_json=True,
         supports_temperature=False,
@@ -1532,6 +1532,7 @@ def run_openai_chat(
         LargeLanguageModels.gpt_5,
         LargeLanguageModels.gpt_5_mini,
         LargeLanguageModels.gpt_5_nano,
+        LargeLanguageModels.gpt_5_chat,
     ]:
         # fuck you, openai
         for entry in messages_for_completion:
@@ -1547,7 +1548,8 @@ def run_openai_chat(
 
         # reserved tokens for reasoning...
         # https://platform.openai.com/docs/guides/reasoning#allocating-space-for-reasoning
-        max_completion_tokens = max(25_000, max_completion_tokens)
+        if model.max_output_tokens and model.max_output_tokens > 25_000:
+            max_completion_tokens = max(25_000, max_completion_tokens)
     elif model in [
         LargeLanguageModels.claude_4_sonnet,
         LargeLanguageModels.claude_4_opus,

--- a/daras_ai_v2/language_model.py
+++ b/daras_ai_v2/language_model.py
@@ -56,7 +56,6 @@ class LLMApis(Enum):
     palm2 = 1
     gemini = 2
     openai = 3
-    # together = 4
     fireworks = 4
     groq = 5
     anthropic = 6

--- a/daras_ai_v2/language_model.py
+++ b/daras_ai_v2/language_model.py
@@ -93,6 +93,7 @@ class LargeLanguageModels(Enum):
         max_output_tokens=128_000,
         is_vision_model=True,
         supports_json=True,
+        supports_temperature=False,
     )
     # https://platform.openai.com/docs/models/gpt-5-mini
     gpt_5_mini = LLMSpec(
@@ -103,6 +104,7 @@ class LargeLanguageModels(Enum):
         max_output_tokens=128_000,
         is_vision_model=True,
         supports_json=True,
+        supports_temperature=False,
     )
     # https://platform.openai.com/docs/models/gpt-5-nano
     gpt_5_nano = LLMSpec(
@@ -113,6 +115,7 @@ class LargeLanguageModels(Enum):
         max_output_tokens=128_000,
         is_vision_model=True,
         supports_json=True,
+        supports_temperature=False,
     )
     # https://platform.openai.com/docs/models/gpt-5-chat-latest
     gpt_5_chat = LLMSpec(
@@ -123,6 +126,7 @@ class LargeLanguageModels(Enum):
         max_output_tokens=128_000,
         is_vision_model=True,
         supports_json=True,
+        supports_temperature=False,
     )
 
     # https://platform.openai.com/docs/models/gpt-4-1
@@ -1515,7 +1519,7 @@ def run_openai_chat(
     response_format_type: ResponseFormatType | None = None,
     stream: bool = False,
 ) -> list[ConversationEntry] | typing.Generator[list[ConversationEntry], None, None]:
-    from openai._types import NOT_GIVEN
+    from openai import NOT_GIVEN
 
     messages_for_completion = deepcopy(messages)
 
@@ -1564,13 +1568,7 @@ def run_openai_chat(
         frequency_penalty = 0
         presence_penalty = 0
 
-    # fuck you, openai
-    if temperature is None or model in [
-        LargeLanguageModels.gpt_5,
-        LargeLanguageModels.gpt_5_mini,
-        LargeLanguageModels.gpt_5_nano,
-        LargeLanguageModels.gpt_5_chat,
-    ]:
+    if temperature is None or not model.supports_temperature:
         temperature = NOT_GIVEN
 
     if tools:

--- a/daras_ai_v2/language_model_openai_audio.py
+++ b/daras_ai_v2/language_model_openai_audio.py
@@ -38,7 +38,8 @@ def run_openai_audio(
 ):
     openai_ws, created = get_or_create_ws(model)
 
-    temperature = max(min(temperature, 0.6), 1.2)
+    if temperature:
+        temperature = min(max(temperature, 0.6), 1.2)
 
     twilio_ws = None
     audio_data = None


### PR DESCRIPTION
- **refactor: use supports_temperature=False for gpt-5 models**
- **fix: set correct max_output_tokens & context window for gpt-5-chat**
- **fix: temperature calculation for openai audio: bound to interval [0.6,1.2]**
- **refactor: remove commented LLMApis.together**

### Q/A checklist

- [ ] I have tested my UI changes on mobile and they look acceptable
- [ ] I have tested changes to the workflows in both the API and the UI
- [ ] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [ ] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
