### PR TITLE
fix: ignore stale Bulk Eval array columns

### DIFF
--- a/recipes/BulkEval.py
+++ b/recipes/BulkEval.py
@@ -415,6 +415,7 @@ def submit(
 
 
 def iter_eval_groups(df: "pd.DataFrame", array_columns: list[str] | None):
+    array_columns = [col for col in array_columns or [] if col in df.columns]
     out_df_recs = []
     prev_group_ix = None
     prompt_columns = {}


### PR DESCRIPTION
- Bulk Eval uses array_columns metadata from Bulk Runner to regroup multi-row list outputs, but stale names from an older run could be carried into a new CSV where those columns no longer exist. Those missing names were seeded into prompt_columns as [None], so the scoring prompt treated them as real workflow outputs and produced phantom aggregate rows like Test Workflow 1/2.

- Filter array_columns against the current DataFrame columns before grouping. Valid Bulk Runner array outputs still group normally when present, while stale hidden metadata can no longer inject nonexistent workflow outputs into prompts or aggregations.

### Q/A checklist

- [ ] I have tested my UI changes on mobile and they look acceptable
- [ ] I have tested changes to the workflows in both the API and the UI
- [ ] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [ ] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
