### PR TITLE
feat: close dialogs on pressing esc key

### DIFF
--- a/gooey_gui/components/modal.py
+++ b/gooey_gui/components/modal.py
@@ -2,6 +2,21 @@ from gooey_gui import core
 from gooey_gui.components import common as gui
 
 
+MODAL_CLOSE_CLASS = "modal-close-btn"
+MODAL_ESC_HANDLER_JS = """
+document.removeEventListener('keydown', window._gooeyModalEscHandler);
+window._gooeyModalEscHandler = function(e) {
+    if (e.key !== 'Escape') return;
+    const modals = document.querySelectorAll('.modal.d-block');
+    const topModal = modals[modals.length - 1];
+    if (!topModal) return;
+    const closeBtn = topModal.querySelector('button.modal-close-btn');
+    if (closeBtn) closeBtn.click();
+};
+document.addEventListener('keydown', window._gooeyModalEscHandler);
+"""
+
+
 class AlertDialogRef:
     def __init__(self, key: str, is_open: bool = False):
         self.key = key
@@ -67,7 +82,7 @@ def alert_dialog(
             '<i class="fa fa-times fa-xl">',
             key=ref.close_btn_key,
             type="tertiary",
-            className="m-0 py-1 px-2",
+            className=f"m-0 py-1 px-2 {MODAL_CLOSE_CLASS}",
         )
     return body
 
@@ -125,7 +140,7 @@ def confirm_dialog(
         gui.button(
             label=cancel_label,
             key=ref.close_btn_key,
-            className=cancel_className,
+            className=f"{cancel_className} {MODAL_CLOSE_CLASS}".strip(),
             type="tertiary",
         )
         gui.button(
@@ -148,6 +163,7 @@ def modal_scaffold(
     else:
         large_cls = ""
     with core.current_root_ctx():
+        gui.js(MODAL_ESC_HANDLER_JS)
         with (
             gui.div(
                 className="modal d-block",


### PR DESCRIPTION
### Q/A checklist

- [x] I have tested my UI changes on mobile and they look acceptable
- [x] I have tested changes to the workflows in both the API and the UI
- [x] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [x] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
