### PR TITLE
feat: implement stopping state for recipe runs

### DIFF
--- a/bots/migrations/0117_savedrun_cancelled.py
+++ b/bots/migrations/0117_savedrun_cancelled.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("bots", "0116_botintegration_telegram_bot_id_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="savedrun",
+            name="cancelled",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/bots/models/saved_run.py
+++ b/bots/models/saved_run.py
@@ -86,6 +86,7 @@ class SavedRun(models.Model):
         blank=True,
         help_text="The error message. If this is not set, the run is deemed successful.",
     )
+    cancelled = models.BooleanField(default=False)
     run_time = models.DurationField(default=datetime.timedelta, blank=True)
     run_status = models.TextField(default="", blank=True)
 
@@ -204,6 +205,8 @@ class SavedRun(models.Model):
             ret[StateKeys.created_at] = self.created_at
         if self.error_msg:
             ret[StateKeys.error_msg] = self.error_msg
+        if self.cancelled:
+            ret[StateKeys.cancelled] = self.cancelled
         if self.run_time:
             ret[StateKeys.run_time] = self.run_time.total_seconds()
         if self.run_status:
@@ -234,6 +237,7 @@ class SavedRun(models.Model):
         if created_at:
             self.created_at = created_at
         self.error_msg = state.pop(StateKeys.error_msg, None) or ""
+        self.cancelled = bool(state.pop(StateKeys.cancelled, None))
         self.run_time = datetime.timedelta(
             seconds=state.pop(StateKeys.run_time, None) or 0
         )

--- a/celeryapp/tasks.py
+++ b/celeryapp/tasks.py
@@ -20,7 +20,7 @@ from celeryapp.celeryconfig import app
 from daras_ai.image_input import truncate_text_words
 from daras_ai_v2 import gcs_v2, settings
 from daras_ai_v2.base import BasePage, StateKeys
-from daras_ai_v2.exceptions import UserError
+from daras_ai_v2.exceptions import StopRequested, UserError
 from daras_ai_v2.send_email import send_email_via_postmark, send_low_balance_email
 from daras_ai_v2.settings import templates
 from gooeysite.bg_db_conn import db_middleware
