### PR TITLE
refactor: rename integrations to deployments across API and UI

### DIFF
--- a/bots/admin.py
+++ b/bots/admin.py
@@ -40,7 +40,7 @@ from gooeysite.custom_filters import (
 )
 from gooeysite.custom_widgets import JSONEditorWidget
 from recipes.VideoBots import VideoBotsPage
-from routers.root import integrations_stats_route
+from routers.root import deployments_stats_route
 
 fb_fields = [
     "fb_page_id",
@@ -344,16 +344,16 @@ class BotIntegrationAdmin(admin.ModelAdmin):
         if not bi.id:
             raise bi.DoesNotExist
 
-        integration_id = bi.api_integration_id()
+        deployment_id = bi.api_deployment_id()
         return open_in_new_tab(
             url=get_app_route_url(
-                integrations_stats_route,
+                deployments_stats_route,
                 path_params=dict(
                     page_slug=VideoBotsPage.slug_versions[-1],
-                    integration_id=integration_id,
+                    deployment_id=deployment_id,
                 ),
             ),
-            label=integration_id,
+            label=deployment_id,
         )
 
 

--- a/bots/models/bot_integration.py
+++ b/bots/models/bot_integration.py
@@ -516,7 +516,7 @@ class BotIntegration(models.Model):
             or self.name
             or (
                 self.platform == Platform.WEB
-                and f"Integration ID {self.api_integration_id()}"
+                and f"Deployment ID {self.api_deployment_id()}"
             )
             or ""
         ) + ((self.extension_number and f" ex {self.extension_number}") or "")
@@ -545,8 +545,8 @@ class BotIntegration(models.Model):
             return get_app_route_url(
                 chat_route,
                 path_params=dict(
-                    integration_id=self.api_integration_id(),
-                    integration_name=slugify(self.name) or "untitled",
+                    deployment_id=self.api_deployment_id(),
+                    deployment_name=slugify(self.name) or "untitled",
                 ),
             )
         elif self.twilio_phone_number:
@@ -557,7 +557,7 @@ class BotIntegration(models.Model):
         else:
             return None
 
-    def api_integration_id(self) -> str:
+    def api_deployment_id(self) -> str:
         from routers.bots_api import api_hashids
 
         return api_hashids.encode(self.id)
@@ -567,7 +567,7 @@ class BotIntegration(models.Model):
     ) -> dict:
         config = self.web_config_extras | dict(
             target=target,
-            integration_id=self.api_integration_id(),
+            deployment_id=self.api_deployment_id(),
             branding=self.get_web_widget_branding(),
         )
 

--- a/bots/models/convo_msg.py
+++ b/bots/models/convo_msg.py
@@ -95,7 +95,7 @@ class ConversationQuerySet(models.QuerySet):
                     .replace(tzinfo=None)
                     .strftime(settings.SHORT_DATETIME_FORMAT)
                 ),
-                "Integration Name": convo.bot_integration.name,
+                "Deployment Name": convo.bot_integration.name,
             }
             rows.append(row)
         df = pd.DataFrame.from_records(
@@ -115,7 +115,7 @@ class ConversationQuerySet(models.QuerySet):
                 "R30",
                 "Delta Hours",
                 "Created At",
-                "Integration Name",
+                "Deployment Name",
             ],
         )
         return df
@@ -293,7 +293,7 @@ class Conversation(models.Model):
         for col in self.user_id_fields:
             if value := getattr(self, col, None):
                 return value
-        return self.api_integration_id()
+        return self.api_deployment_id()
 
     get_display_name.short_description = "User"
 
@@ -330,7 +330,7 @@ class Conversation(models.Model):
     def last_n_msgs(self) -> list["Message"]:
         return self.messages.all().last_n_msgs(reset_at=self.reset_at)
 
-    def api_integration_id(self) -> str:
+    def api_deployment_id(self) -> str:
         from routers.bots_api import api_hashids
 
         return api_hashids.encode(self.id)
@@ -378,7 +378,7 @@ class MessageQuerySet(models.QuerySet):
                 "Input Audio": row.get("input_audio"),
                 "User Message ID": row.get("user_message_id"),
                 "Conversation ID": row.get("conversation_id"),
