### PR TITLE
feat: when filtering by workspace default sort should be last_updated

### DIFF
--- a/widgets/workflow_search.py
+++ b/widgets/workflow_search.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 import typing
 
@@ -55,8 +57,11 @@ class SortOptions(SortOption, GooeyEnum):
     )
 
     @classmethod
-    def get(cls, key=None):
-        return super().get(key, default=cls.featured)
+    def get(cls, key=None, *, search_filters: SearchFilters | None = None):
+        if search_filters and search_filters.workspace:
+            return super().get(key, default=cls.last_updated)
+        else:
+            return super().get(key, default=cls.featured)
 
     def html_icon_label(self) -> str:
         return f'{self.icon}<span class="hide-on-small-screens"> {self.label}</span>'
@@ -154,11 +159,12 @@ def render_search_filters(
                     gui.div(),
                 ):
                     sort_options = {
-                        opt.name if opt != SortOptions.get() else None: (
-                            opt.html_icon_label()
-                        )
-                        for opt in SortOptions
+                        option.name: option.html_icon_label() for option in SortOptions
                     }
+                    default_sort_option = SortOptions.get(search_filters=search_filters)
+                    if search_filters.sort != default_sort_option.name:
+                        sort_options[""] = sort_options.pop(default_sort_option.name)
+
                     search_filters.sort = (
                         gui.selectbox(
                             label="",
@@ -439,7 +445,7 @@ def get_filtered_published_runs(
 
 
 def build_sort_filter(qs: QuerySet, search_filters: SearchFilters) -> QuerySet:
-    match SortOptions.get(search_filters.sort):
+    match SortOptions.get(search_filters.sort, search_filters=search_filters):
         case SortOptions.featured:
             qs = qs.annotate(is_root_workflow=Q(published_run_id=""))
             fields = (


### PR DESCRIPTION
### Q/A checklist

- [x] I have tested my UI changes on mobile and they look acceptable
- [x] I have tested changes to the workflows in both the API and the UI
- [x] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [x] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