@@ -79,6 +79,7 @@ def runner_task(
             # extract status of the run
             {
                 StateKeys.error_msg: error_msg,
+                StateKeys.cancelled: sr.cancelled,
                 StateKeys.run_time: time() - start_time,
                 StateKeys.run_status: run_status,
             }
@@ -121,7 +122,14 @@ def runner_task(
     try:
         save_on_step()
         for val in page.main(sr, gui.session_state):
+            page.current_sr.refresh_from_db(fields=["cancelled"])
+            if page.current_sr.cancelled:
+                break
             save_on_step(val)
+
+    except StopRequested:
+        if deduct_credits:
+            sr.transaction, sr.price = page.deduct_credits(gui.session_state)
 
     # render errors nicely
     except Exception as e:
@@ -134,6 +142,7 @@ def runner_task(
             traceback.print_exc()
         sentry_sdk.capture_exception(e, level=sentry_level)
         error_msg = err_msg_for_exc(e)
+        sr.error_msg = error_msg
         sr.error_type = getattr(e, "error_type", None) or type(e).__qualname__
         sr.error_code = getattr(e, "status_code", None)
         sr.error_params = error_params or {}

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -47,6 +47,7 @@ from daras_ai_v2.breadcrumbs import get_title_breadcrumbs
 from daras_ai_v2.copy_to_clipboard_button_widget import copy_to_clipboard_button
 from daras_ai_v2.crypto import get_random_doc_id
 from daras_ai_v2.db import ANONYMOUS_USER_COOKIE
+from daras_ai_v2.exceptions import InsufficientCredits, StopRequested, is_stop_requested
 from daras_ai_v2.fastapi_tricks import get_route_path
 from daras_ai_v2.github_tools import github_url_for_file
 from daras_ai_v2.grid_layout_widget import grid_layout
@@ -135,6 +136,7 @@ class StateKeys:
     updated_at = "updated_at"
 
     error_msg = "__error_msg"
+    cancelled = "__cancelled"
     run_time = "__run_time"
     run_status = "__run_status"
     pressed_randomize = "__randomize"
@@ -1644,13 +1646,30 @@ class BasePage:
             ):
                 self.render_run_cost()
             with col2:
-                submitted = gui.button(
+                run_state = self.get_run_state(gui.session_state)
+                is_running = run_state in (
+                    RecipeRunState.starting,
+                    RecipeRunState.running,
+                )
+                stop_clicked = is_running and gui.button(
+                    f"{icons.cancel} Stop",
+                    key="--stop-run",
+                    type="secondary",
+                    className="my-0 py-2 text-danger",
+                )
+                submitted = not is_running and gui.button(
                     f"{icons.run} Run",
                     key=key,
                     type="primary",
                     className="my-0 py-2",
-                    # disabled=bool(gui.session_state.get(StateKeys.run_status)),
                 )
+            if stop_clicked:
+                if self.trigger_stop():
+                    gui.rerun()
+                else:
+                    gui.error("You don't have permission to stop this run.")
+            if is_running:
+                return False
             if not submitted:
                 return False
             try:
@@ -1777,6 +1796,8 @@ class BasePage:
         try:
             for val in self.run_v2(request, response):
                 state.update(response.model_dump(exclude_unset=True))
+                if is_stop_requested():
+                    raise StopRequested(self.get_stop_message())
                 yield val
         finally:
             state.update(response.model_dump(exclude_unset=True))
@@ -1866,6 +1887,8 @@ class BasePage:
 
     @classmethod
     def get_run_state(cls, state: dict[str, typing.Any]) -> RecipeRunState:
+        if state.get(StateKeys.cancelled):
+            return RecipeRunState.completed
         if detail := state.get(StateKeys.run_status):
             if detail.lower().strip(". ") == STARTING_STATE.lower().strip(". "):
                 return RecipeRunState.starting
@@ -1917,7 +1940,10 @@ class BasePage:
             if not is_deleted:
                 self.render_output()
 
-            if run_state in (RecipeRunState.running, RecipeRunState.starting):
+            if run_state in (
+                RecipeRunState.running,
+                RecipeRunState.starting,
+            ):
                 self.click_preview_tab()
                 self._render_running_output()
             elif not is_deleted:
@@ -2006,6 +2032,7 @@ class BasePage:
             run_status="",
             error_msg="",
             run_time=datetime.timedelta(),
+            cancelled=False,
         ).update(run_status=STARTING_STATE, uid=self.request.user.uid)
         if updated_count >= 1:
             # updated now
@@ -2081,6 +2108,7 @@ class BasePage:
         **defaults,
     ) -> SavedRun:
         gui.session_state[StateKeys.run_status] = run_status
+        gui.session_state[StateKeys.cancelled] = False
         gui.session_state.pop(StateKeys.error_msg, None)
         gui.session_state.pop(StateKeys.run_time, None)
         self._setup_rng_seed()
@@ -2164,6 +2192,15 @@ class BasePage:
     def realtime_channel_name(cls, run_id: str, uid: str) -> str:
         return f"gooey-outputs/{cls.slug_versions[0]}/{uid}/{run_id}"
 
+    def trigger_stop(self):
+        if not (self.is_current_user_owner() or self.is_current_user_admin()):
+            return False
+        sr = self.current_sr
+        gui.session_state[StateKeys.cancelled] = True
+        sr.cancelled = True
+        sr.save(update_fields=["cancelled"])
+        return True
+
     def _setup_rng_seed(self):
         seed = gui.session_state.get("seed")
         if not seed:
@@ -2178,6 +2215,8 @@ class BasePage:
             gui.session_state.pop(field_name, None)
 
     def _render_after_output(self):
+        if gui.session_state.get(StateKeys.cancelled):
+            gui.info(self.get_stop_message(), icon="🛑")
         self._render_regenerate_button()
 
     def _render_regenerate_button(self):
@@ -2363,7 +2402,9 @@ class BasePage:
                     )
 
             with gui.div(className="mt-2"):
-                if saved_run.run_status:
+                if saved_run.cancelled:
+                    gui.info(self.get_stop_message(), icon="🛑")
+                elif saved_run.run_status:
                     started_at_text(saved_run.created_at)
                     html_spinner(saved_run.run_status)
                 elif saved_run.error_msg:
@@ -2477,7 +2518,9 @@ class BasePage:
 
         raise exceptions.InsufficientCredits(self.request.user, sr)
 
-    def deduct_credits(self, state: dict) -> tuple[AppUserTransaction, int]:
+    def deduct_credits(
+        self, state: dict, amount: int = None
+    ) -> tuple[AppUserTransaction, int]:
         assert self.request.user, "request.user must be set to deduct credits"
 
         amount = self.get_price_roundoff(state)
@@ -2596,6 +2639,10 @@ class BasePage:
 
     def get_cost_note(self) -> str | None:
         pass
