### PR TITLE
feat: add support for reasoning_effort for OpenAI and Gemini thinking models

### DIFF
--- a/daras_ai_v2/language_model.py
+++ b/daras_ai_v2/language_model.py
@@ -22,11 +22,7 @@ from openai.types.chat import (
     ChatCompletionMessageToolCallParam,
 )
 
-from daras_ai.image_input import (
-    gs_url_to_uri,
-    bytes_to_cv2_img,
-    cv2_img_to_bytes,
-)
+from daras_ai.image_input import gs_url_to_uri, bytes_to_cv2_img, cv2_img_to_bytes
 from daras_ai_v2.asr import get_google_auth_session
 from daras_ai_v2.exceptions import raise_for_status, UserError
 from daras_ai_v2.gpu_server import call_celery_task
@@ -74,6 +70,7 @@ class LLMSpec(typing.NamedTuple):
     price: int = 1
     is_chat_model: bool = True
     is_vision_model: bool = False
+    is_thinking_model: bool = False
     supports_json: bool = False
     supports_temperature: bool = True
     is_audio_model: bool = False
@@ -91,6 +88,7 @@ class LargeLanguageModels(Enum):
         context_window=400_000,
         max_output_tokens=128_000,
         is_vision_model=True,
+        is_thinking_model=True,
         supports_json=True,
     )
     # https://platform.openai.com/docs/models/gpt-5-mini
@@ -101,6 +99,7 @@ class LargeLanguageModels(Enum):
         context_window=400_000,
         max_output_tokens=128_000,
         is_vision_model=True,
+        is_thinking_model=True,
         supports_json=True,
     )
     # https://platform.openai.com/docs/models/gpt-5-nano
@@ -111,6 +110,7 @@ class LargeLanguageModels(Enum):
         context_window=400_000,
         max_output_tokens=128_000,
         is_vision_model=True,
+        is_thinking_model=True,
         supports_json=True,
     )
     # https://platform.openai.com/docs/models/gpt-5-chat-latest
@@ -118,9 +118,10 @@ class LargeLanguageModels(Enum):
         label="GPT-5 Chat • openai",
         model_id="gpt-5-chat-latest",
         llm_api=LLMApis.openai,
-        context_window=400_000,
-        max_output_tokens=128_000,
+        context_window=128_000,
+        max_output_tokens=16_384,
         is_vision_model=True,
+        is_thinking_model=True,
         supports_json=True,
     )
 
@@ -174,6 +175,7 @@ class LargeLanguageModels(Enum):
         context_window=200_000,
         max_output_tokens=100_000,
         is_vision_model=True,
+        is_thinking_model=True,
         supports_json=True,
         supports_temperature=False,
     )
@@ -186,6 +188,7 @@ class LargeLanguageModels(Enum):
         context_window=200_000,
         max_output_tokens=100_000,
         is_vision_model=True,
+        is_thinking_model=True,
         supports_json=True,
         supports_temperature=False,
     )
@@ -199,6 +202,7 @@ class LargeLanguageModels(Enum):
         max_output_tokens=100_000,
         price=13,
         is_vision_model=False,
+        is_thinking_model=True,
         supports_json=True,
         supports_temperature=False,
     )
@@ -212,6 +216,7 @@ class LargeLanguageModels(Enum):
         max_output_tokens=100_000,
         price=50,
         is_vision_model=True,
+        is_thinking_model=True,
         supports_json=True,
         supports_temperature=False,
     )
@@ -225,6 +230,7 @@ class LargeLanguageModels(Enum):
         max_output_tokens=32_768,
         price=50,
         is_vision_model=False,
+        is_thinking_model=True,
         supports_json=False,
         supports_temperature=False,
         is_deprecated=True,
@@ -240,6 +246,7 @@ class LargeLanguageModels(Enum):
         max_output_tokens=65_536,
         price=13,
         is_vision_model=False,
+        is_thinking_model=True,
         supports_json=False,
         supports_temperature=False,
     )
@@ -598,6 +605,7 @@ class LargeLanguageModels(Enum):
         max_output_tokens=65_535,
         price=1,
         is_vision_model=True,
