### PR TITLE
fix: sunbird: use tokens for languages instead of langcodes

### DIFF
--- a/daras_ai_v2/asr.py
+++ b/daras_ai_v2/asr.py
@@ -244,9 +244,10 @@ MMS_SUPPORTED = {
 }  # fmt: skip
 
 SUNBIRD_SUPPORTED_LANGUAGES = {
-    "eng", "swa", "ach", "lgg", "lug", "nyn",
-    "teo", "xog", "ttj", "kin", "myx",
+    "ach": "<|su|>", "eng": "<|en|>", "kin": "<|as|>", "lgg": "<|jw|>", "lug": "<|ba|>", "myx": "<|mg|>",
+    "nyn": "<|ha|>", "swa": "<|sw|>", "teo": "<|ln|>", "ttj": "<|tt|>", "xog": "<|haw|>"
 }  # fmt: skip
+
 
 # https://translation.ghananlp.org/api-details#api=ghananlp-translation-webservice-api
 GHANA_NLP_SUPPORTED = {'en': 'English', 'tw': 'Twi', 'gaa': 'Ga', 'ee': 'Ewe', 'fat': 'Fante', 'dag': 'Dagbani',
@@ -1301,6 +1302,8 @@ def run_asr(
             # don't pass language or task
             kwargs.pop("task", None)
             kwargs["max_length"] = 448
+        elif selected_model == AsrModels.whisper_sunbird_large_v3:
+            kwargs["language"] = SUNBIRD_SUPPORTED_LANGUAGES[language.strip()]
         elif "whisper" in selected_model.name:
             forced_lang = forced_asr_languages.get(selected_model)
             if forced_lang:


### PR DESCRIPTION
### Q/A checklist

- [ ] I have tested my UI changes on mobile and they look acceptable
- [ ] I have tested changes to the workflows in both the API and the UI
- [ ] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [ ] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
