### PR TITLE
feat: add lazy tool loading for video bots

### DIFF
--- a/.agents/test-workflows-in-process/SKILL.md
+++ b/.agents/test-workflows-in-process/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: test-workflows-in-process
+description: Use when reproducing or inspecting Gooey workflow behavior locally without the browser, especially for capturing VideoBots prompts, tool-call traces, workflow-tool arguments, or comparing prompt/schema changes against a published run.
+---
+
+# Test Workflows In Process
+
+## Overview
+Run Gooey workflows directly in Python against real published-run state when you need prompt and tool-call evidence faster than a browser or API round-trip.
+
+Core principle: reproduce the real workflow state first, then stub downstream workflow execution only if you need prompt/tool traces without waiting for the called workflow to finish.
+
+## When To Use
+- You need the exact `final_prompt` sent to the LLM.
+- You need raw `tool_calls` emitted by `VideoBotsPage`.
+- You want to compare prompt/schema changes against the same published run.
+- A downstream workflow is slow or flaky, but you still need the tool arguments.
+- You want to inspect a published copilot URL like `/copilot/<slug>-<example_id>/`.
+
+Do not use this when the behavior depends on browser-only UI interactions. Use browser testing for that.
+
+## Setup
+
+```python
+__import__("gooeysite.wsgi")
+```
+
+## Workflow Pattern
+1. Parse the published run ID from the URL.
+2. Build the page class directly, usually `VideoBotsPage(...)`.
+3. Load real state with `page.current_sr_to_session_state()`.
+4. Override only the fields needed for the experiment:
+   - `messages`
+   - `input_prompt`
+   - `output_text`
+   - `raw_output_text`
+   - `final_prompt`
+   - `output_audio`
+5. Call `gui.set_session_state(state)`.
+6. Patch `get_current_workspace()` to return the published-run workspace.
+7. Run `page.run(gui.session_state)`.
+8. Read `gui.session_state["final_prompt"]`, `output_text`, and any assistant `tool_calls`.
+
+## Base Script Template
+
+```python
+__import__("gooeysite.wsgi")
+
+import json
+
+import gooey_gui as gui
+from starlette.datastructures import URL
+from unittest.mock import patch
+
+from bots.models import get_default_published_run_workspace
+from recipes.VideoBots import VideoBotsPage
+from workspaces.models import Workspace
+
+example_id = "v1xm6uhp"
+request_url = URL("http://localhost:3000/copilot/base-copilot-w-search-rag-code-execution-v1xm6uhp/")
+workspace = Workspace.objects.get(id=get_default_published_run_workspace())
+user = workspace.created_by
+
+page = VideoBotsPage(
+    user=user,
+    request_session={},
+    request_url=request_url,
+    query_params={"example_id": example_id, "uid": user.uid},
+)
+
+state = page.current_sr_to_session_state()
+state.update(
+    {
+        "messages": [],
+        "input_prompt": "Your test input here",
+        "output_text": [],
+        "raw_output_text": [],
+        "final_prompt": [],
+        "output_audio": [],
+    }
+)
+gui.set_session_state(state)
+
+progress = []
+with patch("daras_ai_v2.base.get_current_workspace", return_value=workspace):
+    for step in page.run(gui.session_state):
+        if step:
+            progress.append(step)
+
+final_state = dict(gui.session_state)
+print(json.dumps(
+    {
+        "progress": progress,
+        "final_prompt": final_state.get("final_prompt"),
+        "output_text": final_state.get("output_text"),
+        "error_msg": final_state.get("error_msg"),
+    },
+    indent=2,
+    default=str,
+))
+```
+
+## Capturing Tool Traces
+To capture assistant-emitted tool calls from `VideoBotsPage`:
+
+```python
+assistant_entries = [
+    entry for entry in final_state.get("final_prompt", [])
+    if entry.get("role") == "assistant"
+]
+
+trace = []
+for entry in assistant_entries:
+    for call in entry.get("tool_calls") or []:
+        trace.append(
+            {
+                "id": call.get("id"),
+                "name": call.get("function", {}).get("name"),
+                "arguments": call.get("function", {}).get("arguments"),
+                "label": call.get("label"),
+                "content": entry.get("content"),
+            }
+        )
+```
+
+## Stubbing Workflow Tools
+If a workflow tool is slow or triggers another full run, stub `WorkflowLLMTool.call` and capture its kwargs instead of executing it:
+
+```python
+from functions.recipe_functions import WorkflowLLMTool
+
+captured_calls = []
+
+def fake_call(self, **kwargs):
+    captured_calls.append(
+        {
+            "name": self.name,
+            "label": self.label,
+            "description": self.spec_function["description"],
+            "kwargs": kwargs,
+            "spec_parameters": self.spec_parameters,
+        }
+    )
+    return {"stubbed": True, "tool_name": self.name, "kwargs": kwargs}
+
+with (
+    patch("daras_ai_v2.base.get_current_workspace", return_value=workspace),
+    patch.object(WorkflowLLMTool, "call", fake_call),
+):
+    for step in page.run(gui.session_state):
+        ...
+```
+
+Use this when you care about:
+- the exact tool arguments
+- the tool description/schema shown to the model
+- the final prompt and assistant text
+
+## Editing The Copilot Prompt For Experiments
+To test prompt sensitivity without modifying saved workflow data, edit `state["bot_script"]` in memory before `gui.set_session_state(state)`.
+
+Good use cases:
+- remove one tool instruction block
+- rewrite one tool hint
+- compare before/after prompt wording
+
+## Reporting Format
+When you finish, report:
+- the workflow URL or `example_id`
+- the exact user input sequence used
+- the relevant system prompt excerpt
+- the raw `tool_call_trace`
+- the captured workflow-tool kwargs if stubbing
+- whether the downstream workflow was real or stubbed
+- the resulting `output_text`
+
+## Common Pitfalls
+- Anonymous users fail when tool binding needs a workspace. Use the published-run owner workspace and patch `get_current_workspace()`.
+- Real workflow execution can hang or run long. Stub `WorkflowLLMTool.call` when you only need tool traces.
+- Clear `messages`, `final_prompt`, and output fields between experiments or you will mix traces.
+- If comparing prompt variants, keep the same `example_id` and same user-turn sequence.

--- a/Procfile
+++ b/Procfile
@@ -17,6 +17,6 @@ admin: poetry run python manage.py runserver 127.0.0.1:8000
 
 dashboard: poetry run streamlit run Home.py --server.port 8501 --server.headless true
 
-celery: poetry run celery -A celeryapp worker -P threads -c 16 -l DEBUG
+celery: poetry run watchfiles --filter python --ignore-paths ".git,node_modules,gooey-gui/node_modules,__pycache__,.pytest_cache,.ruff_cache,.mypy_cache" --target-type command "poetry run celery -A celeryapp worker -P threads -c 16 -l DEBUG" .
 
 ui: cd gooey-gui/; PORT=3000 REDIS_URL=redis://localhost:6379 npm run dev

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ These are the services that you need to run to start developing locally. Open th
 | ----------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | Python API + GUI Server | `8080` | `poetry run uvicorn server:app --host 127.0.0.1 --port 8080 --reload`                                                                     |
 | Node Frontend           | `3000` | `cd gooey-gui/; PORT=3000 REDIS_URL=redis://localhost:6379 npm run build && npm run start`                                                |
-| Celery (Task Runner)    | -      | `poetry run celery -A celeryapp worker -P threads -c 16 -l DEBUG`                                                                         |
+| Celery (Task Runner)    | -      | `poetry run watchfiles --filter python --ignore-paths ".git,node_modules,gooey-gui/node_modules,__pycache__,.pytest_cache,.ruff_cache,.mypy_cache" --target-type command "poetry run celery -A celeryapp worker -P threads -c 16 -l DEBUG" .` |
 | Django Admin site       | `8000` | `poetry run python manage.py runserver 127.0.0.1:8000`                                                                                    |
 | Vespa (Vector DB)       | `8085` | `docker run --hostname vespa-container -p 8085:8080 -p 19071:19071 --volume vespa:/opt/vespa/var -it --rm --name vespa vespaengine/vespa` |
 
