### PR TITLE
refactor: centralize workflow tool schema generation

### DIFF
--- a/.agents/test-workflows-in-process/SKILL.md
+++ b/.agents/test-workflows-in-process/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: test-workflows-in-process
+description: Use when reproducing or inspecting Gooey workflow behavior locally without the browser, especially for capturing VideoBots prompts, tool-call traces, workflow-tool arguments, or comparing prompt/schema changes against a published run.
+---
+
+# Test Workflows In Process
+
+## Overview
+Run Gooey workflows directly in Python against real published-run state when you need prompt and tool-call evidence faster than a browser or API round-trip.
+
+Core principle: reproduce the real workflow state first, then stub downstream workflow execution only if you need prompt/tool traces without waiting for the called workflow to finish.
+
+## When To Use
+- You need the exact `final_prompt` sent to the LLM.
+- You need raw `tool_calls` emitted by `VideoBotsPage`.
+- You want to compare prompt/schema changes against the same published run.
+- A downstream workflow is slow or flaky, but you still need the tool arguments.
+- You want to inspect a published copilot URL like `/copilot/<slug>-<example_id>/`.
+
+Do not use this when the behavior depends on browser-only UI interactions. Use browser testing for that.
+
+## Setup
+
+```python
+__import__("gooeysite.wsgi")
+```
+
+## Workflow Pattern
+1. Parse the published run ID from the URL.
+2. Build the page class directly, usually `VideoBotsPage(...)`.
+3. Load real state with `page.current_sr_to_session_state()`.
+4. Override only the fields needed for the experiment:
+   - `messages`
+   - `input_prompt`
+   - `output_text`
+   - `raw_output_text`
+   - `final_prompt`
+   - `output_audio`
+5. Call `gui.set_session_state(state)`.
+6. Patch `get_current_workspace()` to return the published-run workspace.
+7. Run `page.run(gui.session_state)`.
+8. Read `gui.session_state["final_prompt"]`, `output_text`, and any assistant `tool_calls`.
+
+## Base Script Template
+
+```python
+__import__("gooeysite.wsgi")
+
+import json
+
+import gooey_gui as gui
+from starlette.datastructures import URL
+from unittest.mock import patch
+
+from bots.models import get_default_published_run_workspace
+from recipes.VideoBots import VideoBotsPage
+from workspaces.models import Workspace
+
+example_id = "v1xm6uhp"
+request_url = URL("http://localhost:3000/copilot/base-copilot-w-search-rag-code-execution-v1xm6uhp/")
+workspace = Workspace.objects.get(id=get_default_published_run_workspace())
+user = workspace.created_by
+
+page = VideoBotsPage(
+    user=user,
+    request_session={},
+    request_url=request_url,
+    query_params={"example_id": example_id, "uid": user.uid},
+)
+
+state = page.current_sr_to_session_state()
+state.update(
+    {
+        "messages": [],
+        "input_prompt": "Your test input here",
+        "output_text": [],
+        "raw_output_text": [],
+        "final_prompt": [],
+        "output_audio": [],
+    }
+)
+gui.set_session_state(state)
+
+progress = []
+with patch("daras_ai_v2.base.get_current_workspace", return_value=workspace):
+    for step in page.run(gui.session_state):
+        if step:
+            progress.append(step)
+
+final_state = dict(gui.session_state)
+print(json.dumps(
+    {
+        "progress": progress,
+        "final_prompt": final_state.get("final_prompt"),
+        "output_text": final_state.get("output_text"),
+        "error_msg": final_state.get("error_msg"),
+    },
+    indent=2,
+    default=str,
+))
+```
+
+## Capturing Tool Traces
+To capture assistant-emitted tool calls from `VideoBotsPage`:
+
+```python
+assistant_entries = [
+    entry for entry in final_state.get("final_prompt", [])
+    if entry.get("role") == "assistant"
+]
+
+trace = []
+for entry in assistant_entries:
+    for call in entry.get("tool_calls") or []:
+        trace.append(
+            {
+                "id": call.get("id"),
+                "name": call.get("function", {}).get("name"),
+                "arguments": call.get("function", {}).get("arguments"),
+                "label": call.get("label"),
+                "content": entry.get("content"),
+            }
+        )
+```
+
+## Stubbing Workflow Tools
+If a workflow tool is slow or triggers another full run, stub `WorkflowLLMTool.call` and capture its kwargs instead of executing it:
+
+```python
+from functions.recipe_functions import WorkflowLLMTool
+
+captured_calls = []
+
+def fake_call(self, **kwargs):
+    captured_calls.append(
+        {
+            "name": self.name,
+            "label": self.label,
+            "description": self.spec_function["description"],
+            "kwargs": kwargs,
+            "spec_parameters": self.spec_parameters,
+        }
+    )
+    return {"stubbed": True, "tool_name": self.name, "kwargs": kwargs}
+
+with (
+    patch("daras_ai_v2.base.get_current_workspace", return_value=workspace),
+    patch.object(WorkflowLLMTool, "call", fake_call),
+):
+    for step in page.run(gui.session_state):
+        ...
+```
+
+Use this when you care about:
+- the exact tool arguments
+- the tool description/schema shown to the model
+- the final prompt and assistant text
+
+## Editing The Copilot Prompt For Experiments
+To test prompt sensitivity without modifying saved workflow data, edit `state["bot_script"]` in memory before `gui.set_session_state(state)`.
+
+Good use cases:
+- remove one tool instruction block
+- rewrite one tool hint
+- compare before/after prompt wording
+
+## Reporting Format
+When you finish, report:
+- the workflow URL or `example_id`
+- the exact user input sequence used
+- the relevant system prompt excerpt
+- the raw `tool_call_trace`
+- the captured workflow-tool kwargs if stubbing
+- whether the downstream workflow was real or stubbed
+- the resulting `output_text`
+
+## Common Pitfalls
+- Anonymous users fail when tool binding needs a workspace. Use the published-run owner workspace and patch `get_current_workspace()`.
+- Real workflow execution can hang or run long. Stub `WorkflowLLMTool.call` when you only need tool traces.
+- Clear `messages`, `final_prompt`, and output fields between experiments or you will mix traces.
+- If comparing prompt variants, keep the same `example_id` and same user-turn sequence.