+        is_thinking_model=True,
         supports_json=True,
     )
     gemini_2_5_flash = LLMSpec(
@@ -608,6 +616,7 @@ class LargeLanguageModels(Enum):
         max_output_tokens=65_535,
         price=1,
         is_vision_model=True,
+        is_thinking_model=True,
         supports_json=True,
     )
     gemini_2_5_pro_preview = LLMSpec(
@@ -620,6 +629,7 @@ class LargeLanguageModels(Enum):
         is_vision_model=True,
         supports_json=True,
         is_deprecated=True,
+        is_thinking_model=True,
         redirect_to="gemini_2_5_pro",
     )
     gemini_2_5_flash_preview = LLMSpec(
@@ -632,6 +642,7 @@ class LargeLanguageModels(Enum):
         is_vision_model=True,
         supports_json=True,
         is_deprecated=True,
+        is_thinking_model=True,
         redirect_to="gemini_2_5_flash",
     )
     gemini_2_flash_lite = LLMSpec(
@@ -947,6 +958,7 @@ class LargeLanguageModels(Enum):
         self.is_deprecated = spec.is_deprecated
         self.is_chat_model = spec.is_chat_model
         self.is_vision_model = spec.is_vision_model
+        self.is_thinking_model = spec.is_thinking_model
         self.supports_json = spec.supports_json
         self.supports_temperature = spec.supports_temperature
         self.is_audio_model = spec.is_audio_model
@@ -1528,15 +1540,16 @@ def run_openai_chat(
     messages_for_completion = deepcopy(messages)
 
     if model in [
-        LargeLanguageModels.o1_mini,
-        LargeLanguageModels.o1,
-        LargeLanguageModels.o3_mini,
-        LargeLanguageModels.o3,
-        LargeLanguageModels.o4_mini,
-        LargeLanguageModels.gpt_5,
-        LargeLanguageModels.gpt_5_mini,
-        LargeLanguageModels.gpt_5_nano,
+        LargeLanguageModels.gemini_2_5_pro,
+        LargeLanguageModels.gemini_2_5_flash,
+        LargeLanguageModels.claude_4_sonnet,
+        LargeLanguageModels.claude_4_opus,
+        LargeLanguageModels.claude_4_1_opus,
     ]:
+        # we want the lower bound for reasoning, but not the rest of openai's new changes
+        max_tokens = max(25_000, max_completion_tokens)
+        max_completion_tokens = NOT_GIVEN
+    elif model.is_thinking_model and model.llm_api == LLMApis.openai:
         # fuck you, openai
         for entry in messages_for_completion:
             if entry["role"] == CHATML_ROLE_SYSTEM:
@@ -1551,17 +1564,10 @@ def run_openai_chat(
 
         # reserved tokens for reasoning...
         # https://platform.openai.com/docs/guides/reasoning#allocating-space-for-reasoning
-        max_completion_tokens = max(25_000, max_completion_tokens)
-    elif model in [
-        LargeLanguageModels.claude_4_sonnet,
-        LargeLanguageModels.claude_4_opus,
-        LargeLanguageModels.claude_4_1_opus,
-        LargeLanguageModels.gemini_2_5_pro,
-        LargeLanguageModels.gemini_2_5_flash,
-    ]:
-        # we want the lower bound for reasoning, but not the rest of openai's new changes
-        max_tokens = max(25_000, max_completion_tokens)
-        max_completion_tokens = NOT_GIVEN
+        if model.max_output_tokens:
+            max_completion_tokens = min(
+                max(25_000, max_completion_tokens), model.max_output_tokens
+            )
     else:
         max_tokens = max_completion_tokens
         max_completion_tokens = NOT_GIVEN

--- a/daras_ai_v2/language_model_settings_widgets.py
+++ b/daras_ai_v2/language_model_settings_widgets.py
@@ -1,3 +1,5 @@
+import typing
+
 from pydantic import BaseModel, Field
 
 import gooey_gui as gui
@@ -12,9 +14,11 @@ class LanguageModelSettings(BaseModel):
     quality: float | None = None
     max_tokens: int | None = None
     sampling_temperature: float | None = None
+    reasoning_effort: typing.Literal["minimal", "low", "medium", "high"] | None = Field(
+        None, title="Reasoning Effort"
+    )
     response_format_type: ResponseFormatType | None = Field(
-        None,
-        title="Response Format",
+        None, title="Response Format"
     )
 
 
@@ -115,4 +119,14 @@ Generate multiple responses and choose the best one
                 min_value=1.0,
                 max_value=5.0,
                 step=0.1,
+            )
+
+    if any(llm.is_thinking_model and llm.llm_api == LLMApis.openai for llm in llms):
+        col1, _ = gui.columns(2)
+        with col1:
+            gui.selectbox(
+                label=f"###### {field_title_desc(LanguageModelSettings, 'reasoning_effort')}",
+                options=[None, "minimal", "low", "medium", "high"],
+                key="reasoning_effort",
+                format_func=lambda x: x.capitalize() if x else BLANK_OPTION,
             )


### PR DESCRIPTION
### Q/A checklist

- [ ] I have tested my UI changes on mobile and they look acceptable
- [ ] I have tested changes to the workflows in both the API and the UI
- [ ] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [ ] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