@@ -185,7 +185,7 @@ The frontend source lives at `./gooey-gui/` inside this repo.
 
 - The Python API + GUI Server should reload the entire server on code changes. You can refresh the page to see the changes.
 
-- The Celery worker must be manually restarted on code changes.
+- The Celery worker now restarts automatically on Python file changes when started with the `watchfiles` command above.
 
 - If you are working on the gooey-gui (react frontend), you can run:
 

--- a/ai_models/models.py
+++ b/ai_models/models.py
@@ -68,6 +68,17 @@ class AIModelSpecQuerySet(models.QuerySet):
                 q |= Q(name__in=selected_models)
         return self.filter(q)
 
+    def get_llms_for_frontend(self, *, selected_models: list[str] | str | None = None):
+        return (
+            self.filter(
+                category=AIModelSpec.Categories.llm,
+            )
+            .exclude_deprecated(
+                selected_models=selected_models,
+            )
+            .order_for_frontend()
+        )
+
     def order_for_frontend(self):
         return self.select_related("creator").order_by(
             F("creator__priority").desc(nulls_last=True),

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -61,7 +61,7 @@ from daras_ai_v2.utils import get_relative_time
 from daras_ai_v2.variables_widget import variables_input
 from functions.composio_tools import ComposioLLMTool
 from functions.inbuilt_tools import (
-    INBUILT_INTEGRATION_TOOLS,
+    INBUILT_FUNCTION_TOOLS,
     get_inbuilt_tools_from_state,
 )
 from functions.models import (
@@ -210,6 +210,8 @@ class BasePage:
 
         self.tab = tab
         self.request = request
+
+        self._active_tool_names = set()
 
     @classmethod
     def api_endpoint(cls) -> str:
@@ -1448,7 +1450,7 @@ class BasePage:
                         query_params={SUBMIT_AFTER_LOGIN_Q: "1"}
                     ),
                 )