--- a/ai_models/llm_openapi.py
+++ b/ai_models/llm_openapi.py
@@ -1,0 +1,32 @@
+import typing
+
+from pydantic import Field
+
+from ai_models.models import AIModelSpec
+
+_LLM_MODEL_MARKER = "x-gooey-llm-model"
+
+LLMModelField = typing.Annotated[
+    str,
+    Field(json_schema_extra={_LLM_MODEL_MARKER: True}),
+]
+
+
+def patch_llm_model_schema_enums(
+    schema: dict | list[typing.Any], llm_model_names: list[str] | None = None
+) -> None:
+    match schema:
+        case dict():
+            if schema.pop(_LLM_MODEL_MARKER, None):
+                if llm_model_names is None:
+                    llm_model_names = list(
+                        AIModelSpec.objects.get_llms_for_frontend().values_list(
+                            "name", flat=True
+                        )
+                    )
+                schema["enum"] = llm_model_names
+            for value in schema.values():
+                patch_llm_model_schema_enums(value, llm_model_names)
+        case list():
+            for item in schema:
+                patch_llm_model_schema_enums(item, llm_model_names)

--- a/ai_models/models.py
+++ b/ai_models/models.py
@@ -59,6 +59,17 @@ class ModelProvider(models.IntegerChoices):
 
 
 class AIModelSpecQuerySet(models.QuerySet):
+    def get_llms_for_frontend(self, *, selected_models: list[str] | str | None = None):
+        return (
+            self.filter(
+                category=AIModelSpec.Categories.llm,
+            )
+            .exclude_deprecated(
+                selected_models=selected_models,
+            )
+            .order_for_frontend()
+        )
+
     def exclude_deprecated(self, *, selected_models: list[str] | str | None = None):
         q = Q(is_deprecated=False)
         if selected_models:

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -52,6 +52,10 @@ from daras_ai_v2.grid_layout_widget import grid_layout
 from daras_ai_v2.html_spinner_widget import html_spinner
 from daras_ai_v2.manage_api_keys_widget import manage_api_keys
 from daras_ai_v2.meta_preview_url import meta_preview_url
+from daras_ai_v2.openapi_tricks import (
+    patch_custom_schema_pydantic,
+    get_full_pydantic_schema,
+)
 from daras_ai_v2.query_params_util import extract_query_params
 from daras_ai_v2.ratelimits import RateLimitExceeded, ensure_rate_limits
 from daras_ai_v2.send_email import send_reported_run_email
@@ -2544,10 +2548,10 @@ class BasePage:
         return []
 
     @classmethod
