### PR TITLE
fix: default seat count in team plan to next highest when not in options

### DIFF
--- a/daras_ai_v2/billing.py
+++ b/daras_ai_v2/billing.py
@@ -35,6 +35,8 @@ from workspaces.widgets import open_create_workspace_popup_js, set_current_works
 rounded_border = "w-100 border shadow-sm rounded p-3"
 SeatSelection = tuple[SeatType, int]
 
+SEAT_COUNT_OPTIONS = [2, 3, 4, 5, 10, 15, 20, 25, 50]
+
 
 def _get_team_tier_upgrade_prorated_amount(
     workspace: Workspace,
@@ -689,16 +691,25 @@ def _render_seat_selection(plan: PricingPlan, workspace: Workspace) -> SeatSelec
         selected_seat_type = seat_options[seat_type_id]
 
     if plan == PricingPlan.TEAM:
+        default_seat_count = (
+            workspace.subscription
+            and workspace.subscription.billed_seats().count()
+            or max(workspace.used_seats, 1)
+        )
+        if (
+            default_seat_count not in SEAT_COUNT_OPTIONS
+            and default_seat_count < SEAT_COUNT_OPTIONS[-1]
+        ):
+            default_seat_count = next(
+                c for c in SEAT_COUNT_OPTIONS if c > default_seat_count
+            )
+
         with col2:
             count = gui.selectbox(
                 label="Seats",
-                options=[2, 3, 4, 5, 10, 15, 20, 25, 50],
+                options=SEAT_COUNT_OPTIONS,
                 key=f"seat-count-select-{plan.key}-{workspace.id}",
-                value=(
-                    workspace.subscription
-                    and workspace.subscription.billed_seats().count()
-                    or max(workspace.used_seats, 1)
-                ),
+                value=default_seat_count,
                 className="mb-0 container-margin-reset",
             )
     else:
@@ -768,30 +779,35 @@ def _render_plan_action_button(
         and seat_selection
         and seat_selection[1] < workspace.used_seats
     ):
+        min_allowed_seat_count = next(
+            (c for c in SEAT_COUNT_OPTIONS if c >= workspace.used_seats),
+            SEAT_COUNT_OPTIONS[-1],
+        )
+
         with gui.div(className="d-flex p-3 pb-0 gap-2 alert alert-danger text-black"):
             # fire emoji
             gui.write("🔥")
             with gui.div():
                 gui.write(
                     f"""
-                    You are currently using {workspace.used_seats} seats.
-                    Please select at least {workspace.used_seats} seats or remove some members.
+                    You currently have {workspace.used_seats} members in your team.
+                    Please select a plan with at least {workspace.used_seats} seats or remove some members.
                     """
                 )
                 with gui.div(className="d-flex align-items-center gap-2"):
                     if gui.button(
-                        f"Stay at {workspace.used_seats} seats",
+                        f"Stay at {min_allowed_seat_count} seats",
                         type="link",
                         className="fw-normal",
                     ):
                         gui.session_state[
                             f"seat-count-select-{plan.key}-{workspace.id}"
-                        ] = workspace.used_seats
+                        ] = min_allowed_seat_count
                         raise gui.RerunException()
                     gui.write("|")
                     gui.write(
                         f"""
-                        [Edit Members]({get_route_path(members_route)})
+                        [Remove Members]({get_route_path(members_route)})
                         """
                     )
 


### PR DESCRIPTION
### Q/A checklist

- [ ] I have tested my UI changes on mobile and they look acceptable
- [ ] I have tested changes to the workflows in both the API and the UI
- [ ] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [ ] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
