### PR TITLE
fix: set LiveKit Gemini Vertex requests to global region

### DIFF
--- a/livekit_agent.py
+++ b/livekit_agent.py
@@ -79,7 +79,7 @@ from routers.api import create_new_run
 
 DTMF_TIMEOUT = 30
 MAX_TRIES = 5
-
+LIVEKIT_GEMINI_VERTEX_LOCATION = "global"
 
 server = AgentServer(
     num_idle_processes=config("MAX_THREADS", default=1, cast=int),
@@ -397,18 +397,10 @@ async def create_audio_model_session(
     if "gemini" in llm_model.model_id:
         from livekit.plugins import google
 
-        if llm_model.api_key:
-            gemini_auth_kwargs = {"api_key": llm_model.api_key}
-        else:
-            gemini_auth_kwargs = {
-                "vertexai": True,
-                "project": settings.GCP_PROJECT,
-            }
-
         llm = google.beta.realtime.RealtimeModel(
             model=llm_model.model_id,
             temperature=request.sampling_temperature,
-            **gemini_auth_kwargs,
+            **gemini_auth_kwargs(llm_model),
         )
         tts = google.TTS()
     else:
@@ -455,18 +447,10 @@ async def create_stt_llm_tts_session(
         case _ if "gemini" in llm_model.model_id:
             from livekit.plugins import google
 
-            if llm_model.api_key:
-                gemini_auth_kwargs = {"api_key": llm_model.api_key}
-            else:
-                gemini_auth_kwargs = {
-                    "vertexai": True,
-                    "project": settings.GCP_PROJECT,
-                }
-
             llm = google.LLM(
                 model=llm_model.model_id.removeprefix("google/"),
                 temperature=temperature,
-                **gemini_auth_kwargs,
+                **gemini_auth_kwargs(llm_model),
             )
 
         case _ if "claude" in llm_model.model_id:
@@ -561,6 +545,17 @@ async def create_stt_llm_tts_session(
         vad=silero.VAD.load(),
         turn_handling=TurnHandlingOptions(turn_detection=MultilingualModel()),
     )
+
+
+def gemini_auth_kwargs(llm_model: AIModelSpec) -> dict:
+    if llm_model.api_key:
+        return {"api_key": llm_model.api_key}
+
+    return {
+        "vertexai": True,
+        "project": settings.GCP_PROJECT,
+        "location": LIVEKIT_GEMINI_VERTEX_LOCATION,
+    }
 
 
 @sync_to_async


### PR DESCRIPTION
### Q/A checklist

- [ ] I have tested my UI changes on mobile and they look acceptable
- [ ] I have tested changes to the workflows in both the API and the UI
- [ ] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [ ] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
