### PR TITLE
revert unauth pages meta change

### DIFF
--- a/daras_ai_v2/meta_content.py
+++ b/daras_ai_v2/meta_content.py
@@ -215,27 +215,31 @@ def robots_tag_for_page(
     is_root = pr and pr.saved_run == sr and pr.is_root()
     is_example = pr and pr.saved_run == sr and not pr.is_root()
 
-    match page.tab:
-        case RecipeTabs.run if is_root or is_example:
-            no_follow, no_index = False, False
-        case RecipeTabs.preview if is_root or is_example:
-            no_follow, no_index = False, False
-        case RecipeTabs.run:  # ordinary run (not example)
-            no_follow, no_index = False, True
-        case RecipeTabs.preview:
-            no_follow, no_index = False, True
-        case RecipeTabs.examples:
-            no_follow, no_index = False, False
-        case RecipeTabs.run_as_api:
-            no_follow, no_index = False, True
-        case RecipeTabs.integrations:
-            no_follow, no_index = True, True
-        case RecipeTabs.history:
-            no_follow, no_index = True, True
-        case RecipeTabs.saved:
-            no_follow, no_index = True, True
-        case _:
-            raise ValueError(f"Unknown tab: {page.tab}")
+    if not page.is_user_authorized(None):
+        # nofollow & noindex if page is not open for anonymous users
+        no_follow, no_index = True, True
+    else:
+        match page.tab:
+            case RecipeTabs.run if is_root or is_example:
+                no_follow, no_index = False, False
+            case RecipeTabs.preview if is_root or is_example:
+                no_follow, no_index = False, False
+            case RecipeTabs.run:  # ordinary run (not example)
+                no_follow, no_index = False, True
+            case RecipeTabs.preview:
+                no_follow, no_index = False, True
+            case RecipeTabs.examples:
+                no_follow, no_index = False, False
+            case RecipeTabs.run_as_api:
+                no_follow, no_index = False, True
+            case RecipeTabs.integrations:
+                no_follow, no_index = True, True
+            case RecipeTabs.history:
+                no_follow, no_index = True, True
+            case RecipeTabs.saved:
+                no_follow, no_index = True, True
+            case _:
+                raise ValueError(f"Unknown tab: {page.tab}")
 
     parts = []
     if no_follow:


### PR DESCRIPTION
### Q/A checklist

- [x] I have tested my UI changes on mobile and they look acceptable
- [x] I have tested changes to the workflows in both the API and the UI
- [x] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [x] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
