### PR TITLE
fix: align workflow URL action buttons with selectors

### DIFF
--- a/daras_ai_v2/workflow_url_input.py
+++ b/daras_ai_v2/workflow_url_input.py
@@ -25,7 +25,7 @@ def workflow_url_input(
 ) -> tuple[typing.Type[BasePage], SavedRun, PublishedRun | None] | None:
     init_workflow_selector(internal_state, key)
 
-    with gui.div(className="d-flex"):
+    with gui.div(className="d-flex align-items-center"):
         if not internal_state.get("workflow") and internal_state.get("url"):
             with gui.div(className="flex-grow-1"):
                 url = gui.text_input(

--- a/gooey_gui/components/url_button.py
+++ b/gooey_gui/components/url_button.py
@@ -2,12 +2,10 @@ from gooey_gui.components import common as gui
 
 
 def url_button(url):
-    gui.html(
-        f"""
-<a href='{url}' target='_blank'>
-    <button type="button" class="btn btn-theme btn-tertiary">
-        <i class="fa-regular fa-external-link-square"></i>
-    </button>
-</a>
-        """
+    gui.anchor(
+        '<i class="fa-regular fa-external-link-square"></i>',
+        href=url,
+        type="tertiary",
+        new_tab=True,
+        unsafe_allow_html=True,
     )


### PR DESCRIPTION
Render url_button as a single tertiary anchor instead of a nested anchor plus button, and vertically center the workflow URL action row.

### Q/A checklist

- [ ] I have tested my UI changes on mobile and they look acceptable
- [ ] I have tested changes to the workflows in both the API and the UI
- [ ] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [ ] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
