### PR TITLE
fix: sea-lion v4 does not support tools

### DIFF
--- a/daras_ai_v2/language_model.py
+++ b/daras_ai_v2/language_model.py
@@ -1662,12 +1662,11 @@ def run_openai_chat(
         # openai thinking models don't support frequency_penalty and presence_penalty
         avoid_repetition = False
 
-    if model == LargeLanguageModels.apertus_70b_instruct:
+    if model in [
+        LargeLanguageModels.apertus_70b_instruct,
+        LargeLanguageModels.sea_lion_v4_gemma_3_27b_it,
+    ]:
         # Swiss AI Apertus model doesn't support tool calling
-        tools = None
-
-    if model == LargeLanguageModels.sea_lion_v4_gemma_3_27b_it:
-        # sea lion doesn't support tools
         tools = None
 
     if avoid_repetition:


### PR DESCRIPTION
### Q/A checklist

- [x] I have tested my UI changes on mobile and they look acceptable
- [x] I have tested changes to the workflows in both the API and the UI
- [x] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [x] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables tool calling for `LargeLanguageModels.sea_lion_v4_gemma_3_27b_it` in `run_openai_chat`, aligning it with Apertus which also lacks tool support.
> 
> - **LLM runtime**:
>   - In `run_openai_chat`, extend the no-tools exception to include `LargeLanguageModels.sea_lion_v4_gemma_3_27b_it` (tools set to `None`), matching existing handling for `apertus_70b_instruct`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3855be74e32958e65c4a51d143563227c2dfeef4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->