### PR TITLE
Fix: slack buttons

### DIFF
--- a/daras_ai_v2/bots.py
+++ b/daras_ai_v2/bots.py
@@ -268,6 +268,7 @@ class BotInterface:
                 update_msg_id=update_msg_id,
             )
             text = ""
+            update_msg_id = None
 
         if send_feedback_buttons:
             buttons = _feedback_buttons()

--- a/daras_ai_v2/slack_bot.py
+++ b/daras_ai_v2/slack_bot.py
@@ -740,9 +740,7 @@ def update_msg_ack_selection_from_payload(payload: dict):
     original_blocks = (payload.get("message", {}) or {}).get("blocks", []) or []
     original_text = (payload.get("message", {}) or {}).get("text") or ""
 
-    bi = BotIntegration.objects.get(
-        slack_channel_id=channel_id, slack_team_id=team_id
-    )
+    bi = BotIntegration.objects.get(slack_channel_id=channel_id, slack_team_id=team_id)
     update_msg_acknowledge_selection(
         channel=channel_id,
         ts=message_ts,

--- a/routers/slack_api.py
+++ b/routers/slack_api.py
@@ -227,8 +227,6 @@ def _handle_slack_event(event: dict, background_tasks: BackgroundTasks):
 
                 files = message.get("files", [])
                 if not files:
-                    message.get("message", {}).get("files", [])
-                if not files:
                     attachments = message.get("attachments", [])
                     files = [
                         file

--- a/routers/slack_api.py
+++ b/routers/slack_api.py
@@ -35,6 +35,7 @@ from daras_ai_v2.slack_bot import (
     SlackAPIError,
     fetch_user_info,
     parse_slack_response,
+    update_msg_ack_selection_from_payload,
 )
 from routers.custom_api_router import CustomAPIRouter
 from workspaces.widgets import get_current_workspace
@@ -171,6 +172,11 @@ def slack_interaction(
         raise HTTPException(403, "Only accepts requests from Slack")
     if data["type"] != "block_actions":
         return
+    # Immediately update the original message to remove buttons and show selection
+    try:
+        update_msg_ack_selection_from_payload(data)
+    except Exception as e:
+        capture_exception(e)
     bot = SlackBot(
         message_ts=data["container"]["message_ts"],
         team_id=data["team"]["id"],


### PR DESCRIPTION
- **remove line that did nothing**
- **feat: slackbot: show feedback to user on button press**
- **fix: message-with-button disappaears when feedback buttons on slack**

### Q/A checklist

- [x] I have tested my UI changes on mobile and they look acceptable
- [x] I have tested changes to the workflows in both the API and the UI
- [x] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [x] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
