### PR TITLE
infra: add cleanup script for vespa & embedded files

### DIFF
--- a/daras_ai_v2/vector_search.py
+++ b/daras_ai_v2/vector_search.py
@@ -242,7 +242,7 @@ def get_top_k_references(
 
 def vespa_search_results_to_refs(
     search_result: dict,
-) -> typing.Iterable[SearchReference]:
+) -> typing.Iterable[tuple[str, SearchReference]]:
     for hit in search_result["root"].get("children", []):
         try:
             ref = EmbeddingsReference.objects.get(vespa_doc_id=hit["fields"]["id"])
@@ -250,7 +250,6 @@ def vespa_search_results_to_refs(
         except EmbeddingsReference.DoesNotExist:
             continue
         if "text/html" in ref.embedded_file.metadata.mime_type:
-            # logger.debug(f"Generating fragments {ref['url']} as it is a HTML file")
             ref.url = generate_text_fragment_url(url=ref.url, text=ref.snippet)
         yield (
             ref_key,

--- a/scripts/cleanup_vespa_db.py
+++ b/scripts/cleanup_vespa_db.py
@@ -37,13 +37,12 @@ def cleanup_stale_cache():
 
             def vespa_callback(response: "VespaResponse", id: str):
                 nonlocal total_deleted
-                if response.is_successful:
+                if response.is_successful():
                     total_deleted += 1
                 else:
                     print(
-                        f"Failed to delete document {id} from Vespa: {response.status_code} - {response.get_json()}"
+                        f"Failed to delete document {id} from Vespa: {getattr(response,'status_code', 'NA')} - {response.get_json()}"
                     )
-
             vespa.feed_iterable(
                 docs_to_delete,
                 schema=settings.VESPA_SCHEMA,

--- a/scripts/cleanup_vespa_db.py
+++ b/scripts/cleanup_vespa_db.py
@@ -42,9 +42,11 @@ def cleanup_stale_cache():
             if response.is_successful():
                 total_deleted += 1
             else:
-                print(
-                    f"Failed to delete document {id} from Vespa: {getattr(response, 'status_code', 'NA')} - {response.get_json()}"
-                )
+                print(f"""\
+                    Failed to delete document {id} from Vespa.
+                    Status code: {response.get_status_code()}
+                    JSON: {response.get_json()}
+                    """)
 
         vespa.feed_iterable(
             docs_to_delete,

--- a/scripts/cleanup_vespa_db.py
+++ b/scripts/cleanup_vespa_db.py
@@ -19,14 +19,14 @@ def cleanup_stale_cache():
     vespa = get_vespa_app()
 
     while True:
-        stale_files = EmbeddedFile.objects.prefetch_related(
+        stale_qs = EmbeddedFile.objects.prefetch_related(
             "embeddings_references"
         ).filter(
             updated_at__lt=timezone.now() - timedelta(days=STALENESS_THRESHOLD_DAYS)
-        )[:BATCH_SIZE]
+        ).order_by("updated_at")[:BATCH_SIZE]
+        stale_files = list(stale_qs)
         if not stale_files:
             break
-
         docs_to_delete = (
             {"id": ref.vespa_doc_id}
             for ef in stale_files

--- a/scripts/cleanup_vespa_db.py
+++ b/scripts/cleanup_vespa_db.py
@@ -1,0 +1,62 @@
+import typing
+from datetime import timedelta
+
+from django.utils import timezone
+
+from daras_ai_v2 import settings
+from daras_ai_v2.vector_search import get_vespa_app
+from embeddings.models import EmbeddedFile
+
+if typing.TYPE_CHECKING:
+    from vespa.io import VespaResponse
+
+
+STALENESS_THRESHOLD_DAYS = 90
+BATCH_SIZE = 1_000
+
+
+def cleanup_stale_cache():
+    vespa = get_vespa_app()
+
+    while True:
+        stale_files = EmbeddedFile.objects.prefetch_related(
+            "embeddings_references"
+        ).filter(
+            updated_at__lt=timezone.now() - timedelta(days=STALENESS_THRESHOLD_DAYS)
+        )[:BATCH_SIZE]
+        if not stale_files:
+            break
+
+        docs_to_delete = (
+            {"id": ref.vespa_doc_id}
+            for ef in stale_files
+            for ref in ef.embeddings_references.all()
+        )
+        if docs_to_delete:
+            total_deleted = 0
+
+            def vespa_callback(response: "VespaResponse", id: str):
+                nonlocal total_deleted
+                if response.is_successful:
+                    total_deleted += 1
+                else:
+                    print(
+                        f"Failed to delete document {id} from Vespa: {response.status_code} - {response.get_json()}"
+                    )
+
+            vespa.feed_iterable(
+                docs_to_delete,
+                schema=settings.VESPA_SCHEMA,
+                operation_type="delete",
+                callback=vespa_callback,
+            )
+            print(f"Deleted {total_deleted} documents from Vespa.")
+
+        deleted_per_model = EmbeddedFile.objects.filter(
+            id__in=[ef.id for ef in stale_files]
+        ).delete()
+        print(f"Deleted EmbeddedFiles & related objects: {deleted_per_model}")
+
+
+def run():
+    cleanup_stale_cache()


### PR DESCRIPTION
- **refactor: fix return type of 'vespa_search_results_to_refs'**
- **infra: add cleanup script for vespa & embedding documents**

### Q/A checklist

- [ ] I have tested my UI changes on mobile and they look acceptable
- [ ] I have tested changes to the workflows in both the API and the UI
- [ ] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [ ] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