+
+    def get_stop_message(self) -> str:
+        """Return the message to display when the run is stopped."""
+        return "Run stopped by user."
 
     def is_current_user_admin(self) -> bool:
         return self.is_user_admin(self.request.user)

--- a/daras_ai_v2/bots.py
+++ b/daras_ai_v2/bots.py
@@ -546,7 +546,7 @@ def _process_and_send_msg(
                 bot.recipe_run_state = bot.page_cls.get_run_state(state)
                 bot.run_status = state.get(StateKeys.run_status) or ""
                 # check for errors
-                if bot.recipe_run_state == RecipeRunState.failed:
+                if bot.recipe_run_state in (RecipeRunState.failed,):
                     err_msg = state.get(StateKeys.error_msg)
                     bot.send_msg(text=ERROR_MSG.format(err_msg))
                     return  # abort

--- a/daras_ai_v2/exceptions.py
+++ b/daras_ai_v2/exceptions.py
@@ -76,6 +76,22 @@ class GPUError(UserError):
     pass
 
 
+class StopRequested(UserError):
+    def __init__(self, message: str):
+        super().__init__(message)
+
+
+def is_stop_requested() -> bool:
+    from celeryapp.tasks import get_running_saved_run
+
+    sr = get_running_saved_run()
+    if not sr:
+        return False
+
+    sr.refresh_from_db(fields=["cancelled"])
+    return sr.cancelled
+
+
 class InsufficientCredits(UserError):
     def __init__(self, user: AppUser, sr: SavedRun):
         from daras_ai_v2.base import SUBMIT_AFTER_LOGIN_Q

--- a/recipes/CompareLLM.py
+++ b/recipes/CompareLLM.py
@@ -128,7 +128,12 @@ class CompareLLMPage(BasePage):
     def get_raw_price(self, state: dict) -> float:
         grouped_costs = self.get_grouped_linked_usage_cost_in_credits()
         price = sum(map(math.ceil, grouped_costs.values()))
-        if "agrillm_qwen3_30b" in state.get("selected_models", []):
+
+        models_to_charge = list(state.get("output_text", {}).keys()) or state.get(
+            "selected_models", []
+        )
+
+        if "agrillm_qwen3_30b" in models_to_charge:
             price += 100
 
         return price + self.PROFIT_CREDITS

--- a/recipes/CompareText2Img.py
+++ b/recipes/CompareText2Img.py
@@ -28,6 +28,7 @@ from daras_ai_v2.stable_diffusion import (
     LoraWeight,
 )
 from daras_ai_v2.variables_widget import render_prompt_vars
+from daras_ai_v2.exceptions import StopRequested, is_stop_requested
 
 
 class CompareText2ImgPage(BasePage):
@@ -201,6 +202,10 @@ class CompareText2ImgPage(BasePage):
 
         for selected_model in request.selected_models:
             model = Text2ImgModels[selected_model]
+
+            if is_stop_requested():
+                raise StopRequested(self.get_stop_message())
+
             yield f"Running {model.value}..."
 
             output_images[selected_model] = yield from text2img(
@@ -268,9 +273,11 @@ class CompareText2ImgPage(BasePage):
                 )
 
     def get_raw_price(self, state: dict) -> int:
-        selected_models = state.get("selected_models", [])
+        models_to_charge = list(state.get("output_images", {}).keys()) or state.get(
+            "selected_models", []
+        )
         total = 0
-        for model in selected_models:
+        for model in models_to_charge:
             match model:
                 case Text2ImgModels.deepfloyd_if.name:
                     total += 5

--- a/recipes/CompareUpscaler.py
+++ b/recipes/CompareUpscaler.py
@@ -151,8 +151,12 @@ class CompareUpscalerPage(BasePage):
             _render_outputs(state)
 
     def get_raw_price(self, state: dict) -> int:
-        selected_models = state.get("selected_models", [])
-        return 5 * len(selected_models)
+        output_keys = set(state.get("output_images", {}).keys()) | set(
+            state.get("output_videos", {}).keys()
+        )
+        models_to_charge = list(output_keys) or state.get("selected_models", [])
+
+        return 5 * len(models_to_charge)
 
     def related_workflows(self) -> list:
         from recipes.CompareText2Img import CompareText2ImgPage


### PR DESCRIPTION
### Q/A checklist

- [x] I have tested my UI changes on mobile and they look acceptable
- [x] I have tested changes to the workflows in both the API and the UI
- [x] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [x] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205816995454513