-    def get_update_gui_state_schema(cls, builder_state: dict) -> dict[str, typing.Any]:
-        """Return top-level request properties for the builder's update_gui_state tool."""
-        schema = cls.RequestModel.model_json_schema(ref_template="{model}")
-        return schema["properties"]
+    def get_tool_call_schema(cls, request: dict) -> dict[str, typing.Any]:
+        """Return top-level request properties for tool calling schema."""
+        properties = get_full_pydantic_schema(cls.RequestModel)
+        return patch_custom_schema_pydantic(properties, request)
 
     @classmethod
     def get_example_request(

--- a/daras_ai_v2/language_model_openai_audio.py
+++ b/daras_ai_v2/language_model_openai_audio.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import base64
 import tempfile
 import threading
-import typing
 
 from furl import furl
 from websockets.exceptions import ConnectionClosed

--- a/daras_ai_v2/language_model_settings_widgets.py
+++ b/daras_ai_v2/language_model_settings_widgets.py
@@ -56,14 +56,8 @@ def language_model_selector(
     label_visibility: str = "visible",
     key: str = "selected_model",
 ):
-    llm_models = (
-        AIModelSpec.objects.filter(
-            category=AIModelSpec.Categories.llm,
-        )
-        .exclude_deprecated(
-            selected_models=gui.session_state.get(key),
-        )
-        .order_for_frontend()
+    llm_models = AIModelSpec.objects.get_llms_for_frontend(
+        selected_models=gui.session_state.get(key)
     )
     options = {model.name: model.display_html() for model in llm_models}
     return gui.selectbox(

--- a/daras_ai_v2/openapi_tricks.py
+++ b/daras_ai_v2/openapi_tricks.py
@@ -1,0 +1,69 @@
+import asyncio
+import typing
+
+from asgiref.sync import sync_to_async
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from ai_models.llm_openapi import patch_llm_model_schema_enums
+
+
+def patch_custom_schema_fastapi(app: FastAPI):
+    if getattr(app, "_is_openapi_patched", False):
+        return
+
+    app._openapi_old = app.openapi
+
+    def custom_openapi():
+        schema = app._openapi_old()
+        loop = asyncio.get_running_loop()
+        loop.create_task(patch_openapi_full(schema))
+        return schema
+
+    custom_openapi()
+    app.openapi = custom_openapi
+    app._is_openapi_patched = True
+
+
+@sync_to_async
+def patch_openapi_full(openapi_schema) -> dict:
+    components = openapi_schema.get("components") or {}
+    schemas = components.get("schemas") or {}
+    return patch_custom_schema_pydantic(schemas)
+
+
+def patch_custom_schema_pydantic(schema: dict, request: dict | None = None) -> dict:
+    patch_llm_model_schema_enums(schema)
+    return schema
+
+
+def get_full_pydantic_schema(model: typing.Type[BaseModel]) -> dict:
+    schema = model.model_json_schema(ref_template="{model}")
+    return inline_pydantic_schema_refs(schema["properties"], schema.get("$defs", {}))
+
+
+def inline_pydantic_schema_refs(
+    schema: dict[str, typing.Any],
+    defs: dict[str, typing.Any],
+) -> dict[str, typing.Any]:
+    if not isinstance(schema, dict):
+        return schema
+
+    ref = schema.get("$ref")
+    if ref:
+        resolved = defs.get(ref, {}).copy()
+        if not resolved:
+            return schema
+        schema.clear()
+        schema.update(resolved)
+
+    for key, value in schema.items():
+        match value:
+            case dict():
+                schema[key] = inline_pydantic_schema_refs(value, defs)
+            case list():
+                schema[key] = [
+                    inline_pydantic_schema_refs(item, defs) for item in value
+                ]
+
+    return schema

--- a/daras_ai_v2/variables_widget.py
+++ b/daras_ai_v2/variables_widget.py
@@ -1,7 +1,6 @@
 import json
 import typing
 from datetime import datetime
-from functools import partial
 from types import SimpleNamespace
 
 import gooey_gui as gui

--- a/functions/inbuilt_tools.py
+++ b/functions/inbuilt_tools.py
@@ -131,13 +131,13 @@ class UpdateGuiStateLLMTool(BaseLLMTool):
     def __init__(self, builder_state: dict, page_slug: str):
         from daras_ai_v2.all_pages import normalize_slug, page_slug_map
 
+        request = builder_state.get("request", builder_state)
         try:
             page_cls = page_slug_map[normalize_slug(page_slug)]
         except KeyError:
-            request = builder_state.get("request", builder_state)
             properties = dict(generate_tool_properties(request, {}))
         else:
-            properties = page_cls.get_update_gui_state_schema(builder_state)
+            properties = page_cls.get_tool_call_schema(request)
 
         properties["-submit-workflow"] = {
             "type": "boolean",

--- a/functions/recipe_functions.py
+++ b/functions/recipe_functions.py
@@ -10,8 +10,13 @@ from app_users.models import AppUser
 from daras_ai_v2 import icons
 from daras_ai_v2.enum_selector_widget import enum_selector
 from daras_ai_v2.field_render import field_title_desc
-from functions.models import CalledFunction, FunctionScopes, FunctionTrigger
+from functions.models import (
+    CalledFunction,
+    FunctionScopes,
+    FunctionTrigger,
+)
 from widgets.switch_with_section import switch_with_section
+import textwrap
 
 if typing.TYPE_CHECKING:
     from bots.models import PublishedRun, SavedRun
@@ -92,28 +97,28 @@ class WorkflowLLMTool(BaseLLMTool):
     def __init__(self, function_url: str):
         from bots.models import Workflow
         from daras_ai_v2.workflow_url_input import url_to_runs
+        from daras_ai_v2.base import extract_model_fields
 
         self.function_url = function_url
 
         self.page_cls, self.fn_sr, self.fn_pr = url_to_runs(function_url)
         self._fn_runs = (self.fn_sr, self.fn_pr)
 
+        self.name = slugify(self.fn_pr.title).replace("-", "_")
+
         self.is_function_workflow = self.fn_sr.workflow == Workflow.FUNCTIONS
         if self.is_function_workflow:
             fn_vars = self.fn_sr.state.get("variables", {})
             fn_vars_schema = self.fn_sr.state.get("variables_schema", {})
+            properties = dict(generate_tool_properties(fn_vars, fn_vars_schema))
         else:
-            fn_vars = self.page_cls.get_example_request(self.fn_sr.state, self.fn_pr)[1]
-            fn_vars_schema = self.page_cls.RequestModel.model_json_schema().get(
-                "properties", {}
-            )
-        properties = dict(generate_tool_properties(fn_vars, fn_vars_schema))
+            fn_vars = extract_model_fields(self.page_cls.RequestModel, self.fn_sr.state)
+            properties = self.page_cls.get_tool_call_schema(self.fn_sr.state)
 
-        name = slugify(self.fn_pr.title).replace("-", "_")
         super().__init__(
-            name=name,
-            label=self.fn_pr.title or name,
-            description=self.fn_pr.notes,
+            name=self.name,
+            label=self.fn_pr.title or self.name,
+            description=self._build_workflow_description(fn_vars),
             properties=properties,
         )
 
@@ -243,6 +248,15 @@ class WorkflowLLMTool(BaseLLMTool):
                 return function.get("scope")
         return None
 
+    def _build_workflow_description(self, fn_vars: dict) -> str:
+        description = (
+            self.fn_pr.notes
+            + "\n\nUse default parameters unless explicitly requested. "
+            "It's a bad programming practice if argument equals to the default parameter value. "
+        )
+        params = [f"{k} = {json.dumps(v)}" for k, v in fn_vars.items()]
+        return render_fn_pseudocode(self.name, description, params)
+
     def _get_system_vars(self) -> tuple[dict, dict]:
         request = self.request_model.model_validate(self.state)
         system_vars = dict(
@@ -344,7 +358,7 @@ def get_nested_type(val, schema=None) -> dict[str, typing.Any]:
     if json_type == "array":
         try:
             return {"type": "array", "items": get_nested_type(val[0])}
-        except IndexError:
+        except (IndexError, TypeError):
             return {"type": "array", "items": {"type": "object"}}
     else:
         return {"type": json_type}
@@ -352,16 +366,22 @@ def get_nested_type(val, schema=None) -> dict[str, typing.Any]:
 
 def get_json_type(val) -> "JsonTypes":
     match val:
+        case bool():
+            return "boolean"
         case str():
             return "string"
         case int() | float() | complex():
             return "number"
-        case bool():
-            return "boolean"
         case list() | tuple() | set():
             return "array"
         case _:
             return "object"
+
+
+def render_fn_pseudocode(name: str, description: str, params: list[str]) -> str:
+    description = textwrap.indent(description, " * ", predicate=lambda line: True)
+    params_str = ", ".join(params)
+    return "/**\n" + description + "\n */\n" + name + "({ " + params_str + " });"
 
 
 def is_functions_enabled(key="functions") -> bool:

--- a/gooey_gui/components/input_widgets.py
+++ b/gooey_gui/components/input_widgets.py
@@ -1,13 +1,7 @@
-import base64
-import html as html_lib
-import math
-import textwrap
 import typing
-from datetime import datetime, timezone
+from datetime import datetime
 
-from furl import furl
 from gooey_gui import core
-from loguru import logger
 
 from .common import LabelVisibility, TooltipPlacement, dedent
 

--- a/gooey_gui/core/reloader.py
+++ b/gooey_gui/core/reloader.py
@@ -1,8 +1,6 @@
 import asyncio
-import importlib
 import logging
 import sys
-from time import time
 import traceback
 from copy import copy
 from pathlib import Path

--- a/livekit_agent.py
+++ b/livekit_agent.py
@@ -28,7 +28,6 @@ from livekit.agents import (
     CloseEvent,
     ConversationItemAddedEvent,
     ErrorEvent,
-    RoomInputOptions,
     function_tool,
     stt,
     tts,

--- a/number_cycling/utils.py
+++ b/number_cycling/utils.py
@@ -1,13 +1,10 @@
-import random
 import re
 
-import hashids
 import phonenumbers
 from django.db import IntegrityError, transaction
 
 from bots.models.bot_integration import BotIntegration, Platform
-from daras_ai_v2 import settings
-from number_cycling.models import SharedPhoneNumber, SharedPhoneNumberBotUser
+from number_cycling.models import SharedPhoneNumber
 from workspaces.models import Workspace
 import secrets
 

--- a/recipes/CompareLLM.py
+++ b/recipes/CompareLLM.py
@@ -5,6 +5,7 @@ import typing
 import gooey_gui as gui
 from pydantic import BaseModel
 
+from ai_models.llm_openapi import LLMModelField
 from ai_models.models import AIModelSpec
 from bots.models import Workflow
 from daras_ai_v2.base import BasePage
@@ -37,7 +38,7 @@ class CompareLLMPage(BasePage):
 
     class RequestModelBase(BasePage.RequestModel):
         input_prompt: str | None = None
-        selected_models: list[str] | None = None
+        selected_models: list[LLMModelField] | None = None
 
     class RequestModel(LanguageModelSettings, RequestModelBase):
         pass
@@ -58,14 +59,8 @@ class CompareLLMPage(BasePage):
             help="Supports [Jinja](https://jinja.palletsprojects.com/en/stable/templates/) templating",
         )
 
-        llm_models = (
-            AIModelSpec.objects.filter(
-                category=AIModelSpec.Categories.llm,
-            )
-            .exclude_deprecated(
-                selected_models=gui.session_state.get("selected_models"),
-            )
-            .order_for_frontend()
+        llm_models = AIModelSpec.objects.get_llms_for_frontend(
+            selected_models=gui.session_state.get("selected_models")
         )
         options = {model.name: model.display_html() for model in llm_models}
         gui.multiselect(

--- a/recipes/DocExtract.py
+++ b/recipes/DocExtract.py
@@ -9,6 +9,7 @@ from django.db.models import IntegerChoices
 from furl import furl
 from pydantic import BaseModel, Field
 
+from ai_models.llm_openapi import LLMModelField
 from bots.models import Workflow
 from daras_ai.image_input import upload_file_from_bytes
 from daras_ai_v2 import settings
@@ -92,7 +93,7 @@ class DocExtractPage(BasePage):
 
         sheet_url: OptionalHttpUrlStr = None
 
-        selected_model: str | None = None
+        selected_model: LLMModelField | None = None
         document_model: str | None = Field(
             "azure-prebuilt-layout",
             title="🩻 Document Intelligence Model",

--- a/recipes/DocSearch.py
+++ b/recipes/DocSearch.py
@@ -3,6 +3,7 @@ import typing
 
 import gooey_gui as gui
 from ai_models.models import AIModelSpec
+from ai_models.llm_openapi import LLMModelField
 from bots.models import Workflow
 from daras_ai_v2.base import BasePage
 from daras_ai_v2.doc_search_settings_widgets import (
@@ -68,7 +69,7 @@ class DocSearchPage(BasePage):
         task_instructions: str | None = None
         query_instructions: str | None = None
         check_document_updates: bool | None = None
-        selected_model: str | None = None
+        selected_model: LLMModelField | None = None
 
         citation_style: typing.Literal[tuple(e.name for e in CitationStyles)] | None = (
             None

--- a/recipes/DocSummary.py
+++ b/recipes/DocSummary.py
@@ -5,6 +5,7 @@ import gooey_gui as gui
 from pydantic import BaseModel
 
 from ai_models.models import AIModelSpec
+from ai_models.llm_openapi import LLMModelField
 from bots.models import Workflow
 from daras_ai_v2.asr import AsrModels
 from daras_ai_v2.base import BasePage
@@ -64,7 +65,7 @@ class DocSummaryPage(BasePage):
         task_instructions: str | None = None
         merge_instructions: str | None = None
 
-        selected_model: str | None = None
+        selected_model: LLMModelField | None = None
 
         chain_type: (
             typing.Literal[tuple(e.name for e in CombineDocumentsChains)] | None

--- a/recipes/GoogleGPT.py
+++ b/recipes/GoogleGPT.py
@@ -5,6 +5,7 @@ from furl import furl
 from pydantic import BaseModel, Field
 
 from ai_models.models import AIModelSpec
+from ai_models.llm_openapi import LLMModelField
 from bots.models import Workflow
 from daras_ai_v2.base import BasePage
 from daras_ai_v2.doc_search_settings_widgets import (
@@ -88,7 +89,7 @@ class GoogleGPTPage(BasePage):
         task_instructions: str | None = None
         query_instructions: str | None = None
 
-        selected_model: str | None = None
+        selected_model: LLMModelField | None = None
         check_document_updates: bool | None = None
         max_search_urls: int | None = None
 

--- a/recipes/SEOSummary.py
+++ b/recipes/SEOSummary.py
@@ -10,6 +10,7 @@ from loguru import logger
 from pydantic import BaseModel
 
 from ai_models.models import AIModelSpec
+from ai_models.llm_openapi import LLMModelField
 from bots.models import Workflow
 from daras_ai_v2.base import BasePage
 from daras_ai_v2.exceptions import raise_for_status
@@ -91,7 +92,7 @@ class SEOSummaryPage(BasePage):
 
         enable_html: bool | None = None
 
-        selected_model: str | None = None
+        selected_model: LLMModelField | None = None
 
         max_search_urls: int | None = None
 

--- a/recipes/SmartGPT.py
+++ b/recipes/SmartGPT.py
@@ -4,6 +4,7 @@ import jinja2.sandbox
 from pydantic import BaseModel
 
 import gooey_gui as gui
+from ai_models.llm_openapi import LLMModelField
 from bots.models import Workflow
 from daras_ai_v2.base import BasePage
 from daras_ai_v2.functional import map_parallel
@@ -35,7 +36,7 @@ class SmartGPTPage(BasePage):
         reflexion_prompt: str | None = None
         dera_prompt: str | None = None
 
-        selected_model: str | None = None
+        selected_model: LLMModelField | None = None
 
     class RequestModel(LanguageModelSettings, RequestModelBase):
         pass

--- a/recipes/SocialLookupEmail.py
+++ b/recipes/SocialLookupEmail.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 
 import gooey_gui as gui
 from ai_models.models import AIModelSpec
+from ai_models.llm_openapi import LLMModelField
 from bots.models import Workflow
 from daras_ai.text_format import daras_ai_format_str
 from daras_ai_v2 import settings
@@ -52,7 +53,7 @@ class SocialLookupEmailPage(BasePage):
         # domain: str | None
         # key_words: str | None
 
-        selected_model: str | None = None
+        selected_model: LLMModelField | None = None
 
     class RequestModel(LanguageModelSettings, RequestModelBase):
         pass

--- a/recipes/VideoBots.py
+++ b/recipes/VideoBots.py
@@ -9,6 +9,7 @@ from django.db.models import Q, QuerySet
 from furl import furl
 from pydantic import BaseModel, Field
 
+from ai_models.llm_openapi import LLMModelField
 from ai_models.models import AIModelSpec
 from bots.models import (
     BotIntegration,
@@ -226,7 +227,7 @@ class VideoBotsPage(BasePage):
         )
 
         # llm model
-        selected_model: str | None = None
+        selected_model: LLMModelField | None = None
         document_model: str | None = Field(
             None,
             title="🩻 Photo / Document Intelligence",
@@ -370,7 +371,12 @@ Translation Glossary for LLM Language (English) -> User Langauge
             llm_model = AIModelSpec.objects.get(name=request.selected_model)
         except AIModelSpec.DoesNotExist:
             raise UserError(
-                f"Model {request.selected_model} not found. Should be one of: {AIModelSpec.objects.filter(category=AIModelSpec.Categories.llm).values_list('name', flat=True)}"
+                f"Model {request.selected_model} not found. Should be one of: "
+                + ", ".join(
+                    AIModelSpec.objects.filter(
+                        category=AIModelSpec.Categories.llm
+                    ).values_list("name", flat=True)
+                )
             )
         user_input = (request.input_prompt or "").strip()
         if not (
@@ -771,15 +777,20 @@ Translation Glossary for LLM Language (English) -> User Langauge
             if not arguments:
                 continue
             yield f"🛠 {tool.label}..."
-            output = tool.call_json(arguments)
-            response.final_prompt.append(
-                dict(
-                    role="tool",
-                    content=output,
-                    tool_call_id=call["id"],
-                    run_url=tool.get_url(),
-                ),
-            )
+            try:
+                output = tool.call_json(arguments)
+            except Exception as e:
+                output = json.dumps({"error": str(e)})
+                raise
+            finally:
+                response.final_prompt.append(
+                    dict(
+                        role="tool",
+                        content=output,
+                        tool_call_id=call["id"],
+                        run_url=tool.get_url(),
+                    ),
+                )
 
         yield from self.llm_loop(
             request=request,

--- a/recipes/VideoGenPage.py
+++ b/recipes/VideoGenPage.py
@@ -259,9 +259,8 @@ class VideoGenPage(BasePage):
         render_audio_gen_form(self.available_audio_models)
 
     @classmethod
-    def get_update_gui_state_schema(cls, builder_state: dict) -> dict[str, typing.Any]:
-        properties = super().get_update_gui_state_schema(builder_state)
-        request = builder_state.get("request", builder_state)
+    def get_tool_call_schema(cls, request: dict) -> dict[str, typing.Any]:
+        properties = super().get_tool_call_schema(request)
 
         selected_models = request.get("selected_models") or []
         video_models = AIModelSpec.objects.filter(name__in=selected_models)

--- a/scripts/init_llm_models.py
+++ b/scripts/init_llm_models.py
@@ -1,5 +1,3 @@
-import typing
-from enum import Enum
 from django.db import transaction
 from ai_models.models import AIModelSpec, ModelProvider
 

--- a/server.py
+++ b/server.py
@@ -48,12 +48,14 @@ from routers import (
     pycon,
 )
 from routers import twilio_ws_api
+from daras_ai_v2.openapi_tricks import patch_custom_schema_fastapi
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     limiter = anyio.to_thread.current_default_thread_limiter()
     limiter.total_tokens = config("MAX_THREADS", default=limiter.total_tokens, cast=int)
+    patch_custom_schema_fastapi(app)
     yield
 
 

--- a/tests/test_integrations_api.py
+++ b/tests/test_integrations_api.py
@@ -3,7 +3,7 @@ import json
 from furl import furl
 from starlette.testclient import TestClient
 
-from bots.models import BotIntegration, Platform
+from bots.models import BotIntegration
 from server import app
 
 client = TestClient(app)

--- a/usage_costs/models.py
+++ b/usage_costs/models.py
@@ -1,8 +1,6 @@
 from django.db import models
 
 from bots.custom_fields import CustomURLField
-from daras_ai_v2.stable_diffusion import InpaintingModels
-from usage_costs.twilio_usage_cost import IVRPlatformMedium
 from ai_models.models import ModelProvider
 
 max_digits = 15


### PR DESCRIPTION
## Summary
- centralize dynamic LLM model schema decoration in shared OpenAPI/Pydantic helpers
- switch workflow request models to marker-based `LLMModelField` annotations and remove repeated recipe-level tool schema overrides
- patch FastAPI OpenAPI generation so docs can advertise available models while request fields remain permissive strings

## Test plan
- [x] `pytest tests/test_tool_schema.py`
- [x] `ruff check ai_models/llm_openapi.py server.py tests/test_tool_schema.py daras_ai_v2/base.py`

Made with [Cursor](https://cursor.com)