### PR TITLE
feat: clean Gemma 4 control characters from tool call args

### DIFF
--- a/functions/recipe_functions.py
+++ b/functions/recipe_functions.py
@@ -65,9 +65,20 @@ class BaseLLMTool:
 
         self.await_audio_completed = await_audio_completed
 
+    def _clean_gemma4_tool_call_args(self, data: typing.Any) -> typing.Any:
+        """Strip Gemma 4 control characters from tool call arguments."""
+        if isinstance(data, str):
+            return data.replace('<|"|>', "").replace('<|"|', "")
+        elif isinstance(data, dict):
+            return {k: self._clean_gemma4_tool_call_args(v) for k, v in data.items()}
+        elif isinstance(data, list):
+            return [self._clean_gemma4_tool_call_args(v) for v in data]
+        return data
+
     def call_json(self, arguments: str) -> str:
         try:
             kwargs = json.loads(arguments)
+            kwargs = self._clean_gemma4_tool_call_args(kwargs)
             ret = self.call(**kwargs)
         except (json.JSONDecodeError, TypeError) as e:
             ret = dict(error=repr(e))

--- a/tests/test_gemma4_tool_args.py
+++ b/tests/test_gemma4_tool_args.py
@@ -1,0 +1,91 @@
+import json
+
+from functions.recipe_functions import BaseLLMTool
+
+
+class _EchoTool(BaseLLMTool):
+    def call(self, **kwargs):
+        return kwargs
+
+
+def _tool() -> _EchoTool:
+    return _EchoTool(name="test", label="test", description="test", properties={})
+
+
+def test_clean_gemma4_tool_call_args_single_tool_call_args():
+    tool = _tool()
+    arguments = r'{"location":"<|\"|London<|\"|>"}'
+
+    result = json.loads(tool.call_json(arguments))
+    assert result == {"location": "London"}
+
+
+def test_clean_gemma4_tool_call_args_multiple_arguments():
+    tool = _tool()
+    arguments = r'{"location":"<|\"|San Francisco<|\"|>","unit":"<|\"|celsius<|\"|>"}'
+
+    result = json.loads(tool.call_json(arguments))
+    assert result == {"location": "San Francisco", "unit": "celsius"}
+
+
+def test_clean_gemma4_tool_call_args_nested_arguments():
+    tool = _tool()
+    arguments = r'{"nested":{"inner":"<|\"|value<|\"|>"},"list":["<|\"|a<|\"|>","<|\"|b<|\"|>"]}'
+
+    result = json.loads(tool.call_json(arguments))
+    assert result == {"nested": {"inner": "value"}, "list": ["a", "b"]}
+
+
+def test_clean_gemma4_tool_call_args_numbers_and_boolean():
+    tool = _tool()
+    arguments = r'{"is_active":true,"count":42,"score":3.14}'
+
+    result = json.loads(tool.call_json(arguments))
+    assert result == {"is_active": True, "count": 42, "score": 3.14}
+
+
+def test_clean_gemma4_tool_call_args_no_arguments():
+    tool = _tool()
+    arguments = "{}"
+
+    result = json.loads(tool.call_json(arguments))
+    assert result == {}
+
+
+def test_clean_gemma4_tool_call_args_incomplete_json_returns_error():
+    tool = _tool()
+    arguments = r'{"location":"<|\"|London'
+
+    result = json.loads(tool.call_json(arguments))
+    assert "error" in result
+
+
+def test_clean_gemma4_tool_call_args_text_unchanged():
+    tool = _tool()
+    assert tool._clean_gemma4_tool_call_args("normal string") == "normal string"
+
+
+def test_clean_gemma4_tool_call_args_other_types_unchanged():
+    tool = _tool()
+
+    assert tool._clean_gemma4_tool_call_args(42) == 42
+    assert tool._clean_gemma4_tool_call_args(3.14) == 3.14
+    assert tool._clean_gemma4_tool_call_args(True) is True
+    assert tool._clean_gemma4_tool_call_args(False) is False
+    assert tool._clean_gemma4_tool_call_args(None) is None
+
+
+def test_clean_gemma4_tool_call_args_array_with_mixed_types():
+    tool = _tool()
+    data = ['<|"|a<|"|>', '<|"|b<|"|>', 42, True]
+
+    cleaned = tool._clean_gemma4_tool_call_args(data)
+    assert cleaned == ["a", "b", 42, True]
+
+
+def test_clean_gemma4_tool_call_args_empty_structures():
+    tool = _tool()
+
+    assert tool._clean_gemma4_tool_call_args({}) == {}
+    assert tool._clean_gemma4_tool_call_args([]) == []
+    assert tool._clean_gemma4_tool_call_args("") == ""


### PR DESCRIPTION
…rguments

### Q/A checklist

- [ ] I have tested my UI changes on mobile and they look acceptable
- [ ] I have tested changes to the workflows in both the API and the UI
- [ ] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [ ] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
