### PR TITLE
fix: retry 504 error on Intron asr

### DIFF
--- a/daras_ai_v2/asr.py
+++ b/daras_ai_v2/asr.py
@@ -9,6 +9,7 @@ import typing
 from enum import Enum
 from functools import lru_cache
 
+import aifail
 import gooey_gui as gui
 import requests
 import typing_extensions
@@ -1070,13 +1071,12 @@ def intron_asr(audio_url: str, language: str | None = None) -> dict:
     content_type = audio_r.headers.get("content-type") or "application/octet-stream"
     upload_url = str(intron_base_url / "file/v1/upload/sync")
 
-    response = requests.post(
-        upload_url,
-        headers={"Authorization": f"Bearer {settings.INTRON_API_KEY}"},
+    response = _upload_intron_audio(
+        upload_url=upload_url,
         data=data,
-        files={"audio_file_blob": ("audio.wav", audio_r.content, content_type)},
+        audio_content=audio_r.content,
+        content_type=content_type,
     )
-    raise_for_status(response)
 
     response_data = response.json().get("data") or {}
     file_id = response_data.get("file_id")
@@ -1101,6 +1101,24 @@ def intron_asr(audio_url: str, language: str | None = None) -> dict:
     raise TimeoutError(
         "Intron ASR timed out while waiting for the transcription to complete."
     )
+
+
+@aifail.retry_if(aifail.http_should_retry)
+def _upload_intron_audio(
+    *,
+    upload_url: str,
+    data: dict,
+    audio_content: bytes,
+    content_type: str,
+) -> requests.Response:
+    response = requests.post(
+        upload_url,
+        headers={"Authorization": f"Bearer {settings.INTRON_API_KEY}"},
+        data=data,
+        files={"audio_file_blob": ("audio.wav", audio_content, content_type)},
+    )
+    raise_for_status(response)
+    return response
 
 
 def run_asr(


### PR DESCRIPTION
### Q/A checklist

- [ ] I have tested my UI changes on mobile and they look acceptable
- [ ] I have tested changes to the workflows in both the API and the UI
- [ ] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [ ] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