-                "Integration Name": row.get("integration_name"),
+                "Deployment Name": row.get("deployment_name"),
             }
             for row in self.to_json(tz=tz, row_limit=row_limit)
             if row.get("sent")
@@ -434,8 +434,8 @@ class MessageQuerySet(models.QuerySet):
                             message.platform_msg_id
                             and message.platform_msg_id.removeprefix(MSG_ID_PREFIX)
                         ),
-                        "conversation_id": message.conversation.api_integration_id(),
-                        "integration_name": message.conversation.bot_integration.name,
+                        "conversation_id": message.conversation.api_deployment_id(),
+                        "deployment_name": message.conversation.bot_integration.name,
                     }
                 )
 
@@ -623,7 +623,7 @@ class FeedbackQuerySet(models.QuerySet):
                 "Feedback (EN)": feedback.text_english,
                 "Feedback (Local)": feedback.text,
                 "Run URL": feedback.message.saved_run.get_app_url(),
-                "Integration Name": feedback.message.conversation.bot_integration.name,
+                "Deployment Name": feedback.message.conversation.bot_integration.name,
             }
             rows.append(row)
         df = pd.DataFrame.from_records(
@@ -639,7 +639,7 @@ class FeedbackQuerySet(models.QuerySet):
                 "Feedback (EN)",
                 "Feedback (Local)",
                 "Run URL",
-                "Integration Name",
+                "Deployment Name",
             ],
         )
         return df

--- a/daras_ai_v2/api_examples_widget.py
+++ b/daras_ai_v2/api_examples_widget.py
@@ -330,7 +330,7 @@ If you encounter any issues, write to us at support@gooey.ai and make sure to in
         )
 
 
-def bot_api_example_generator(integration_id: str):
+def bot_api_example_generator(deployment_id: str):
     from routers import bots_api
     from recipes.VideoBots import VideoBotsPage
 