-            case _ if tool.name in INBUILT_INTEGRATION_TOOLS:
+            case _ if tool.name in INBUILT_FUNCTION_TOOLS:
                 return tool.bind(
                     user_id=FunctionScopes.get_user_id_for_scope(
                         tool.scope,
@@ -2544,10 +2546,38 @@ class BasePage:
         return []
 
     @classmethod
-    def get_update_gui_state_schema(cls, builder_state: dict) -> dict[str, typing.Any]:
+    def get_tool_call_schema(cls, builder_state: dict) -> dict[str, typing.Any]:
         """Return top-level request properties for the builder's update_gui_state tool."""
         schema = cls.RequestModel.model_json_schema(ref_template="{model}")
         return schema["properties"]
+
+    @classmethod
+    def override_nullable_string_enum_schema(
+        cls, schema: dict[str, typing.Any], enum: list[str]
+    ) -> dict[str, typing.Any]:
+        if schema.get("anyOf"):
+            non_null_schema = next(
+                (
+                    entry
+                    for entry in schema["anyOf"]
+                    if entry.get("type") and entry.get("type") != "null"
+                ),
+                {},
+            )
+            return schema | {"anyOf": [non_null_schema | {"enum": enum}, {"type": "null"}]}
+        return schema | {"type": "string", "enum": enum}
+
+    @classmethod
+    def override_nullable_string_array_enum_schema(
+        cls, schema: dict[str, typing.Any], enum: list[str]
+    ) -> dict[str, typing.Any]:
+        array_schema = {
+            "type": "array",
+            "items": {"type": "string", "enum": enum},
+        }
+        if schema.get("anyOf"):
+            return schema | {"anyOf": [array_schema, {"type": "null"}]}
+        return schema | array_schema
 
     @classmethod
     def get_example_request(

--- a/daras_ai_v2/language_model_settings_widgets.py
+++ b/daras_ai_v2/language_model_settings_widgets.py
@@ -50,20 +50,13 @@ class LanguageModelSettings(BaseModel):
         None, title="Response Format"
     )
 
-
 def language_model_selector(
     label: str = "##### 🔠 Language Model Settings",
     label_visibility: str = "visible",
     key: str = "selected_model",
 ):
-    llm_models = (
-        AIModelSpec.objects.filter(
-            category=AIModelSpec.Categories.llm,
-        )
-        .exclude_deprecated(
-            selected_models=gui.session_state.get(key),
-        )
-        .order_for_frontend()
+    llm_models = AIModelSpec.objects.get_llms_for_frontend(
+        selected_models=gui.session_state.get(key)
     )
     options = {model.name: model.display_html() for model in llm_models}
     return gui.selectbox(

--- a/functions/gooey_memory_tools.py
+++ b/functions/gooey_memory_tools.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import typing
+
+from django.utils import timezone
+
+from functions.models import FunctionScopes
+from functions.recipe_functions import BaseLLMTool
+from memory.models import MemoryEntry
+
+if typing.TYPE_CHECKING:
+    from bots.models import SavedRun
+
+
+class GooeyMemoryLLMToolRead(BaseLLMTool):
+    name = "GOOEY_MEMORY_READ_VALUE"
+
+    def __init__(self, scope: FunctionScopes | None):
+        self.scope = scope
+        super().__init__(
+            name=self.name,
+            label="Read Value from Gooey.AI Memory",
+            description="Read the value of a key from the Gooey.AI store.",
+            properties={
+                "key": {
+                    "type": "string",
+                    "description": "The key to read from the Gooey.AI store.",
+                },
+            },
+            required=["key"],
+        )
+
+    def bind(self, user_id: str, saved_run: SavedRun):
+        self.user_id = user_id
+        self.saved_run = saved_run
+        return self
+
+    def call(self, key: str) -> dict:
+        try:
+            value = MemoryEntry.objects.get(user_id=self.user_id, key=key).value
+        except MemoryEntry.DoesNotExist:
+            return {"success": False, "error": f"Key not found: {key}"}
+        return {"success": True, "key": key, "value": value}
+
+
+class GooeyMemoryLLMToolWrite(BaseLLMTool):
+    name = "GOOEY_MEMORY_WRITE_VALUE"
+
+    def __init__(self, scope: FunctionScopes):
+        self.scope = scope
+        super().__init__(
+            name=self.name,
+            label="Write Value to Gooey.AI Memory",
+            description="Write a value to the Gooey.AI store.",
+            properties={
+                "key": {
+                    "type": "string",
+                    "description": "The key to write to the Gooey.AI store.",
+                },
+                "value": {
+                    "type": "string",
+                    "description": "The value to write to the Gooey.AI store.",
+                },
+            },
+            required=["key", "value"],
+        )
+
+    def bind(self, user_id: str, saved_run: SavedRun):
+        self.user_id = user_id
+        self.saved_run = saved_run
+        return self
+
+    def call(self, key: str, value) -> dict:
+        MemoryEntry.objects.update_or_create(
+            user_id=self.user_id,
+            key=key,
+            defaults=dict(
+                value=value, saved_run=self.saved_run, updated_at=timezone.now()
+            ),
+        )
+        return {"success": True}
+
+
+class GooeyMemoryLLMToolDelete(BaseLLMTool):
+    name = "GOOEY_MEMORY_DELETE_VALUE"
+
+    def __init__(self, scope: FunctionScopes):
+        self.scope = scope
+        super().__init__(
+            name=self.name,
+            label="Delete Value from Gooey.AI Memory",
+            description="Delete a value from the Gooey.AI store.",
+            properties={
+                "key": {
+                    "type": "string",
+                    "description": "The key to delete from the Gooey.AI store.",
+                },
+            },
+            required=["key"],
+        )
+
+    def bind(self, user_id: str, saved_run: SavedRun):
+        self.user_id = user_id
+        self.saved_run = saved_run
+        return self
+
+    def call(self, key: str) -> dict:
+        MemoryEntry.objects.filter(user_id=self.user_id, key=key).delete()
+        return {"success": True}

--- a/functions/inbuilt_tools.py
+++ b/functions/inbuilt_tools.py
@@ -1,7 +1,7 @@
+import textwrap
 import typing
 
 from django.core.exceptions import ValidationError
-from django.utils import timezone
 from loguru import logger
 from sentry_sdk import capture_exception
 from twilio.base.exceptions import TwilioRestException
@@ -10,16 +10,26 @@ from twilio.twiml.voice_response import VoiceResponse
 from bots.models import BotIntegration
 from bots.models.bot_integration import validate_phonenumber
 from functions.composio_tools import ComposioLLMTool
+from functions.gooey_memory_tools import (
+    GooeyMemoryLLMToolDelete,
+    GooeyMemoryLLMToolRead,
+    GooeyMemoryLLMToolWrite,
+)
 from functions.models import FunctionScopes
 from functions.recipe_functions import (
     BaseLLMTool,
     generate_tool_properties,
     get_external_tool_slug_from_url,
 )
-from memory.models import MemoryEntry
 
-if typing.TYPE_CHECKING:
-    from bots.models import SavedRun
+INBUILT_FUNCTION_TOOLS = {
+    tool.name: tool
+    for tool in [
+        GooeyMemoryLLMToolRead,
+        GooeyMemoryLLMToolWrite,
+        GooeyMemoryLLMToolDelete,
+    ]
+}
 
 
 def get_inbuilt_tools_from_state(state: dict) -> typing.Iterable[BaseLLMTool]:
@@ -65,10 +75,11 @@ def get_inbuilt_tools_from_state(state: dict) -> typing.Iterable[BaseLLMTool]:
             continue
         scope = FunctionScopes.get(function.get("scope"))
         try:
-            tool_cls = INBUILT_INTEGRATION_TOOLS[tool_slug]
-            yield tool_cls(scope)
+            tool_cls = INBUILT_FUNCTION_TOOLS[tool_slug]
         except KeyError:
             composio_tools[tool_slug] = scope
+            continue
+        yield tool_cls(scope)
     for tool_spec in Composio().tools.get_raw_composio_tools(
         tools=composio_tools, limit=50
     ):
@@ -127,6 +138,79 @@ You should build well-written queries, including keywords as well as the context
         }
 
 
+class LoadToolsLLMTool(BaseLLMTool):
+    def __init__(
+        self, available_tools: dict[str, BaseLLMTool], active_tool_names: set[str]
+    ):
+        self.available_tools = available_tools
+        self.active_tool_names = active_tool_names
+
+        filtered_tools = [
+            tool
+            for tool in available_tools.values()
+            if not self.is_first_class_tool(tool) and tool.name not in active_tool_names
+        ]
+
+        tool_catalog = "\n\n".join(
+            _render_tool_catalog_entry(tool) for tool in filtered_tools
+        )
+        description = (
+            "Request the full schema for one or more tools by exact name. "
+            "Use this before calling tools that are not currently loaded. "
+            "If a task needs multiple tools, request all of them in a single call."
+            f"\n\nAvailable tools:\n\n{tool_catalog}"
+        )
+
+        searchable_tool_names = sorted(tool.name for tool in filtered_tools)
+
+        super().__init__(
+            name="load_tools",
+            label="Load Tools",
+            description=description,
+            properties={
+                "tool_names": {
+                    "type": "array",
+                    "description": "One or more exact tool names from the list above.",
+                    "items": {
+                        "type": "string",
+                        "enum": searchable_tool_names,
+                    },
+                }
+            },
+            required=["tool_names"],
+        )
+
+    @staticmethod
+    def is_first_class_tool(tool: BaseLLMTool) -> bool:
+        from functions.recipe_functions import WorkflowLLMTool
+
+        return not isinstance(tool, (WorkflowLLMTool, ComposioLLMTool))
+
+    def call(self, tool_names: list[str]) -> dict:
+        missing = []
+        for tool_name in tool_names:
+            if tool_name in self.available_tools:
+                self.active_tool_names.add(tool_name)
+            else:
+                missing.append(tool_name)
+        ret = {"loaded_tools": list(self.active_tool_names)}
+        if missing:
+            ret["missing_tools"] = missing
+        return ret
+
+
+def _render_tool_catalog_entry(tool: BaseLLMTool) -> str:
+    description = tool.description or tool.label
+    param_names = list(tool.spec_parameters.get("properties", {}))
+    return render_fn_pseudocode(tool.name, description, param_names)
+
+
+def render_fn_pseudocode(name: str, description: str, params: list[str]) -> str:
+    description = textwrap.indent(description, " * ", predicate=lambda line: True)
+    params_str = ", ".join(params)
+    return "/**\n" + description + "\n */\n" + name + "({ " + params_str + " });"
+
+
 class UpdateGuiStateLLMTool(BaseLLMTool):
     def __init__(self, builder_state: dict, page_slug: str):
         from daras_ai_v2.all_pages import normalize_slug, page_slug_map
@@ -137,7 +221,7 @@ class UpdateGuiStateLLMTool(BaseLLMTool):
             request = builder_state.get("request", builder_state)
             properties = dict(generate_tool_properties(request, {}))
         else:
-            properties = page_cls.get_update_gui_state_schema(builder_state)
+            properties = page_cls.get_tool_call_schema(builder_state)
 
         properties["-submit-workflow"] = {
             "type": "boolean",
@@ -347,110 +431,3 @@ class FeedbackCollectionLLMTool(BaseLLMTool):
         feedback.save()
 
         return {"success": True}
-
-
-class GooeyMemoryLLMToolRead(BaseLLMTool):
-    name = "GOOEY_MEMORY_READ_VALUE"
-
-    def __init__(self, scope: FunctionScopes | None):
-        self.scope = scope
-        super().__init__(
-            name=self.name,
-            label="Read Value from Gooey.AI Memory",
-            description="Read the value of a key from the Gooey.AI store.",
-            properties={
-                "key": {
-                    "type": "string",
-                    "description": "The key to read from the Gooey.AI store.",
-                },
-            },
-            required=["key"],
-        )
-
-    def bind(self, user_id: str, saved_run: "SavedRun"):
-        self.user_id = user_id
-        self.saved_run = saved_run
-        return self
-
-    def call(self, key: str) -> dict:
-        try:
-            value = MemoryEntry.objects.get(user_id=self.user_id, key=key).value
-        except MemoryEntry.DoesNotExist:
-            return {"success": False, "error": f"Key not found: {key}"}
-        return {"success": True, "key": key, "value": value}
-
-
-class GooeyMemoryLLMToolWrite(BaseLLMTool):
-    name = "GOOEY_MEMORY_WRITE_VALUE"
-
-    def __init__(self, scope: FunctionScopes):
-        self.scope = scope
-        super().__init__(
-            name=self.name,
-            label="Write Value to Gooey.AI Memory",
-            description="Write a value to the Gooey.AI store.",
-            properties={
-                "key": {
-                    "type": "string",
-                    "description": "The key to write to the Gooey.AI store.",
-                },
-                "value": {
-                    "type": "string",
-                    "description": "The value to write to the Gooey.AI store.",
-                },
-            },
-            required=["key", "value"],
-        )
-
-    def bind(self, user_id: str, saved_run: "SavedRun"):
-        self.user_id = user_id
-        self.saved_run = saved_run
-        return self
-
-    def call(self, key: str, value) -> dict:
-        MemoryEntry.objects.update_or_create(
-            user_id=self.user_id,
-            key=key,
-            defaults=dict(
-                value=value, saved_run=self.saved_run, updated_at=timezone.now()
-            ),
-        )
-        return {"success": True}
-
-
-class GooeyMemoryLLMToolDelete(BaseLLMTool):
-    name = "GOOEY_MEMORY_DELETE_VALUE"
-
-    def __init__(self, scope: FunctionScopes):
-        self.scope = scope
-        super().__init__(
-            name=self.name,
-            label="Delete Value from Gooey.AI Memory",
-            description="Delete a value from the Gooey.AI store.",
-            properties={
-                "key": {
-                    "type": "string",
-                    "description": "The key to delete from the Gooey.AI store.",
-                },
-            },
-            required=["key"],
-        )
-
-    def bind(self, user_id: str, saved_run: "SavedRun"):
-        self.user_id = user_id
-        self.saved_run = saved_run
-        return self
-
-    def call(self, key: str) -> dict:
-        MemoryEntry.objects.filter(user_id=self.user_id, key=key).delete()
-        return {"success": True}
-
-
-INBUILT_INTEGRATION_TOOLS = {
-    tool.name: tool
-    for tool in [
-        GooeyMemoryLLMToolRead,
-        GooeyMemoryLLMToolWrite,
-        GooeyMemoryLLMToolDelete,
-    ]
-}

--- a/functions/recipe_functions.py
+++ b/functions/recipe_functions.py
@@ -41,6 +41,7 @@ class BaseLLMTool:
         self.name = name
         self.label = label
         self.properties = properties
+        self.description = description
 
         self.spec_parameters = {
             "type": "object",
@@ -92,30 +93,40 @@ class WorkflowLLMTool(BaseLLMTool):
     def __init__(self, function_url: str):
         from bots.models import Workflow
         from daras_ai_v2.workflow_url_input import url_to_runs
+        from daras_ai_v2.base import extract_model_fields
 
         self.function_url = function_url
 
         self.page_cls, self.fn_sr, self.fn_pr = url_to_runs(function_url)
         self._fn_runs = (self.fn_sr, self.fn_pr)
 
+        self.name = slugify(self.fn_pr.title).replace("-", "_")
+
         self.is_function_workflow = self.fn_sr.workflow == Workflow.FUNCTIONS
         if self.is_function_workflow:
             fn_vars = self.fn_sr.state.get("variables", {})
             fn_vars_schema = self.fn_sr.state.get("variables_schema", {})
         else:
-            fn_vars = self.page_cls.get_example_request(self.fn_sr.state, self.fn_pr)[1]
-            fn_vars_schema = self.page_cls.RequestModel.model_json_schema().get(
-                "properties", {}
-            )
+            fn_vars = extract_model_fields(self.page_cls.RequestModel, self.fn_sr.state)
+            if hasattr(self.page_cls, "get_tool_call_schema"):
+                fn_vars_schema = self.page_cls.get_tool_call_schema(self.fn_sr.state)
+            elif hasattr(self.page_cls, "get_update_gui_state_schema"):
+                fn_vars_schema = self.page_cls.get_update_gui_state_schema(
+                    self.fn_sr.state
+                )
+            else:
+                fn_vars_schema = self.page_cls.RequestModel.model_json_schema().get(
+                    "properties", {}
+                )
         properties = dict(generate_tool_properties(fn_vars, fn_vars_schema))
 
-        name = slugify(self.fn_pr.title).replace("-", "_")
         super().__init__(
-            name=name,
-            label=self.fn_pr.title or name,
+            name=self.name,
+            label=self.fn_pr.title,
             description=self.fn_pr.notes,
             properties=properties,
         )
+        self.spec_function["description"] = self._build_workflow_description(fn_vars)
 
     def bind(
         self,
@@ -222,7 +233,7 @@ class WorkflowLLMTool(BaseLLMTool):
         )
 
     def _get_gooey_memory_tool_scope_name(self) -> str | None:
-        from functions.inbuilt_tools import (
+        from functions.gooey_memory_tools import (
             GooeyMemoryLLMToolDelete,
             GooeyMemoryLLMToolRead,
             GooeyMemoryLLMToolWrite,
@@ -242,6 +253,17 @@ class WorkflowLLMTool(BaseLLMTool):
             if tool_slug in memory_tool_names:
                 return function.get("scope")
         return None
+
+    def _build_workflow_description(self, fn_vars: dict) -> str:
+        from functions.inbuilt_tools import render_fn_pseudocode
+
+        description = (
+            self.fn_pr.notes
+            + "\n\nUse default parameters unless explicitly requested. "
+            "It's a bad programming practice if argument equals to the default parameter value. "
+        )
+        params = [f"{k} = {json.dumps(v)}" for k, v in fn_vars.items()]
+        return render_fn_pseudocode(self.name, description, params)
 
     def _get_system_vars(self) -> tuple[dict, dict]:
         request = self.request_model.model_validate(self.state)
@@ -340,24 +362,44 @@ def generate_tool_properties(
 
 
 def get_nested_type(val, schema=None) -> dict[str, typing.Any]:
-    json_type = schema and schema.get("type") or get_json_type(val)
+    schema = schema or {}
+    json_schema = {
+        key: value
+        for key, value in schema.items()
+        if key not in {"description", "role"}
+    }
+    json_type = json_schema.get("type") or get_json_type(val)
     if json_type == "array":
+        if json_schema.get("items"):
+            return {"type": "array"} | json_schema
         try:
-            return {"type": "array", "items": get_nested_type(val[0])}
+            return {"type": "array"} | json_schema | {"items": get_nested_type(val[0])}
         except IndexError:
-            return {"type": "array", "items": {"type": "object"}}
-    else:
-        return {"type": json_type}
+            return {"type": "array"} | json_schema | {"items": {"type": "object"}}
+    if json_type == "object":
+        if json_schema.get("properties") or "additionalProperties" in json_schema:
+            return {"type": "object"} | json_schema
+        if isinstance(val, dict):
+            return (
+                {"type": "object"}
+                | json_schema
+                | {
+                    "properties": {
+                        key: get_nested_type(value) for key, value in val.items()
+                    }
+                }
+            )
+    return {"type": json_type} | json_schema
 
 
 def get_json_type(val) -> "JsonTypes":
     match val:
+        case bool():
+            return "boolean"
         case str():
             return "string"
         case int() | float() | complex():
             return "number"
-        case bool():
-            return "boolean"
         case list() | tuple() | set():
             return "array"
         case _:

--- a/recipes/CompareLLM.py
+++ b/recipes/CompareLLM.py
@@ -49,6 +49,21 @@ class CompareLLMPage(BasePage):
     def get_example_preferred_fields(cls, state: dict) -> list[str]:
         return ["input_prompt", "selected_models"]
 
+    @classmethod
+    def get_tool_call_schema(cls, builder_state: dict) -> dict[str, typing.Any]:
+        properties = super().get_tool_call_schema(builder_state)
+        request = builder_state.get("request", builder_state)
+        properties["selected_models"] = cls.override_nullable_string_array_enum_schema(
+            properties.get("selected_models", {}),
+            [
+                model.name
+                for model in AIModelSpec.objects.get_llms_for_frontend(
+                    selected_models=request.get("selected_models")
+                )
+            ],
+        )
+        return properties
+
     def render_form_v2(self):
         gui.code_editor(
             label="#### 👩‍💻 Prompt",
@@ -58,14 +73,8 @@ class CompareLLMPage(BasePage):
             help="Supports [Jinja](https://jinja.palletsprojects.com/en/stable/templates/) templating",
         )
 
-        llm_models = (
-            AIModelSpec.objects.filter(
-                category=AIModelSpec.Categories.llm,
-            )
-            .exclude_deprecated(
-                selected_models=gui.session_state.get("selected_models"),
-            )
-            .order_for_frontend()
+        llm_models = AIModelSpec.objects.get_llms_for_frontend(
+            selected_models=gui.session_state.get("selected_models")
         )
         options = {model.name: model.display_html() for model in llm_models}
         gui.multiselect(

--- a/recipes/DocExtract.py
+++ b/recipes/DocExtract.py
@@ -9,6 +9,7 @@ from django.db.models import IntegerChoices
 from furl import furl
 from pydantic import BaseModel, Field
 
+from ai_models.models import AIModelSpec
 from bots.models import Workflow
 from daras_ai.image_input import upload_file_from_bytes
 from daras_ai_v2 import settings
@@ -139,6 +140,21 @@ class DocExtractPage(BasePage):
             "translation_model",
             "translation_target",
         ]
+
+    @classmethod
+    def get_tool_call_schema(cls, builder_state: dict) -> dict[str, typing.Any]:
+        properties = super().get_tool_call_schema(builder_state)
+        request = builder_state.get("request", builder_state)
+        properties["selected_model"] = cls.override_nullable_string_enum_schema(
+            properties.get("selected_model", {}),
+            [
+                model.name
+                for model in AIModelSpec.objects.get_llms_for_frontend(
+                    selected_models=request.get("selected_model")
+                )
+            ],
+        )
+        return properties
 
     def render_form_v2(self):
         bulk_documents_uploader(

--- a/recipes/DocSearch.py
+++ b/recipes/DocSearch.py
@@ -88,6 +88,21 @@ class DocSearchPage(BasePage):
     def get_example_preferred_fields(self, state: dict) -> list[str]:
         return ["documents"]
 
+    @classmethod
+    def get_tool_call_schema(cls, builder_state: dict) -> dict[str, typing.Any]:
+        properties = super().get_tool_call_schema(builder_state)
+        request = builder_state.get("request", builder_state)
+        properties["selected_model"] = cls.override_nullable_string_enum_schema(
+            properties.get("selected_model", {}),
+            [
+                model.name
+                for model in AIModelSpec.objects.get_llms_for_frontend(
+                    selected_models=request.get("selected_model")
+                )
+            ],
+        )
+        return properties
+
     def render_form_v2(self):
         gui.text_area("#### Search Query", key="search_query")
         bulk_documents_uploader("#### Documents")

--- a/recipes/DocSummary.py
+++ b/recipes/DocSummary.py
@@ -88,6 +88,21 @@ class DocSummaryPage(BasePage):
     def get_example_preferred_fields(cls, state: dict) -> list[str]:
         return ["task_instructions", "merge_instructions"]
 
+    @classmethod
+    def get_tool_call_schema(cls, builder_state: dict) -> dict[str, typing.Any]:
+        properties = super().get_tool_call_schema(builder_state)
+        request = builder_state.get("request", builder_state)
+        properties["selected_model"] = cls.override_nullable_string_enum_schema(
+            properties.get("selected_model", {}),
+            [
+                model.name
+                for model in AIModelSpec.objects.get_llms_for_frontend(
+                    selected_models=request.get("selected_model")
+                )
+            ],
+        )
+        return properties
+
     def render_form_v2(self):
         bulk_documents_uploader("#### 📎 Documents")
         gui.text_area("#### 👩‍💻 Instructions", key="task_instructions")

--- a/recipes/GoogleGPT.py
+++ b/recipes/GoogleGPT.py
@@ -114,6 +114,21 @@ class GoogleGPTPage(BasePage):
 
         final_search_query: str | None = None
 
+    @classmethod
+    def get_tool_call_schema(cls, builder_state: dict) -> dict[str, typing.Any]:
+        properties = super().get_tool_call_schema(builder_state)
+        request = builder_state.get("request", builder_state)
+        properties["selected_model"] = cls.override_nullable_string_enum_schema(
+            properties.get("selected_model", {}),
+            [
+                model.name
+                for model in AIModelSpec.objects.get_llms_for_frontend(
+                    selected_models=request.get("selected_model")
+                )
+            ],
+        )
+        return properties
+
     def render_form_v2(self):
         gui.text_area(
             "#### " + field_title(self.RequestModel, "search_query"),

--- a/recipes/SEOSummary.py
+++ b/recipes/SEOSummary.py
@@ -112,6 +112,21 @@ class SEOSummaryPage(BasePage):
         summarized_urls: list[dict]
         final_prompt: str
 
+    @classmethod
+    def get_tool_call_schema(cls, builder_state: dict) -> dict[str, typing.Any]:
+        properties = super().get_tool_call_schema(builder_state)
+        request = builder_state.get("request", builder_state)
+        properties["selected_model"] = cls.override_nullable_string_enum_schema(
+            properties.get("selected_model", {}),
+            [
+                model.name
+                for model in AIModelSpec.objects.get_llms_for_frontend(
+                    selected_models=request.get("selected_model")
+                )
+            ],
+        )
+        return properties
+
     def related_workflows(self):
         from recipes.SocialLookupEmail import SocialLookupEmailPage
         from recipes.GoogleImageGen import GoogleImageGenPage

--- a/recipes/SmartGPT.py
+++ b/recipes/SmartGPT.py
@@ -4,6 +4,7 @@ import jinja2.sandbox
 from pydantic import BaseModel
 
 import gooey_gui as gui
+from ai_models.models import AIModelSpec
 from bots.models import Workflow
 from daras_ai_v2.base import BasePage
 from daras_ai_v2.functional import map_parallel
@@ -44,6 +45,21 @@ class SmartGPTPage(BasePage):
         output_text: list[str]
 
         prompt_tree: PromptTree | None = None
+
+    @classmethod
+    def get_tool_call_schema(cls, builder_state: dict) -> dict[str, typing.Any]:
+        properties = super().get_tool_call_schema(builder_state)
+        request = builder_state.get("request", builder_state)
+        properties["selected_model"] = cls.override_nullable_string_enum_schema(
+            properties.get("selected_model", {}),
+            [
+                model.name
+                for model in AIModelSpec.objects.get_llms_for_frontend(
+                    selected_models=request.get("selected_model")
+                )
+            ],
+        )
+        return properties
 
     def render_form_v2(self):
         gui.text_area(

--- a/recipes/SocialLookupEmail.py
+++ b/recipes/SocialLookupEmail.py
@@ -62,6 +62,21 @@ class SocialLookupEmailPage(BasePage):
         final_prompt: str
         output_text: list[str]
 
+    @classmethod
+    def get_tool_call_schema(cls, builder_state: dict) -> dict[str, typing.Any]:
+        properties = super().get_tool_call_schema(builder_state)
+        request = builder_state.get("request", builder_state)
+        properties["selected_model"] = cls.override_nullable_string_enum_schema(
+            properties.get("selected_model", {}),
+            [
+                model.name
+                for model in AIModelSpec.objects.get_llms_for_frontend(
+                    selected_models=request.get("selected_model")
+                )
+            ],
+        )
+        return properties
+
     def related_workflows(self) -> list:
         from recipes.EmailFaceInpainting import EmailFaceInpaintingPage
         from recipes.SEOSummary import SEOSummaryPage

--- a/recipes/VideoBots.py
+++ b/recipes/VideoBots.py
@@ -36,7 +36,12 @@ from daras_ai_v2.asr import (
 from daras_ai_v2.azure_doc_extract import (
     azure_form_recognizer,
 )
-from daras_ai_v2.base import BasePage, RecipeRunState, RecipeTabs, StateKeys
+from daras_ai_v2.base import (
+    BasePage,
+    RecipeRunState,
+    RecipeTabs,
+    StateKeys,
+)
 from daras_ai_v2.bot_integration_connect import connect_bot_to_published_run
 from daras_ai_v2.bot_integration_widgets import (
     broadcast_input,
@@ -105,7 +110,10 @@ from daras_ai_v2.vector_search import (
     doc_or_yt_url_to_file_metas,
     doc_url_to_text_pages,
 )
-from functions.inbuilt_tools import get_inbuilt_tools_from_state
+from functions.inbuilt_tools import (
+    LoadToolsLLMTool,
+    get_inbuilt_tools_from_state,
+)
 from functions.models import FunctionTrigger
 from functions.recipe_functions import BaseLLMTool
 from functions.recipe_functions import (
@@ -667,6 +675,9 @@ Translation Glossary for LLM Language (English) -> User Langauge
     ) -> typing.Iterator[str | None]:
         yield f"Summarizing with {model.label}..."
 
+        tools_by_name = tools_by_name or {}
+        active_tools_by_name = self._filter_active_tools(tools_by_name)
+
         audio_session_extra = None
         if model.llm_is_audio_model:
             audio_session_extra = {}
@@ -682,7 +693,7 @@ Translation Glossary for LLM Language (English) -> User Langauge
             avoid_repetition=request.avoid_repetition,
             response_format_type=request.response_format_type,
             reasoning_effort=request.reasoning_effort,
-            tools=list(tools_by_name.values()),
+            tools=list(active_tools_by_name.values()),
             stream=True,
             audio_url=request.input_audio,
             audio_session_extra=audio_session_extra,
@@ -711,7 +722,7 @@ Translation Glossary for LLM Language (English) -> User Langauge
             tool_calls = choices[0].get("tool_calls")
             if tool_calls:
                 for call in tool_calls:
-                    tool = tools_by_name[call["function"]["name"]]
+                    tool = active_tools_by_name[call["function"]["name"]]
                     call["label"] = tool.label
                     call["icon"] = tool.get_icon()
                 response.final_prompt[-1]["tool_calls"] = tool_calls
@@ -767,19 +778,24 @@ Translation Glossary for LLM Language (English) -> User Langauge
         if not tool_calls:
             return
         for call in tool_calls:
-            tool, arguments = get_tool_from_call(call["function"], tools_by_name)
+            tool, arguments = get_tool_from_call(call["function"], active_tools_by_name)
             if not arguments:
                 continue
             yield f"🛠 {tool.label}..."
-            output = tool.call_json(arguments)
-            response.final_prompt.append(
-                dict(
-                    role="tool",
-                    content=output,
-                    tool_call_id=call["id"],
-                    run_url=tool.get_url(),
-                ),
-            )
+            try:
+                output = tool.call_json(arguments)
+            except Exception as e:
+                output = json.dumps({"error": str(e)})
+                raise
+            finally:
+                response.final_prompt.append(
+                    dict(
+                        role="tool",
+                        content=output,
+                        tool_call_id=call["id"],
+                        run_url=tool.get_url(),
+                    ),
+                )
 
         yield from self.llm_loop(
             request=request,
@@ -788,6 +804,25 @@ Translation Glossary for LLM Language (English) -> User Langauge
             prev_output_text=output_text,
             tools_by_name=tools_by_name,
         )
+
+    def __init__(self, *args, **kwargs):
+        self._active_tool_names = set()
+        super().__init__(*args, **kwargs)
+
+    def _filter_active_tools(
+        self, tools_by_name: dict[str, BaseLLMTool]
+    ) -> dict[str, BaseLLMTool]:
+        load_tools = LoadToolsLLMTool(tools_by_name, self._active_tool_names)
+        return {
+            load_tools.name: load_tools,
+        } | {
+            tool_name: tool
+            for tool_name, tool in tools_by_name.items()
+            if (
+                tool_name in self._active_tool_names
+                or load_tools.is_first_class_tool(tool)
+            )
+        }
 
     def output_translation_step(self, request, response, output_text):
         from daras_ai_v2.bots import parse_bot_html
@@ -1191,6 +1226,26 @@ PS. This is the workflow that we used to create RadBots - a collection of Turing
     def get_example_preferred_fields(cls, state: dict) -> list[str]:
         return ["input_prompt", "messages"]
 
+    @classmethod
+    def get_tool_call_schema(cls, builder_state: dict) -> dict[str, typing.Any]:
+        properties = super().get_tool_call_schema(builder_state)
+        request = builder_state.get("request", builder_state)
+
+        selected_model = request.get("selected_model")
+        llm_models = (
+            AIModelSpec.objects.filter(
+                category=AIModelSpec.Categories.llm,
+            )
+            .exclude_deprecated(selected_models=selected_model)
+            .order_for_frontend()
+        )
+        properties["selected_model"] = cls.override_nullable_string_enum_schema(
+            properties.get("selected_model", {}),
+            [model.name for model in llm_models],
+        )
+
+        return properties
+
     def render_run_preview_output(self, state: dict):
         from daras_ai_v2.bots import parse_bot_html
 
@@ -1570,18 +1625,41 @@ if (typeof GooeyEmbed !== "undefined" && GooeyEmbed.copilotPreviewControl) {
             gui.write("###### `references`")
             gui.json(references, collapseStringsAfterLength=False)
 
-        tools = list(
-            get_inbuilt_tools_from_state(gui.session_state),
-        )
+        tools_by_name = {
+            tool.name: tool for tool in get_inbuilt_tools_from_state(gui.session_state)
+        }
         if gui.session_state.get("functions"):
             try:
-                tools += list(
-                    get_workflow_tools_from_state(
+                tools_by_name |= {
+                    tool.name: tool
+                    for tool in get_workflow_tools_from_state(
                         gui.session_state, FunctionTrigger.prompt
-                    ),
-                )
+                    )
+                }
             except Exception:
                 pass
+
+        final_prompt = gui.session_state.get("final_prompt")
+        direct_tools = {
+            tool_name: tool
+            for tool_name, tool in tools_by_name.items()
+            if LoadToolsLLMTool.is_first_class_tool(tool)
+        }
+        searched_tools = {
+            tool_name: tool
+            for tool_name, tool in tools_by_name.items()
+            if not LoadToolsLLMTool.is_first_class_tool(tool)
+        }
+        loaded_tool_names = self._get_loaded_tool_names_from_final_prompt(final_prompt)
+        if searched_tools:
+            direct_tools["load_tools"] = LoadToolsLLMTool(
+                searched_tools, loaded_tool_names
+            )
+        for tool_name in loaded_tool_names:
+            tool = searched_tools.get(tool_name)
+            if tool:
+                direct_tools[tool.name] = tool
+        tools = list(direct_tools.values())
         if tools:
             gui.write(f"🛠️ `{FunctionTrigger.prompt.name} functions`")
             gui.json(
@@ -1590,7 +1668,6 @@ if (typeof GooeyEmbed !== "undefined" && GooeyEmbed.copilotPreviewControl) {
                 collapseStringsAfterLength=False,
             )
 
-        final_prompt = gui.session_state.get("final_prompt")
         if final_prompt:
             if isinstance(final_prompt, str):
                 text_output("###### `final_prompt`", value=final_prompt, height=300)
@@ -1612,6 +1689,32 @@ if (typeof GooeyEmbed !== "undefined" && GooeyEmbed.copilotPreviewControl) {
         for idx, audio_url in enumerate(gui.session_state.get("output_audio", [])):
             gui.write(f"###### 🔉 `output_audio[{idx}]`")
             gui.audio(audio_url)
+
+    def _get_loaded_tool_names_from_final_prompt(self, final_prompt) -> list[str]:
+        if not isinstance(final_prompt, list):
+            return []
+
+        loaded_tool_names = []
+        for entry in final_prompt:
+            if not isinstance(entry, dict) or entry.get("role") != "tool":
+                continue
+            content = entry.get("content")
+            if not isinstance(content, str):
+                continue
+            try:
+                payload = json.loads(content)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(payload, dict):
+                continue
+            for tool_name in payload.get("loaded_tools") or []:
+                if not isinstance(tool_name, str):
+                    continue
+                if tool_name in loaded_tool_names:
+                    continue
+                loaded_tool_names.append(tool_name)
+
+        return loaded_tool_names
 
     def get_raw_price(self, state: dict):
         total = get_non_ivr_price_credits(self.current_sr) + self.PROFIT_CREDITS

--- a/recipes/VideoGenPage.py
+++ b/recipes/VideoGenPage.py
@@ -259,8 +259,8 @@ class VideoGenPage(BasePage):
         render_audio_gen_form(self.available_audio_models)
 
     @classmethod
-    def get_update_gui_state_schema(cls, builder_state: dict) -> dict[str, typing.Any]:
-        properties = super().get_update_gui_state_schema(builder_state)
+    def get_tool_call_schema(cls, builder_state: dict) -> dict[str, typing.Any]:
+        properties = super().get_tool_call_schema(builder_state)
         request = builder_state.get("request", builder_state)
 
         selected_models = request.get("selected_models") or []

--- a/tests/test_recipe_functions_schema.py
+++ b/tests/test_recipe_functions_schema.py
@@ -1,0 +1,308 @@
+from types import SimpleNamespace
+
+import pytest
+from pydantic import BaseModel
+
+from ai_models.models import AIModelSpec
+from recipes.DocExtract import DocExtractPage
+from recipes.DocSearch import DocSearchPage
+from recipes.DocSummary import DocSummaryPage
+from recipes.CompareLLM import CompareLLMPage
+from recipes.GoogleGPT import GoogleGPTPage
+from recipes.SEOSummary import SEOSummaryPage
+from recipes.SmartGPT import SmartGPTPage
+from recipes.SocialLookupEmail import SocialLookupEmailPage
+from recipes.VideoBots import VideoBotsPage
+from functions.recipe_functions import WorkflowLLMTool, get_json_type
+
+
+class FakeRequestModel(BaseModel):
+    should_search: bool | None = None
+    search_query: str | None = None
+
+
+class FakePage:
+    RequestModel = FakeRequestModel
+
+    @classmethod
+    def get_example_preferred_fields(cls, state: dict) -> list[str]:
+        return ["search_query"]
+
+    @classmethod
+    def get_example_request(
+        cls,
+        state: dict,
+        pr=None,
+        include_all: bool = False,
+    ) -> tuple[None, dict]:
+        cls.last_include_all = include_all
+        return None, {
+            "should_search": True,
+            "search_query": "weather in sf",
+        }
+
+
+def test_get_json_type_prefers_boolean_over_number():
+    assert get_json_type(True) == "boolean"
+
+
+def test_workflow_llm_tool_description_guides_sparse_updates(monkeypatch):
+    from daras_ai_v2 import workflow_url_input
+
+    monkeypatch.setattr(
+        workflow_url_input,
+        "url_to_runs",
+        lambda function_url: (
+            FakePage,
+            SimpleNamespace(workflow="not-functions", state={}),
+            SimpleNamespace(title="Demo Workflow", notes="Original notes."),
+        ),
+    )
+
+    tool = WorkflowLLMTool("https://example.com/workflow")
+
+    assert "required" not in tool.spec_parameters
+    assert set(tool.spec_parameters["properties"]) == {
+        "should_search",
+        "search_query",
+    }
+    assert tool.spec_parameters["properties"]["should_search"]["type"] == "object"
+    assert (
+        "Use default parameters unless explicitly requested."
+        in tool.spec_function["description"]
+    )
+    assert (
+        "demo_workflow({ should_search = null, search_query = null });"
+        in tool.spec_function["description"]
+    )
+    assert (
+        "It's a bad programming practice if argument equals to the default parameter value."
+        in tool.spec_function["description"]
+    )
+
+
+def test_workflow_llm_tool_description_includes_current_values(monkeypatch):
+    from daras_ai_v2 import workflow_url_input
+
+    monkeypatch.setattr(
+        workflow_url_input,
+        "url_to_runs",
+        lambda function_url: (
+            FakePage,
+            SimpleNamespace(workflow="not-functions", state={}),
+            SimpleNamespace(title="Demo Workflow", notes="Original notes."),
+        ),
+    )
+
+    tool = WorkflowLLMTool("https://example.com/workflow")
+
+    assert (
+        "demo_workflow({ should_search = null, search_query = null });"
+        in tool.spec_function["description"]
+    )
+
+
+def test_workflow_llm_tool_uses_update_gui_state_schema_for_nested_objects(
+    monkeypatch,
+):
+    from daras_ai_v2 import workflow_url_input
+
+    class FakeVideoRequestModel(BaseModel):
+        selected_models: list[str]
+        inputs: dict[str, object]
+
+    class FakeVideoPage:
+        RequestModel = FakeVideoRequestModel
+
+        @classmethod
+        def get_example_preferred_fields(cls, state: dict) -> list[str]:
+            return []
+
+        @classmethod
+        def get_update_gui_state_schema(cls, builder_state: dict) -> dict[str, object]:
+            return {
+                "selected_models": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+                "inputs": {
+                    "type": "object",
+                    "properties": {
+                        "seed": {"type": "number"},
+                        "prompt": {"type": "string"},
+                    },
+                },
+            }
+
+    state = {
+        "selected_models": ["veo-3"],
+        "inputs": {
+            "seed": 0,
+            "prompt": "hello world",
+        },
+    }
+
+    monkeypatch.setattr(
+        workflow_url_input,
+        "url_to_runs",
+        lambda function_url: (
+            FakeVideoPage,
+            SimpleNamespace(workflow="not-functions", state=state),
+            SimpleNamespace(title="Generate Video", notes="Original notes."),
+        ),
+    )
+
+    tool = WorkflowLLMTool("https://example.com/video")
+
+    assert tool.spec_parameters["properties"]["inputs"] == {
+        "description": "",
+        "type": "object",
+        "properties": {
+            "seed": {"type": "number"},
+            "prompt": {"type": "string"},
+        },
+    }
+
+
+@pytest.mark.django_db
+def test_get_llms_for_frontend_includes_selected_deprecated_models():
+    current_model = AIModelSpec.objects.create(
+        name="queryset-llm-current",
+        label="Current LLM",
+        model_id="queryset-llm-current",
+        category=AIModelSpec.Categories.llm,
+    )
+    deprecated_model = AIModelSpec.objects.create(
+        name="queryset-llm-deprecated",
+        label="Deprecated LLM",
+        model_id="queryset-llm-deprecated",
+        category=AIModelSpec.Categories.llm,
+        is_deprecated=True,
+    )
+
+    llm_names = set(
+        AIModelSpec.objects.get_llms_for_frontend(
+            selected_models=deprecated_model.name
+        ).values_list("name", flat=True)
+    )
+
+    assert llm_names >= {
+        current_model.name,
+        deprecated_model.name,
+    }
+
+
+@pytest.mark.django_db
+def test_videobots_tool_call_schema_uses_dynamic_selected_model_enum():
+    current_model = AIModelSpec.objects.create(
+        name="llm-current",
+        label="Current LLM",
+        model_id="llm-current",
+        category=AIModelSpec.Categories.llm,
+    )
+    deprecated_model = AIModelSpec.objects.create(
+        name="llm-deprecated",
+        label="Deprecated LLM",
+        model_id="llm-deprecated",
+        category=AIModelSpec.Categories.llm,
+        is_deprecated=True,
+    )
+
+    schema = VideoBotsPage.get_tool_call_schema(
+        {
+            "selected_model": deprecated_model.name,
+        }
+    )
+
+    selected_model_schema = schema["selected_model"]
+
+    assert "type" not in selected_model_schema
+    assert "enum" not in selected_model_schema
+    assert selected_model_schema["default"] is None
+    assert selected_model_schema["title"] == "Selected Model"
+    assert selected_model_schema["anyOf"][1] == {"type": "null"}
+    assert selected_model_schema["anyOf"][0]["type"] == "string"
+    assert set(selected_model_schema["anyOf"][0]["enum"]) == {
+        current_model.name,
+        deprecated_model.name,
+    }
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "page_cls",
+    [
+        VideoBotsPage,
+        GoogleGPTPage,
+        SEOSummaryPage,
+        DocSummaryPage,
+        SmartGPTPage,
+        DocSearchPage,
+        DocExtractPage,
+        SocialLookupEmailPage,
+    ],
+)
+def test_language_model_selector_recipes_use_dynamic_selected_model_enum(page_cls):
+    current_model = AIModelSpec.objects.create(
+        name=f"{page_cls.__name__}-llm-current",
+        label="Current LLM",
+        model_id=f"{page_cls.__name__}-llm-current",
+        category=AIModelSpec.Categories.llm,
+    )
+    deprecated_model = AIModelSpec.objects.create(
+        name=f"{page_cls.__name__}-llm-deprecated",
+        label="Deprecated LLM",
+        model_id=f"{page_cls.__name__}-llm-deprecated",
+        category=AIModelSpec.Categories.llm,
+        is_deprecated=True,
+    )
+
+    schema = page_cls.get_tool_call_schema({"selected_model": deprecated_model.name})
+
+    selected_model_schema = schema["selected_model"]
+
+    assert "type" not in selected_model_schema
+    assert "enum" not in selected_model_schema
+    assert selected_model_schema["default"] is None
+    assert selected_model_schema["title"] == "Selected Model"
+    assert selected_model_schema["anyOf"][1] == {"type": "null"}
+    assert selected_model_schema["anyOf"][0]["type"] == "string"
+    assert set(selected_model_schema["anyOf"][0]["enum"]) >= {
+        current_model.name,
+        deprecated_model.name,
+    }
+
+
+@pytest.mark.django_db
+def test_compare_llm_tool_call_schema_uses_dynamic_selected_models_enum():
+    current_model = AIModelSpec.objects.create(
+        name="compare-llm-current",
+        label="Current LLM",
+        model_id="compare-llm-current",
+        category=AIModelSpec.Categories.llm,
+    )
+    deprecated_model = AIModelSpec.objects.create(
+        name="compare-llm-deprecated",
+        label="Deprecated LLM",
+        model_id="compare-llm-deprecated",
+        category=AIModelSpec.Categories.llm,
+        is_deprecated=True,
+    )
+
+    schema = CompareLLMPage.get_tool_call_schema(
+        {"selected_models": [deprecated_model.name]}
+    )
+
+    selected_models_schema = schema["selected_models"]
+
+    assert "type" not in selected_models_schema
+    assert "items" not in selected_models_schema
+    assert selected_models_schema["default"] is None
+    assert selected_models_schema["title"] == "Selected Models"
+    assert selected_models_schema["anyOf"][1] == {"type": "null"}
+    assert selected_models_schema["anyOf"][0]["type"] == "array"
+    assert selected_models_schema["anyOf"][0]["items"]["type"] == "string"
+    assert set(selected_models_schema["anyOf"][0]["items"]["enum"]) >= {
+        current_model.name,
+        deprecated_model.name,
+    }

--- a/tests/test_videobots_tool_error_rendering.py
+++ b/tests/test_videobots_tool_error_rendering.py
@@ -1,0 +1,223 @@
+from types import MethodType, SimpleNamespace
+
+import pytest
+
+from functions.inbuilt_tools import LoadToolsLLMTool
+from functions.recipe_functions import BaseLLMTool
+from recipes.VideoBots import VideoBotsPage
+
+
+class FailingTool(BaseLLMTool):
+    icon = "🔥"
+
+    def __init__(self):
+        super().__init__(
+            name="failing_tool",
+            label="Failing Tool",
+            description="Tool that always fails.",
+            properties={},
+        )
+        self.url = "https://example.com/runs/child"
+
+    def call(self, **kwargs):
+        raise RuntimeError("tool exploded")
+
+
+def test_llm_loop_records_failed_tool_output_with_run_url(monkeypatch):
+    def fake_run_language_model(**kwargs):
+        yield [
+            {
+                "content": "Calling the tool now.",
+                "tool_calls": [
+                    {
+                        "id": "call_123",
+                        "function": {
+                            "name": "failing_tool",
+                            "arguments": "{}",
+                        },
+                    }
+                ],
+                "finish_reason": "tool_calls",
+            }
+        ]
+
+    def fake_output_translation_step(self, request, response, output_text):
+        if False:
+            yield None
+        return output_text
+
+    monkeypatch.setattr("recipes.VideoBots.run_language_model", fake_run_language_model)
+
+    page = VideoBotsPage.__new__(VideoBotsPage)
+    page.output_translation_step = MethodType(fake_output_translation_step, page)
+    page._update_searched_tool_names = MethodType(
+        lambda self, tool, arguments: None, page
+    )
+
+    request = SimpleNamespace(
+        max_tokens=100,
+        num_outputs=1,
+        sampling_temperature=0,
+        avoid_repetition=False,
+        response_format_type=None,
+        reasoning_effort=None,
+        input_audio=None,
+        openai_voice_name=None,
+    )
+    response = VideoBotsPage.ResponseModel(
+        final_prompt=[], output_text=[], output_audio=[]
+    )
+    model = SimpleNamespace(
+        name="gpt_4_o_mini",
+        label="GPT-4o Mini",
+        llm_is_audio_model=False,
+    )
+    tool = FailingTool()
+
+    page._active_tool_names = {tool.name}
+
+    with pytest.raises(RuntimeError, match="tool exploded"):
+        list(
+            page.llm_loop(
+                request=request,
+                response=response,
+                model=model,
+                tools_by_name={tool.name: tool},
+            )
+        )
+
+    assert response.final_prompt[-1]["role"] == "tool"
+    assert response.final_prompt[-1]["tool_call_id"] == "call_123"
+    assert response.final_prompt[-1]["run_url"] == "https://example.com/runs/child"
+    assert "tool exploded" in response.final_prompt[-1]["content"]
+
+
+def test_llm_loop_uses_active_tools_for_load_tools_metadata(monkeypatch):
+    active_tool_names = set()
+    LoadToolsLLMTool({"failing_tool": FailingTool()}, active_tool_names)
+    calls = 0
+
+    def fake_run_language_model(**kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            yield [
+                {
+                    "content": "Loading the tool schema.",
+                    "tool_calls": [
+                        {
+                            "id": "call_search",
+                            "function": {
+                                "name": "load_tools",
+                                "arguments": '{"tool_names":["failing_tool"]}',
+                            },
+                        }
+                    ],
+                    "finish_reason": "tool_calls",
+                }
+            ]
+            return
+
+        yield [
+            {
+                "content": "Schema loaded.",
+                "finish_reason": "stop",
+            }
+        ]
+
+    def fake_output_translation_step(self, request, response, output_text):
+        if False:
+            yield None
+        return output_text
+
+    monkeypatch.setattr("recipes.VideoBots.run_language_model", fake_run_language_model)
+
+    page = VideoBotsPage.__new__(VideoBotsPage)
+    page.output_translation_step = MethodType(fake_output_translation_step, page)
+    page._active_tool_names = active_tool_names
+
+    request = SimpleNamespace(
+        max_tokens=100,
+        num_outputs=1,
+        sampling_temperature=0,
+        avoid_repetition=False,
+        response_format_type=None,
+        reasoning_effort=None,
+        input_audio=None,
+        openai_voice_name=None,
+    )
+    response = VideoBotsPage.ResponseModel(
+        final_prompt=[], output_text=[], output_audio=[]
+    )
+    model = SimpleNamespace(
+        name="gpt_4_o_mini",
+        label="GPT-4o Mini",
+        llm_is_audio_model=False,
+    )
+
+    list(
+        page.llm_loop(
+            request=request,
+            response=response,
+            model=model,
+            tools_by_name={"failing_tool": FailingTool()},
+        )
+    )
+
+    assistant_entries = [
+        entry for entry in response.final_prompt if entry.get("role") == "assistant"
+    ]
+    load_tools_calls = [
+        call
+        for entry in assistant_entries
+        for call in entry.get("tool_calls", [])
+        if call["function"]["name"] == "load_tools"
+    ]
+
+    assert load_tools_calls
+    assert load_tools_calls[0]["label"] == "Load Tools"
+    assert any(
+        entry.get("role") == "tool" and entry.get("tool_call_id") == "call_search"
+        for entry in response.final_prompt
+    )
+
+
+def test_load_tools_schema_enums_available_tool_names():
+    from functions.composio_tools import ComposioLLMTool
+    from functions.recipe_functions import WorkflowLLMTool
+
+    workflow_tool = WorkflowLLMTool.__new__(WorkflowLLMTool)
+    workflow_tool.name = "workflow_tool"
+    workflow_tool.label = "Workflow Tool"
+    workflow_tool.description = "Loaded workflow tool."
+    workflow_tool.catalog_description = "Catalog workflow tool."
+    workflow_tool.spec_parameters = {
+        "properties": {
+            "workflow_arg": {"type": "string"},
+            "other_arg": {"type": "number"},
+        }
+    }
+
+    composio_tool = ComposioLLMTool.__new__(ComposioLLMTool)
+    composio_tool.name = "composio_tool"
+    composio_tool.label = "Composio Tool"
+    composio_tool.description = "Loaded composio tool."
+    composio_tool.spec_parameters = {"properties": {}}
+
+    load_tools = LoadToolsLLMTool(
+        {
+            "workflow_tool": workflow_tool,
+            "composio_tool": composio_tool,
+            "failing_tool": FailingTool(),
+        },
+        set(),
+    )
+
+    assert load_tools.spec_parameters["properties"]["tool_names"]["items"]["enum"] == [
+        "composio_tool",
+        "workflow_tool",
+    ]
+    assert "`composio_tool`" in load_tools.description
+    assert "params: none" in load_tools.description
+    assert "workflow_tool" in load_tools.description
+    assert "params: `workflow_arg`, `other_arg`" in load_tools.description


### PR DESCRIPTION
## Summary
- add a `tool_search` router to VideoBots so the model loads tool schemas on demand instead of receiving every tool up front
- keep requested tools available across recursive tool-calling turns and support requesting multiple tools in one router call
- expose full input fields for internal workflow tools while describing preferred fields as guidance in the tool description

## Test Plan
- [x] `ruff check recipes/VideoBots.py functions/recipe_functions.py`
- [ ] Exercise a VideoBots flow end-to-end with real tool calls in the app
- [ ] Verify internal workflow tools still choose sensible fields with the new full-schema exposure

Made with [Cursor](https://cursor.com)