### PR TITLE
feat: render deployment user in run history

### DIFF
--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -30,6 +30,7 @@ from ai_models.llm_openapi import patch_ai_model_schema_enums
 from app_users.models import AppUser, AppUserTransaction, ensure_request_app_user
 from auth.token_authentication import DISABLED_ACCOUNT_ERROR_MESSAGE
 from bots.models import (
+    Platform,
     PublishedRun,
     PublishedRunVersion,
     RetentionPolicy,
@@ -2382,11 +2383,27 @@ class BasePage:
                     )
             gui.write(f"#### {tb.title_with_prefix()}")
 
-            author, _ = AppUser.objects.get_or_create_from_uid(saved_run.uid)
             updated_at = saved_run.updated_at
             left, right = left_and_right(className="container-margin-reset")
             with left:
-                render_author_from_user(author)
+                if saved_run.is_api_call:
+                    msg = saved_run.messages.select_related(
+                        "conversation__bot_integration"
+                    ).first()
+                    if saved_run.platform:
+                        platform = Platform(saved_run.platform)
+                        text = f"{platform.get_icon()} {platform.get_title()} user"
+                        if convo := (msg and msg.conversation):
+                            convo_name = convo.get_display_name()
+                            if len(convo_name) >= 12:
+                                convo_name = convo_name[:3] + "XXX" + convo_name[-3:]
+                            text += f": {convo_name}"
+                        gui.caption(text, unsafe_allow_html=True)
+                    else:
+                        gui.caption(f"{icons.api} API user", unsafe_allow_html=True)
+                else:
+                    author, _ = AppUser.objects.get_or_create_from_uid(saved_run.uid)
+                    render_author_from_user(author)
             with right:
                 if (
                     updated_at
@@ -2396,6 +2413,7 @@ class BasePage:
                     gui.caption(
                         f"{icons.time} {get_relative_time(updated_at)}",
                         unsafe_allow_html=True,
+                        className="text-muted text-nowrap",
                     )
 
             with gui.div(className="mt-2"):

--- a/daras_ai_v2/breadcrumbs.py
+++ b/daras_ai_v2/breadcrumbs.py
@@ -58,7 +58,7 @@ def get_title_breadcrumbs(
     is_root = pr and pr.saved_run == sr and pr.is_root()
     is_example = not is_root and pr and pr.saved_run == sr
     is_run = not is_root and not is_example
-    is_api_call = sr.is_api_call and tab == RecipeTabs.run
+    is_api_call = sr.is_api_call
 
     metadata = page_cls.workflow.get_or_create_metadata()
     root_title = TitleUrl(
@@ -95,10 +95,10 @@ def get_title_breadcrumbs(
                 ),
             )
         case _ if is_run:
-            if tab and tab.label:
-                prefix = "Deployments" if tab == RecipeTabs.integrations else tab.label
-            elif is_api_call:
+            if is_api_call:
                 prefix = "API Run"
+            elif tab and tab.label:
+                prefix = "Deployments" if tab == RecipeTabs.integrations else tab.label
             else:
                 prefix = "Run"
 


### PR DESCRIPTION
- **fix: only show API runs in History tab -> "All" (not in "Just me")**
- **fix: show deployment user in a different format**

### Q/A checklist

- [ ] I have tested my UI changes on mobile and they look acceptable
- [ ] I have tested changes to the workflows in both the API and the UI
- [ ] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [ ] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