@@ -342,8 +342,8 @@ let response = await fetch("%(api_url)s", {
     "Content-Type": "application/json",
   },
   body: JSON.stringify({
-    // your integration's ID as shown in the Gooey.AI Deploy tab
-    "integration_id": "%(integration_id)s",
+    // your deployment's ID as shown in the Gooey.AI Deploy tab
+    "deployment_id": "%(deployment_id)s",
     // the input text for the bot
     "input_prompt": "Hello, world!",
   }),
@@ -382,12 +382,12 @@ evtSource.onerror = (event) => {
             furl(settings.API_BASE_URL)
             / bots_api.app.url_path_for(bots_api.stream_create.__name__)
         ),
-        integration_id=integration_id,
+        deployment_id=deployment_id,
     )
 
     gui.write(
         f"""
-Your Integration ID: `{integration_id}`
+Your Deployment ID: `{deployment_id}`
 
 
 Use the following code snippet to stream messages from the bot.   

--- a/daras_ai_v2/bot_integration_connect.py
+++ b/daras_ai_v2/bot_integration_connect.py
@@ -28,9 +28,9 @@ def connect_bot_to_published_run(
             send_confirmation_msg(bi)
 
     return VideoBotsPage.app_url(
-        tab=RecipeTabs.integrations,
+        tab=RecipeTabs.deployments,
         example_id=published_run.published_run_id,
-        path_params=dict(integration_id=bi.api_integration_id()),
+        path_params=dict(deployment_id=bi.api_deployment_id()),
     )
 
 

--- a/daras_ai_v2/bot_integration_widgets.py
+++ b/daras_ai_v2/bot_integration_widgets.py
@@ -24,7 +24,7 @@ from widgets.demo_button import render_demo_button_settings
 from workspaces.models import Workspace
 
 
-def integrations_welcome_screen(title: str):
+def deployments_welcome_screen(title: str):
     with gui.center():
         gui.markdown(f"#### {title}")
 
@@ -50,7 +50,7 @@ def integrations_welcome_screen(title: str):
         )
         gui.caption("Make changes, Submit & Save your perfect workflow")
     with col2:
-        gui.image(icons.integrations_img, alt="Integrations", style={"height": "5rem"})
+        gui.image(icons.deployments_img, alt="Deployments", style={"height": "5rem"})
         gui.markdown("2. Connect to Slack, Whatsapp or your App")
         gui.caption("Or Facebook, Instagram and the web. Wherever your users chat.")
     with col3:
@@ -365,8 +365,8 @@ def get_web_widget_embed_code(bi: BotIntegration, *, config: dict = None) -> str
     lib_src = get_app_route_url(
         chat_lib_route,
         path_params=dict(
-            integration_id=bi.api_integration_id(),
-            integration_name=slugify(bi.name) or "untitled",
+            deployment_id=bi.api_deployment_id(),
+            deployment_name=slugify(bi.name) or "untitled",
         ),
     ).rstrip("/")
     if config is None:
@@ -546,7 +546,7 @@ def web_widget_config(bi: BotIntegration, user: AppUser | None, hostname: str | 
                 config=bi.get_web_widget_config(hostname) | dict(mode="inline"),
             )
         else:
-            bot_api_example_generator(bi.api_integration_id())
+            bot_api_example_generator(bi.api_deployment_id())
 
 
 def integration_details_generator(bi: BotIntegration, user: AppUser | None):

--- a/daras_ai_v2/bots.py
+++ b/daras_ai_v2/bots.py
@@ -637,11 +637,16 @@ def build_system_vars(
     bi = convo.bot_integration
     if bi.platform == Platform.WEB:
         user_msg_id = user_msg_id.removeprefix(MSG_ID_PREFIX)
+    deployment_id = bi.api_deployment_id()
+    deployment_name = bi.name
     variables = dict(
         platform=Platform(bi.platform).name,
-        integration_id=bi.api_integration_id(),
-        integration_name=bi.name,
-        conversation_id=convo.api_integration_id(),
+        deployment_id=deployment_id,
+        deployment_name=deployment_name,
+        # deprecated aliases - still passed for backward compatibility but not shown in UI
+        integration_id=deployment_id,
+        integration_name=deployment_name,
+        conversation_id=convo.api_deployment_id(),
         user_message_id=user_msg_id,
     )
 
@@ -682,6 +687,9 @@ def build_system_vars(
             )
 
     variables_schema = {var: {"role": "system"} for var in variables}
+    # mark deprecated variables so they're excluded from UI
+    variables_schema["integration_id"] = {"role": "system", "deprecated": True}
+    variables_schema["integration_name"] = {"role": "system", "deprecated": True}
     return variables, variables_schema
 
 

--- a/daras_ai_v2/breadcrumbs.py
+++ b/daras_ai_v2/breadcrumbs.py
@@ -96,7 +96,7 @@ def get_title_breadcrumbs(
             )
         case _ if is_run:
             if tab and tab.label:
-                prefix = "Deployments" if tab == RecipeTabs.integrations else tab.label
+                prefix = "Deployment" if tab == RecipeTabs.deployments else tab.label
             elif is_api_call:
                 prefix = "API Run"
             else:

--- a/daras_ai_v2/icons.py
+++ b/daras_ai_v2/icons.py
@@ -73,6 +73,6 @@ card_icons = {
     "diners": '<i class="fa-brands fa-cc-diners-club"></i>',
 }
 
-integrations_img = "https://storage.googleapis.com/dara-c1b52.appspot.com/daras_ai/media/c3ba2392-d6b9-11ee-a67b-6ace8d8c9501/image.png"
+deployments_img = "https://storage.googleapis.com/dara-c1b52.appspot.com/daras_ai/media/c3ba2392-d6b9-11ee-a67b-6ace8d8c9501/image.png"
 
 help_guide = '<i class="fa-duotone fa-solid fa-life-ring"></i>'

--- a/daras_ai_v2/meta_content.py
+++ b/daras_ai_v2/meta_content.py
@@ -109,7 +109,7 @@ def meta_title_for_page(
     match tab:
         case RecipeTabs.examples:
             ret = f"{tab.label}: {metadata.meta_title}"
-        case RecipeTabs.run_as_api | RecipeTabs.integrations:
+        case RecipeTabs.run_as_api | RecipeTabs.deployments:
             page_title = meta_title_for_page(
                 page=page, metadata=metadata, sr=sr, pr=pr, tab=RecipeTabs.run
             )
@@ -194,7 +194,7 @@ def canonical_url_for_page(
     from routers.root import RecipeTabs
 
     kwargs = {}
-    if page.tab in {RecipeTabs.run, RecipeTabs.run_as_api, RecipeTabs.integrations}:
+    if page.tab in {RecipeTabs.run, RecipeTabs.run_as_api, RecipeTabs.deployments}:
         if pr and pr.saved_run == sr and pr.is_root():
             pass
         elif pr and pr.saved_run == sr:
@@ -232,7 +232,7 @@ def robots_tag_for_page(
                 no_follow, no_index = False, False
             case RecipeTabs.run_as_api:
                 no_follow, no_index = False, True
-            case RecipeTabs.integrations:
+            case RecipeTabs.deployments:
                 no_follow, no_index = True, True
             case RecipeTabs.history:
                 no_follow, no_index = True, True

--- a/daras_ai_v2/variables_widget.py
+++ b/daras_ai_v2/variables_widget.py
@@ -212,6 +212,12 @@ def render_list_item(
                 "Add a value and tap Run to test a sample value.",
                 className="text-muted small",
             )
+        if schema.get("deprecated"):
+            gui.write(
+                "Deprecated",
+                help="This variable is deprecated and will be removed in a future version. ",
+                className="text-muted small",
+            )
 
         gui.div(className="flex-grow-1")
         gui.button(

--- a/functions/models.py
+++ b/functions/models.py
@@ -56,7 +56,7 @@ class FunctionScopes(FunctionScope, GooeyEnum):
     )
 
     deployment = FunctionScope(
-        label=f'<img align="left" width="24" height="24" src="{icons.integrations_img}"> &nbsp; Deployed App',
+        label=f'<img align="left" width="24" height="24" src="{icons.deployments_img}"> &nbsp; Deployed App',
         parts=(ScopeParts.workspace, ScopeParts.deployment),
     )
     deployment_user = FunctionScope(
@@ -157,6 +157,7 @@ class VariableSchema(TypedDict):
     type: NotRequired[JsonTypes]
     role: NotRequired[typing.Literal["user", "system"]]
     description: NotRequired[str]
+    deprecated: NotRequired[bool]
 
 
 class CalledFunctionResponse(BaseModel):

--- a/routers/twilio_ws_api.py
+++ b/routers/twilio_ws_api.py
@@ -44,7 +44,7 @@ class TwilioVoiceWs(TwilioVoice):
         audio_url = furl(settings.WS_PROXY_API_BASE_URL) / get_route_path(
             twilio_ws_proxy, path_params=dict(call_sid=self.call_sid)
         )
-        audio_url.add(query_params={"bi_id": self.bi.api_integration_id()})
+        audio_url.add(query_params={"bi_id": self.bi.api_deployment_id()})
         self._audio_url = str(audio_url)
         # force gpt-4o-audio for non-audio models
         if self.saved_run and self.saved_run.state:

--- a/tests/test_integrations_api.py
+++ b/tests/test_integrations_api.py
@@ -16,7 +16,7 @@ def test_send_msg_streaming(db_fixtures, force_authentication, mock_celery_tasks
     r = client.post(
         "/v3/integrations/stream/",
         json={
-            "integration_id": bi.api_integration_id(),
+            "integration_id": bi.api_deployment_id(),
             "input_text": "hello, world",
         },
         follow_redirects=False,

--- a/tests/test_public_endpoints.py
+++ b/tests/test_public_endpoints.py
@@ -14,7 +14,7 @@ from bots.models import (
 )
 from daras_ai_v2.fastapi_tricks import get_route_path
 from routers import facebook_api
-from routers.root import RecipeTabs, integrations_stats_route
+from routers.root import RecipeTabs, deployments_stats_route
 from routers.slack_api import slack_connect_redirect, slack_connect_redirect_shortcuts
 from routers.static_pages import webflow_upload
 from server import app
@@ -70,10 +70,10 @@ def test_integration_stats_route(db_fixtures, force_authentication, threadpool_s
                     content="test-message-2",
                 )
         url_path = get_route_path(
-            integrations_stats_route,
+            deployments_stats_route,
             path_params=dict(
                 page_slug="test-slug",
-                integration_id=bi.api_integration_id(),
+                deployment_id=bi.api_deployment_id(),
             ),
         )
         threadpool_subtest(


### PR DESCRIPTION
### Q/A checklist

- [ ] I have tested my UI changes on mobile and they look acceptable
- [ ] I have tested changes to the workflows in both the API and the UI
- [ ] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [ ] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
