### PR TITLE
feat: rename copilot to agent with video-bots API compat

### DIFF
--- a/bots/admin.py
+++ b/bots/admin.py
@@ -361,7 +361,7 @@ class BotIntegrationAdmin(GooeyModelAdmin):
             url=get_app_route_url(
                 integrations_stats_route,
                 path_params=dict(
-                    page_slug=VideoBotsPage.slug_versions[0],
+                    page_slug=VideoBotsPage.canonical_slug(),
                     integration_id=integration_id,
                 ),
             ),

--- a/bots/admin.py
+++ b/bots/admin.py
@@ -361,7 +361,7 @@ class BotIntegrationAdmin(GooeyModelAdmin):
             url=get_app_route_url(
                 integrations_stats_route,
                 path_params=dict(
-                    page_slug=VideoBotsPage.slug_versions[-1],
+                    page_slug=VideoBotsPage.slug_versions[0],
                     integration_id=integration_id,
                 ),
             ),

--- a/bots/models/workflow.py
+++ b/bots/models/workflow.py
@@ -191,7 +191,7 @@ class Workflow(models.IntegerChoices):
     DOC_SEARCH = (1, "Doc Search")
     DOC_SUMMARY = (2, "Doc Summary")
     GOOGLE_GPT = (3, "Google GPT")
-    VIDEO_BOTS = (4, "Copilot")
+    VIDEO_BOTS = (4, "Agent")
     LIPSYNC_TTS = (5, "Lipysnc + TTS")
     TEXT_TO_SPEECH = (6, "Text to Speech")
     ASR = (7, "Speech Recognition")

--- a/daras_ai_v2/api_examples_widget.py
+++ b/daras_ai_v2/api_examples_widget.py
@@ -403,7 +403,7 @@ Note that you do not need the API key for this endpoint and can use it directly 
     api_docs_url = (
         furl(
             settings.API_BASE_URL,
-            fragment_path=f"operation/{VideoBotsPage.slug_versions[0]}__stream_create",
+            fragment_path=f"operation/{VideoBotsPage.canonical_slug()}__stream_create",
         )
         / "docs"
     )

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -219,6 +219,14 @@ class BasePage:
     def api_endpoint(cls) -> str:
         return f"/v2/{cls.slug_versions[0]}"
 
+    @classmethod
+    def canonical_slug(cls) -> str:
+        return cls.slug_versions[-1]
+
+    @classmethod
+    def legacy_api_slugs(cls) -> list[str]:
+        return []
+
     def current_app_url(
         self,
         tab: RecipeTabs = RecipeTabs.run,
@@ -272,7 +280,7 @@ class BasePage:
         return str(
             furl(settings.APP_BASE_URL, query_params=query_params)
             / tab.url_path(
-                page_slug=cls.slug_versions[-1],
+                page_slug=cls.canonical_slug(),
                 run_slug=run_slug,
                 example_id=example_id,
                 **(path_params or {}),

--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -216,16 +216,8 @@ class BasePage:
         self.request = request
 
     @classmethod
-    def api_endpoint(cls) -> str:
-        return f"/v2/{cls.slug_versions[0]}"
-
-    @classmethod
     def canonical_slug(cls) -> str:
         return cls.slug_versions[-1]
-
-    @classmethod
-    def legacy_api_slugs(cls) -> list[str]:
-        return []
 
     def current_app_url(
         self,
@@ -301,7 +293,9 @@ class BasePage:
         elif example_id:
             query_params = dict(example_id=example_id)
         return (
-            furl(settings.API_BASE_URL, query_params=query_params) / cls.api_endpoint()
+            furl(settings.API_BASE_URL, query_params=query_params)
+            / "v2"
+            / cls.canonical_slug()
         )
 
     @classmethod
@@ -319,7 +313,7 @@ class BasePage:
     def setup_sentry(self):
         with sentry_sdk.configure_scope() as scope:
             scope.set_transaction_name(
-                "/" + self.slug_versions[0], source=TRANSACTION_SOURCE_ROUTE
+                "/" + self.canonical_slug(), source=TRANSACTION_SOURCE_ROUTE
             )
             scope.add_event_processor(self.sentry_event_set_request)
             scope.add_event_processor(self.sentry_event_set_user)
@@ -2235,7 +2229,7 @@ class BasePage:
 
     @classmethod
     def realtime_channel_name(cls, run_id: str, uid: str) -> str:
-        return f"gooey-outputs/{cls.slug_versions[0]}/{uid}/{run_id}"
+        return f"gooey-outputs/{cls.canonical_slug()}/{uid}/{run_id}"
 
     def _setup_rng_seed(self):
         seed = gui.session_state.get("seed")
@@ -2476,7 +2470,7 @@ class BasePage:
         api_docs_url = str(
             furl(
                 settings.API_BASE_URL,
-                fragment_path=f"operation/{self.slug_versions[0]}",
+                fragment_path=f"operation/{self.canonical_slug()}",
             )
             / "docs"
         )

--- a/daras_ai_v2/bot_integration_widgets.py
+++ b/daras_ai_v2/bot_integration_widgets.py
@@ -90,7 +90,7 @@ def general_integration_settings(
                 "**👍🏾 👎🏽 Show Feedback Buttons**",
                 value=bi.show_feedback_buttons,
                 key=f"_bi_show_feedback_buttons_{bi.id}",
-                help="Users can rate and provide feedback on every copilot response if enabled.",
+                help="Users can rate and provide feedback on every agent/copilot response if enabled.",
             )
 
         with gui.div(className="d-flex align-items-center gap-3"):
@@ -100,7 +100,7 @@ def general_integration_settings(
                 key=f"_bi_ask_detailed_feedback_{bi.id}",
                 help=(
                     "When users give a thumbs down, ask them to explain what was wrong and how it could be improved. "
-                    "Make sure to use our suggested prompt in your copilot to make this work well."
+                    "Make sure to use our suggested prompt in your agent/copilot to make this work well."
                 ),
             )
             copy_to_clipboard_button(
@@ -136,7 +136,7 @@ def analysis_runs_list_view(
             "##### <i class='fa-solid fa-brain'></i> Analysis Workflows",
             unsafe_allow_html=True,
             help=(
-                "Analyze each incoming message and the copilot's response using a Gooey.AI /LLM workflow. "
+                "Analyze each incoming message and the agent's response using a Gooey.AI /LLM workflow. "
                 "Must return a JSON object with a consistent schema. [Learn more](https://gooey.ai/docs/guides/build-your-ai-copilot/conversation-analysis)."
             ),
         )
@@ -256,7 +256,7 @@ def slack_specific_settings(bi: BotIntegration):
     bi.slack_read_receipt_msg = gui.text_input(
         """
             ##### ✅ Read Receipt
-            This message is sent immediately after recieving a user message and replaced with the copilot's response once it's ready.
+            This message is sent immediately after recieving a user message and replaced with the agent's response once it's ready.
             (leave blank to disable)
             """,
         placeholder=bi.slack_read_receipt_msg,

--- a/daras_ai_v2/bot_integration_widgets.py
+++ b/daras_ai_v2/bot_integration_widgets.py
@@ -283,7 +283,7 @@ def broadcast_input(bi: BotIntegration):
     api_docs_url = (
         furl(
             settings.API_BASE_URL,
-            fragment_path=f"operation/{VideoBotsPage.slug_versions[0]}__broadcast",
+            fragment_path=f"operation/{VideoBotsPage.canonical_slug()}__broadcast",
         )
         / "docs"
     )

--- a/daras_ai_v2/doc_search_settings_widgets.py
+++ b/daras_ai_v2/doc_search_settings_widgets.py
@@ -203,7 +203,7 @@ The maximum number of document search citations.
 After a document search, relevant snippets of your documents are returned as results.
 This setting adjusts the maximum number of words in each snippet (tokens = words * 2).
 A high snippet size allows the LLM to access more information from your document results, \
-at the cost of being verbose and potentially exhausting input tokens (which can cause a failure of the copilot to respond).
+at the cost of being verbose and potentially exhausting input tokens (which can cause a failure of the agent to respond).
 """,
         key="max_context_words",
         min_value=10,

--- a/daras_ai_v2/integrations_tab.py
+++ b/daras_ai_v2/integrations_tab.py
@@ -57,7 +57,7 @@ def render_integrations_tab(
     # no connected integrations on this run
     if not (integrations_qs and integrations_qs.exists()):
         render_integrations_add(
-            label="#### Connect your Copilot",
+            label="#### Connect your Agent",
             current_sr=saved_run,
             pr=published_run,
             user=user,
@@ -111,7 +111,7 @@ def render_integrations_settings(
         col1, col2 = gui.columns(2)
 
     with col1:
-        gui.markdown("#### Configure your Copilot")
+        gui.markdown("#### Configure your Agent")
         gui.newline()
 
         if len(integrations) > 1:

--- a/daras_ai_v2/language_model_settings_widgets.py
+++ b/daras_ai_v2/language_model_settings_widgets.py
@@ -19,7 +19,7 @@ class LanguageModelSettings(BaseModel):
     num_outputs: int | None = Field(
         None,
         title="Answer Outputs",
-        description="How many answers should the copilot generate? Additional answer outputs increase the cost of each run.",
+        description="How many answers should the agent/copilot generate? Additional answer outputs increase the cost of each run.",
     )
     quality: float | None = Field(
         None,

--- a/daras_ai_v2/perf_timer.py
+++ b/daras_ai_v2/perf_timer.py
@@ -2,17 +2,16 @@ import threading
 
 from time import perf_counter
 
+from loguru import logger
+
 threadlocal = threading.local()
 
 
-def start_perf_timer():
-    threadlocal._perf_timer_start = perf_counter()
+def perf_timeit(f):
+    def wrapper(*args, **kwargs):
+        s = perf_counter()
+        result = f(*args, **kwargs)
+        logger.debug(f"{f.__name__} took {(perf_counter() - s) * 1000:.2f}ms")
+        return result
 
-
-def perf_timer():
-    try:
-        start = threadlocal._perf_timer_start
-    except AttributeError:
-        start = 0
-    ms = (perf_counter() - start) * 1000
-    return f"{ms:.2f}ms"
+    return wrapper

--- a/functions/gooey_builder_deploy_tool.py
+++ b/functions/gooey_builder_deploy_tool.py
@@ -33,7 +33,7 @@ class DeployWorkflowLLMTool(GooeyBuilderLLMTool):
         self.pr = pr
         self.builder_sr = builder_sr
 
-        description = "Deploy the current saved copilot workflow to an end-user channel so real users can talk to it. "
+        description = "Deploy the current saved agent workflow to an end-user channel so real users can talk to it. "
 
         if self.sr.state != self.pr.saved_run.state:
             description += (

--- a/payments/plans.py
+++ b/payments/plans.py
@@ -86,7 +86,7 @@ class PricingPlan(PricingPlanData, Enum):
         db_value=2,
         key="premium",
         title="Premium Plan",
-        description="10000 Credits (~2000 runs) for $50/month. Includes special access to build bespoke, embeddable [videobots](/video-bots/)",
+        description="10000 Credits (~2000 runs) for $50/month. Includes special access to build bespoke, embeddable [agents](/agent/)",
         credits=10_000,
         monthly_charge=50,
         deprecated=True,
@@ -103,7 +103,7 @@ class PricingPlan(PricingPlanData, Enum):
             """
             **Includes (est.)**
             <ul class="text-muted">
-              <li>400 Copilot Conversations  </li>
+              <li>400 Agent Conversations  </li>
               <li>40 Lipsync minutes  </li>
               <li>133 Animation seconds  </li>
               <li>75 AI QR Codes  </li>
@@ -116,7 +116,7 @@ class PricingPlan(PricingPlanData, Enum):
               <li>Auto recharge with custom budgets  </li>
               <li>Premium LLMs (GPT 4s, Gemini, Claude)  </li>
               <li>100 MB of Knowledge  </li>
-              <li>Copilot Analytics  </li>
+              <li>Agent Analytics  </li>
               <li>11Labs voices for Lipsync  </li>
             </ul>
             """
@@ -134,7 +134,7 @@ class PricingPlan(PricingPlanData, Enum):
             """
             **Includes (est.)**
             <ul class="text-muted">
-              <li>4,000 Copilot Conversations</li>
+              <li>4,000 Agent Conversations</li>
               <li>400 Lipsync minutes</li>
               <li>1333 Animation seconds</li>
               <li>750 AI QR Codes</li>
@@ -170,7 +170,7 @@ class PricingPlan(PricingPlanData, Enum):
               <li>Integrate with Google, M365, Salesforce, Notion + 100s of others</li>
               <li>API Secrets to securely access any system</li>
               <li>Bring your own WhatsApp number</li>
-              <li>Embed copilots in your own App</li>
+              <li>Embed agents in your own App</li>
               <li>Impact and usage <a href="https://docs.gooey.ai/ai-agent/conversation-analysis">dashboards</a></li>
               <li>Role Based Management</li>
               <li>Centralized billing</li>
@@ -205,9 +205,9 @@ class PricingPlan(PricingPlanData, Enum):
               <li>Public Workflows</li>
               <li>Run all frontier <a href="/compare-llm">LLMs</a></li>
               <li><a href="/explore">Explore</a>, fork & run any public AI Workflow</li>
-              <li>Test and deploy via <a href="/copilot/">Agent Web Widget</a></li>
+              <li>Test and deploy via <a href="/agent/">Agent Web Widget</a></li>
               <li><a href="/speech/">Speech recognition</a> and translation for 1000+ languages</li>
-              <li>Broad selection of <a href="/text-to-speech/">Text to Speech voices</a> for <a href="/lipsync/">Lipsync</a> and <a href="/copilot/">Copilot</a></li>
+              <li>Broad selection of <a href="/text-to-speech/">Text to Speech voices</a> for <a href="/lipsync/">Lipsync</a> and <a href="/agent/">Agent</a></li>
               <li>Access top image generation models</li>
               <li>Deploy Workflows via the Web, WhatsApp, SMS/Voice, Slack or FB</li>
             </ul>
@@ -272,7 +272,7 @@ class PricingPlan(PricingPlanData, Enum):
               <li>Integrate with Google, M365, Salesforce, Notion + 100s of others</li>
               <li>API Secrets to securely access any system (Researcher & above)</li>
               <li>Bring your own WhatsApp number</li>
-              <li>Embed copilots in your own App</li>
+              <li>Embed agents in your own App</li>
               <li>Impact and usage <a href="https://docs.gooey.ai/ai-agent/conversation-analysis">dashboards</a></li>
               <li>Role Based Management</li>
               <li>Centralized billing</li>

--- a/recipes/DocExtract.py
+++ b/recipes/DocExtract.py
@@ -81,11 +81,7 @@ class DocExtractPage(BasePage):
     title = "Synthetic Data Maker for Videos & PDFs"
     explore_image = "https://storage.googleapis.com/dara-c1b52.appspot.com/daras_ai/media/aeb83ee8-889e-11ee-93dc-02420a000143/Youtube%20transcripts%20GPT%20extractions.png.png"
     workflow = Workflow.DOC_EXTRACT
-    slug_versions = [
-        "doc-extract",
-        "youtube-bot",
-        "doc-extract",
-    ]
+    slug_versions = ["youtube-bot", "doc-extract"]
     price = 500
 
     class RequestModelBase(BasePage.RequestModel):

--- a/recipes/Functions.py
+++ b/recipes/Functions.py
@@ -45,7 +45,7 @@ class CodeLanguages(PydanticEnumMixin, Enum):
 class FunctionsPage(BasePage):
     title = "Functions"
     workflow = Workflow.FUNCTIONS
-    slug_versions = ["functions", "tools", "function", "fn", "functions"]
+    slug_versions = ["tools", "function", "fn", "functions"]
     show_settings = False
     price = 1
 

--- a/recipes/ModelTrainer.py
+++ b/recipes/ModelTrainer.py
@@ -91,7 +91,7 @@ class FinetuneModels(FinetuneModel, Enum):
 class ModelTrainerPage(BasePage):
     title = "Model Trainer"
     workflow = Workflow.MODEL_TRAINER
-    slug_versions = ["model-trainer", "train", "lora", "model-trainer"]
+    slug_versions = ["train", "lora", "model-trainer"]
 
     class RequestModel(BasePage.RequestModel):
         selected_model: typing.Literal[tuple(e.name for e in FinetuneModels)] | None = (

--- a/recipes/VideoBots.py
+++ b/recipes/VideoBots.py
@@ -136,12 +136,16 @@ class ReplyButton(typing_extensions.TypedDict):
 class VideoBotsPage(BasePage):
     PROFIT_CREDITS = 3
 
-    title = "Copilot for your Enterprise"  # "Create Interactive Video Bots"
+    title = "Agent"  # "Create Interactive Video Bots"
     explore_image = "https://storage.googleapis.com/dara-c1b52.appspot.com/daras_ai/media/8c014530-88d4-11ee-aac9-02420a00016b/Copilot.png.png"
     workflow = Workflow.VIDEO_BOTS
-    slug_versions = ["video-bots", "bots", "copilot"]
+    slug_versions = ["agent", "video-bots", "bots", "copilot", "agent"]
 
     functions_in_settings = False
+
+    @classmethod
+    def legacy_api_slugs(cls) -> list[str]:
+        return ["video-bots"]
 
     sane_defaults = {
         "messages": [],
@@ -184,22 +188,22 @@ class VideoBotsPage(BasePage):
         input_prompt: str | None = Field(
             None,
             title="Input Prompt",
-            description="The text message / prompt sent to the copilot by the user",
+            description="The text message / prompt sent to the agent by the user",
         )
         input_audio: str | None = Field(
             None,
             title="Input Audio",
-            description="The audio message sent to the copilot by the user",
+            description="The audio message sent to the agent by the user",
         )
         input_images: list[HttpUrlStr] | None = Field(
             None,
             title="Input Images",
-            description="The images sent to the copilot by the user",
+            description="The images sent to the agent by the user",
         )
         input_documents: list[HttpUrlStr] | None = Field(
             None,
             title="Input Documents",
-            description="The documents sent to the copilot by the user. Note: this is not the same as the knowledge base documents.",
+            description="The documents sent to the agent by the user. Note: this is not the same as the knowledge base documents.",
         )
 
         doc_extract_url: str | None = Field(
@@ -215,7 +219,7 @@ class VideoBotsPage(BasePage):
             None,
             title="Instructions",
             description="The system prompt for the LLM. "
-            "Use this to set the personality of your copilot and provide instructions for bot's behavior. "
+            "Use this to set the personality of your agent and provide instructions for the bot's behavior. "
             "Supports [Jinja](https://jinja.palletsprojects.com/en/stable/templates/) templating.",
         )
 
@@ -238,7 +242,7 @@ class VideoBotsPage(BasePage):
         documents: list[HttpUrlStr] | None = Field(
             None,
             title="Knowledge Base",
-            description="Add documents or links to give your copilot a knowledge base. When asked a question, we'll search them to generate an answer with citations. [Learn more](https://gooey.ai/docs/guides/build-your-ai-copilot/curate-your-knowledge-base-documents)",
+            description="Add documents or links to give your agent a knowledge base. When asked a question, we'll search them to generate an answer with citations. [Learn more](https://gooey.ai/docs/guides/build-your-ai-copilot/curate-your-knowledge-base-documents)",
         )
         max_references: int | None = None
         max_context_words: int | None = None
@@ -1133,7 +1137,7 @@ Translation Glossary for LLM Language (English) -> User Langauge
                     gui.session_state.get("input_glossary_document")
                     or gui.session_state.get("output_glossary_document")
                 ),
-                help="[Learn more](https://gooey.ai/docs/guides/build-your-ai-copilot/advanced-settings#fine-tuned-language-understanding-with-custom-glossaries) about how to super-charge your copilots domain specific language understanding!",
+                help="[Learn more](https://gooey.ai/docs/guides/build-your-ai-copilot/advanced-settings#fine-tuned-language-understanding-with-custom-glossaries) about how to super-charge your agent's domain specific language understanding!",
             )
             if enable_glossary:
                 gui.caption(
@@ -1509,7 +1513,7 @@ if (typeof GooeyEmbed !== "undefined" && GooeyEmbed.copilotPreviewControl) {
             user = self.request.user
             # not signed in case
             if not user or user.is_anonymous:
-                integrations_welcome_screen(title="Connect your Copilot")
+                integrations_welcome_screen(title="Connect your Agent")
                 gui.newline()
                 with gui.center():
                     gui.anchor("Get Started", href=self.get_auth_url(), type="primary")

--- a/recipes/VideoBots.py
+++ b/recipes/VideoBots.py
@@ -139,13 +139,9 @@ class VideoBotsPage(BasePage):
     title = "Agent"  # "Create Interactive Video Bots"
     explore_image = "https://storage.googleapis.com/dara-c1b52.appspot.com/daras_ai/media/8c014530-88d4-11ee-aac9-02420a00016b/Copilot.png.png"
     workflow = Workflow.VIDEO_BOTS
-    slug_versions = ["agent", "video-bots", "bots", "copilot", "agent"]
+    slug_versions = ["video-bots", "bots", "copilot", "agent"]
 
     functions_in_settings = False
-
-    @classmethod
-    def legacy_api_slugs(cls) -> list[str]:
-        return ["video-bots"]
 
     sane_defaults = {
         "messages": [],

--- a/recipes/VideoBotsStats.py
+++ b/recipes/VideoBotsStats.py
@@ -50,7 +50,7 @@ from widgets.author import render_author_from_user
 
 
 class VideoBotsStatsPage(BasePage):
-    title = "Copilot Analytics"  # "Create Interactive Video Bots"
+    title = "Agent Analytics"  # "Create Interactive Video Bots"
     slug_versions = ["analytics", "stats"]
     workflow = (
         Workflow.VIDEO_BOTS

--- a/routers/api.py
+++ b/routers/api.py
@@ -197,6 +197,8 @@ def script_to_api(page_cls: typing.Type[BasePage]):
         # call regular json api
         return run_api_json(request, page_request=page_request, api_key=api_key)
 
+    endpoint_v2 = endpoint
+    sync_response_model = response_model
     endpoint = endpoint.replace("v2", "v3")
     response_model = AsyncApiResponseModelV3
 
@@ -301,6 +303,63 @@ def script_to_api(page_cls: typing.Type[BasePage]):
                     sr.state = {}
                     sr.save(update_fields=["state", "updated_at"])
             return ret
+
+    for legacy_slug in page_cls.legacy_api_slugs():
+        slug = page_cls.slug_versions[0]
+        app.add_api_route(
+            endpoint_v2.replace(f"/{slug}", f"/{legacy_slug}", 1),
+            run_api_json,
+            methods=["POST"],
+            response_model=sync_response_model,
+            responses={
+                HTTP_500_INTERNAL_SERVER_ERROR: {"model": FailedReponseModelV2},
+                **common_errs,
+            },
+            include_in_schema=False,
+        )
+        app.add_api_route(
+            os.path.join(endpoint_v2.replace(f"/{slug}", f"/{legacy_slug}", 1), "form"),
+            run_api_form,
+            methods=["POST"],
+            response_model=sync_response_model,
+            responses={
+                HTTP_500_INTERNAL_SERVER_ERROR: {"model": FailedReponseModelV2},
+                HTTP_400_BAD_REQUEST: {"model": GenericErrorResponse},
+                **common_errs,
+            },
+            include_in_schema=False,
+        )
+        app.add_api_route(
+            os.path.join(endpoint.replace(f"/{slug}", f"/{legacy_slug}", 1), "async"),
+            run_api_json_async,
+            methods=["POST"],
+            response_model=AsyncApiResponseModelV3,
+            responses=common_errs,
+            status_code=202,
+            include_in_schema=False,
+        )
+        app.add_api_route(
+            os.path.join(
+                endpoint.replace(f"/{slug}", f"/{legacy_slug}", 1), "async/form"
+            ),
+            run_api_form_async,
+            methods=["POST"],
+            response_model=AsyncApiResponseModelV3,
+            responses={
+                HTTP_400_BAD_REQUEST: {"model": GenericErrorResponse},
+                **common_errs,
+            },
+            status_code=202,
+            include_in_schema=False,
+        )
+        app.add_api_route(
+            os.path.join(endpoint.replace(f"/{slug}", f"/{legacy_slug}", 1), "status"),
+            get_run_status,
+            methods=["GET"],
+            response_model=response_model,
+            responses=common_errs,
+            include_in_schema=False,
+        )
 
 
 def _parse_form_data(

--- a/routers/api.py
+++ b/routers/api.py
@@ -1,6 +1,4 @@
 import json
-import os
-import os.path
 import typing
 
 import gooey_gui as gui
@@ -120,7 +118,6 @@ class RunSettings(BaseModel):
 
 
 def script_to_api(page_cls: typing.Type[BasePage]):
-    endpoint = page_cls.api_endpoint().rstrip("/")
     # add the common settings to the request model
     request_model = create_model(
         page_cls.__name__ + "Request",
@@ -133,9 +130,16 @@ def script_to_api(page_cls: typing.Type[BasePage]):
         __base__=page_cls.ResponseModel,
         called_functions=(list[CalledFunctionResponse], None),
     )
-    response_model = create_model(
+
+    v2_response_model = create_model(
         page_cls.__name__ + "Response",
         __base__=ApiResponseModelV2[response_output_model],
+    )
+
+    v3_async_response_model = AsyncApiResponseModelV3
+    v3_status_response_model = create_model(
+        page_cls.__name__ + "StatusResponse",
+        __base__=AsyncStatusResponseModelV3[response_output_model],
     )
 
     common_errs = {
@@ -143,223 +147,167 @@ def script_to_api(page_cls: typing.Type[BasePage]):
         HTTP_429_TOO_MANY_REQUESTS: {"model": GenericErrorResponse},
     }
 
-    @app.post(
-        endpoint,
-        response_model=response_model,
-        responses={
-            HTTP_500_INTERNAL_SERVER_ERROR: {"model": FailedReponseModelV2},
-            **common_errs,
-        },
-        operation_id=page_cls.slug_versions[0],
-        tags=[page_cls.title],
-        name=page_cls.title + " (v2 sync)",
-    )
-    def run_api_json(
-        request: Request,
-        page_request: request_model,
-        api_key: ApiKey = Depends(api_auth_header),
-    ):
-        result, sr = submit_api_call(
-            page_cls=page_cls,
-            query_params=dict(request.query_params),
-            retention_policy=RetentionPolicy[page_request.settings.retention_policy],
-            current_user=api_key.created_by,
-            workspace=api_key.workspace,
-            request_body=page_request.model_dump(exclude_unset=True),
-            enable_rate_limits=True,
+    for slug in page_cls.slug_versions:
+        is_latest = slug == page_cls.canonical_slug()
+
+        @app.post(
+            f"/v2/{slug}",
+            response_model=v2_response_model,
+            responses={
+                HTTP_500_INTERNAL_SERVER_ERROR: {"model": FailedReponseModelV2},
+                **common_errs,
+            },
+            operation_id=slug,
+            tags=[page_cls.title],
+            name=page_cls.title + " (v2 sync)",
+            include_in_schema=is_latest,
         )
-        return build_sync_api_response(result, sr)
-
-    @app.post(
-        os.path.join(endpoint, "form"),
-        response_model=response_model,
-        responses={
-            HTTP_500_INTERNAL_SERVER_ERROR: {"model": FailedReponseModelV2},
-            HTTP_400_BAD_REQUEST: {"model": GenericErrorResponse},
-            **common_errs,
-        },
-        include_in_schema=False,
-    )
-    def run_api_form(
-        request: Request,
-        api_key: ApiKey = Depends(api_auth_header),
-        form_data=fastapi_request_form,
-        page_request_json: str = Form(alias="json"),
-    ):
-        # parse form data
-        page_request = _parse_form_data(
-            request_model,
-            form_data,
-            page_request_json,
-            workspace=api_key.workspace,
-            user=api_key.created_by,
-        )
-        # call regular json api
-        return run_api_json(request, page_request=page_request, api_key=api_key)
-
-    endpoint_v2 = endpoint
-    sync_response_model = response_model
-    endpoint = endpoint.replace("v2", "v3")
-    response_model = AsyncApiResponseModelV3
-
-    @app.post(
-        os.path.join(endpoint, "async"),
-        response_model=response_model,
-        responses=common_errs,
-        operation_id="async__" + page_cls.slug_versions[0],
-        name=page_cls.title + " (v3 async)",
-        tags=[page_cls.title],
-        status_code=202,
-    )
-    def run_api_json_async(
-        request: Request,
-        response: Response,
-        page_request: request_model,
-        api_key: ApiKey = Depends(api_auth_header),
-    ):
-        result, sr = submit_api_call(
-            page_cls=page_cls,
-            query_params=dict(request.query_params),
-            retention_policy=RetentionPolicy[page_request.settings.retention_policy],
-            current_user=api_key.created_by,
-            workspace=api_key.workspace,
-            request_body=page_request.model_dump(exclude_unset=True),
-            enable_rate_limits=True,
-        )
-        ret = build_async_api_response(sr)
-        response.headers["Location"] = ret["status_url"]
-        response.headers["Access-Control-Expose-Headers"] = "Location"
-        return ret
-
-    @app.post(
-        os.path.join(endpoint, "async/form"),
-        response_model=response_model,
-        responses={
-            HTTP_400_BAD_REQUEST: {"model": GenericErrorResponse},
-            **common_errs,
-        },
-        include_in_schema=False,
-    )
-    def run_api_form_async(
-        request: Request,
-        response: Response,
-        api_key: ApiKey = Depends(api_auth_header),
-        form_data=fastapi_request_form,
-        page_request_json: str = Form(alias="json"),
-    ):
-        # parse form data
-        page_request = _parse_form_data(
-            request_model,
-            form_data,
-            page_request_json,
-            workspace=api_key.workspace,
-            user=api_key.created_by,
-        )
-        # call regular json api
-        return run_api_json_async(
-            request, response=response, page_request=page_request, api_key=api_key
-        )
-
-    response_model = create_model(
-        page_cls.__name__ + "StatusResponse",
-        __base__=AsyncStatusResponseModelV3[response_output_model],
-    )
-
-    @app.get(
-        os.path.join(endpoint, "status"),
-        response_model=response_model,
-        responses=common_errs,
-        operation_id="status__" + page_cls.slug_versions[0],
-        tags=[page_cls.title],
-        name=page_cls.title + " (v3 status)",
-    )
-    def get_run_status(
-        run_id: str,
-        api_key: ApiKey = Depends(api_auth_header),
-    ):
-        user = api_key.created_by
-        # init a new page for every request
-        self = page_cls(user=user, query_params=dict(run_id=run_id, uid=user.uid))
-        sr = self.current_sr
-        web_url = str(furl(self.app_url(run_id=run_id, uid=user.uid)))
-        ret = {
-            "run_id": run_id,
-            "web_url": web_url,
-            "created_at": sr.created_at.isoformat(),
-            "run_time_sec": sr.run_time.total_seconds(),
-        }
-        if sr.error_code:
-            return JSONResponse(
-                dict(detail=ret | dict(error=sr.error_msg)), status_code=sr.error_code
+        def run_api_json(
+            request: Request,
+            page_request: request_model,
+            api_key: ApiKey = Depends(api_auth_header),
+        ):
+            result, sr = submit_api_call(
+                page_cls=page_cls,
+                query_params=dict(request.query_params),
+                retention_policy=RetentionPolicy[
+                    page_request.settings.retention_policy
+                ],
+                current_user=api_key.created_by,
+                workspace=api_key.workspace,
+                request_body=page_request.model_dump(exclude_unset=True),
+                enable_rate_limits=True,
             )
-        elif sr.error_msg:
-            ret |= {"status": "failed", "detail": sr.error_msg}
-        else:
-            status = self.get_run_state(sr.to_dict())
-            ret |= {"detail": sr.run_status or "", "status": status}
-            if status == RecipeRunState.completed and sr.state:
-                ret |= {"output": sr.api_output()}
-                if sr.retention_policy == RetentionPolicy.delete:
-                    sr.state = {}
-                    sr.save(update_fields=["state", "updated_at"])
+            return build_sync_api_response(result, sr)
+
+        @app.post(
+            f"/v2/{slug}/form",
+            response_model=v2_response_model,
+            responses={
+                HTTP_500_INTERNAL_SERVER_ERROR: {"model": FailedReponseModelV2},
+                HTTP_400_BAD_REQUEST: {"model": GenericErrorResponse},
+                **common_errs,
+            },
+            include_in_schema=False,
+        )
+        def run_api_form(
+            request: Request,
+            api_key: ApiKey = Depends(api_auth_header),
+            form_data=fastapi_request_form,
+            page_request_json: str = Form(alias="json"),
+        ):
+            # parse form data
+            page_request = _parse_form_data(
+                request_model,
+                form_data,
+                page_request_json,
+                workspace=api_key.workspace,
+                user=api_key.created_by,
+            )
+            # call regular json api
+            return run_api_json(request, page_request=page_request, api_key=api_key)
+
+        @app.post(
+            f"/v3/{slug}/async",
+            response_model=v3_async_response_model,
+            responses=common_errs,
+            operation_id="async__" + slug,
+            name=page_cls.title + " (v3 async)",
+            tags=[page_cls.title],
+            status_code=202,
+            include_in_schema=is_latest,
+        )
+        def run_api_json_async(
+            request: Request,
+            response: Response,
+            page_request: request_model,
+            api_key: ApiKey = Depends(api_auth_header),
+        ):
+            result, sr = submit_api_call(
+                page_cls=page_cls,
+                query_params=dict(request.query_params),
+                retention_policy=RetentionPolicy[
+                    page_request.settings.retention_policy
+                ],
+                current_user=api_key.created_by,
+                workspace=api_key.workspace,
+                request_body=page_request.model_dump(exclude_unset=True),
+                enable_rate_limits=True,
+            )
+            ret = build_async_api_response(sr)
+            response.headers["Location"] = ret["status_url"]
+            response.headers["Access-Control-Expose-Headers"] = "Location"
             return ret
 
-    for legacy_slug in page_cls.legacy_api_slugs():
-        slug = page_cls.slug_versions[0]
-        app.add_api_route(
-            endpoint_v2.replace(f"/{slug}", f"/{legacy_slug}", 1),
-            run_api_json,
-            methods=["POST"],
-            response_model=sync_response_model,
-            responses={
-                HTTP_500_INTERNAL_SERVER_ERROR: {"model": FailedReponseModelV2},
-                **common_errs,
-            },
-            include_in_schema=False,
-        )
-        app.add_api_route(
-            os.path.join(endpoint_v2.replace(f"/{slug}", f"/{legacy_slug}", 1), "form"),
-            run_api_form,
-            methods=["POST"],
-            response_model=sync_response_model,
-            responses={
-                HTTP_500_INTERNAL_SERVER_ERROR: {"model": FailedReponseModelV2},
-                HTTP_400_BAD_REQUEST: {"model": GenericErrorResponse},
-                **common_errs,
-            },
-            include_in_schema=False,
-        )
-        app.add_api_route(
-            os.path.join(endpoint.replace(f"/{slug}", f"/{legacy_slug}", 1), "async"),
-            run_api_json_async,
-            methods=["POST"],
-            response_model=AsyncApiResponseModelV3,
-            responses=common_errs,
-            status_code=202,
-            include_in_schema=False,
-        )
-        app.add_api_route(
-            os.path.join(
-                endpoint.replace(f"/{slug}", f"/{legacy_slug}", 1), "async/form"
-            ),
-            run_api_form_async,
-            methods=["POST"],
-            response_model=AsyncApiResponseModelV3,
+        @app.post(
+            f"/v3/{slug}/async/form",
+            response_model=v3_async_response_model,
             responses={
                 HTTP_400_BAD_REQUEST: {"model": GenericErrorResponse},
                 **common_errs,
             },
-            status_code=202,
             include_in_schema=False,
         )
-        app.add_api_route(
-            os.path.join(endpoint.replace(f"/{slug}", f"/{legacy_slug}", 1), "status"),
-            get_run_status,
-            methods=["GET"],
-            response_model=response_model,
+        def run_api_form_async(
+            request: Request,
+            response: Response,
+            api_key: ApiKey = Depends(api_auth_header),
+            form_data=fastapi_request_form,
+            page_request_json: str = Form(alias="json"),
+        ):
+            # parse form data
+            page_request = _parse_form_data(
+                request_model,
+                form_data,
+                page_request_json,
+                workspace=api_key.workspace,
+                user=api_key.created_by,
+            )
+            # call regular json api
+            return run_api_json_async(
+                request, response=response, page_request=page_request, api_key=api_key
+            )
+
+        @app.get(
+            f"/v3/{slug}/status",
+            response_model=v3_status_response_model,
             responses=common_errs,
-            include_in_schema=False,
+            operation_id="status__" + slug,
+            tags=[page_cls.title],
+            name=page_cls.title + " (v3 status)",
+            include_in_schema=is_latest,
         )
+        def get_run_status(
+            run_id: str,
+            api_key: ApiKey = Depends(api_auth_header),
+        ):
+            user = api_key.created_by
+            # init a new page for every request
+            self = page_cls(user=user, query_params=dict(run_id=run_id, uid=user.uid))
+            sr = self.current_sr
+            web_url = str(furl(self.app_url(run_id=run_id, uid=user.uid)))
+            ret = {
+                "run_id": run_id,
+                "web_url": web_url,
+                "created_at": sr.created_at.isoformat(),
+                "run_time_sec": sr.run_time.total_seconds(),
+            }
+            if sr.error_code:
+                return JSONResponse(
+                    dict(detail=ret | dict(error=sr.error_msg)),
+                    status_code=sr.error_code,
+                )
+            elif sr.error_msg:
+                ret |= {"status": "failed", "detail": sr.error_msg}
+            else:
+                status = self.get_run_state(sr.to_dict())
+                ret |= {"detail": sr.run_status or "", "status": status}
+                if status == RecipeRunState.completed and sr.state:
+                    ret |= {"output": sr.api_output()}
+                    if sr.retention_policy == RetentionPolicy.delete:
+                        sr.state = {}
+                        sr.save(update_fields=["state", "updated_at"])
+                return ret
 
 
 def _parse_form_data(
@@ -497,7 +445,8 @@ def build_async_api_response(sr: "SavedRun") -> dict:
     web_url = sr.get_app_url()
     status_url = str(
         furl(settings.API_BASE_URL, query_params=dict(run_id=sr.run_id))
-        / Workflow(sr.workflow).page_cls.api_endpoint().replace("v2", "v3")
+        / "v3"
+        / Workflow(sr.workflow).page_cls.canonical_slug()
         / "status/"
     )
     return dict(

--- a/routers/bots_api.py
+++ b/routers/bots_api.py
@@ -41,7 +41,7 @@ MSG_ID_PREFIX = "web-"
 
 class CreateStreamRequestBase(BaseModel):
     integration_id: str = Field(
-        description="Your Integration ID as shown in the Copilot Deploy tab"
+        description="Your Integration ID as shown in the Agent Deploy tab"
     )
 
     conversation_id: str | None = Field(
@@ -100,8 +100,8 @@ class CreateStreamResponse(BaseModel):
     response_model=CreateStreamResponse,
     responses={402: {}},
     operation_id=VideoBotsPage.slug_versions[0] + "__stream_create",
-    tags=["Copilot Integrations"],
-    name="Copilot Integrations Create Stream",
+    tags=["Agent Integrations"],
+    name="Agent Integrations Create Stream",
 )
 def stream_create(request: CreateStreamRequest, response: Response):
     request_id = str(uuid.uuid4())
@@ -194,8 +194,8 @@ StreamEvent = ConversationStart | RunStart | MessagePart | FinalResponse | Strea
     response_model=StreamEvent,
     responses={402: {}},
     operation_id=VideoBotsPage.slug_versions[0] + "__stream",
-    tags=["Copilot Integrations"],
-    name="Copilot integrations Stream Response",
+    tags=["Agent Integrations"],
+    name="Agent Integrations Stream Response",
 )
 def stream_response(request_id: str):
     r = get_redis_cache().getdel(f"gooey/stream-init/v1/{request_id}")

--- a/routers/bots_api.py
+++ b/routers/bots_api.py
@@ -99,7 +99,7 @@ class CreateStreamResponse(BaseModel):
     "/v3/integrations/stream",
     response_model=CreateStreamResponse,
     responses={402: {}},
-    operation_id=VideoBotsPage.slug_versions[0] + "__stream_create",
+    operation_id=VideoBotsPage.canonical_slug() + "__stream_create",
     tags=["Agent Integrations"],
     name="Agent Integrations Create Stream",
 )
@@ -193,7 +193,7 @@ StreamEvent = ConversationStart | RunStart | MessagePart | FinalResponse | Strea
     "/v3/integrations/stream/{request_id}",
     response_model=StreamEvent,
     responses={402: {}},
-    operation_id=VideoBotsPage.slug_versions[0] + "__stream",
+    operation_id=VideoBotsPage.canonical_slug() + "__stream",
     tags=["Agent Integrations"],
     name="Agent Integrations Stream Response",
 )

--- a/routers/broadcast_api.py
+++ b/routers/broadcast_api.py
@@ -58,16 +58,6 @@ class BotBroadcastRequestModel(BaseModel):
 R = typing.TypeVar("R", bound=BotBroadcastRequestModel)
 
 
-@app.post(
-    f"/v2/{VideoBotsPage.slug_versions[0]}/broadcast/send/",
-    operation_id=VideoBotsPage.slug_versions[0] + "__broadcast",
-    tags=["Misc"],
-    name="Send Broadcast Message",
-)
-@app.post(
-    f"/v2/{VideoBotsPage.slug_versions[0]}/broadcast/send",
-    include_in_schema=False,
-)
 def broadcast_api_json(
     bot_request: BotBroadcastRequestModel,
     api_key: ApiKey = Depends(api_auth_header),
@@ -146,12 +136,16 @@ def broadcast_api_json(
     return {"status": "success", "count": total}
 
 
-for legacy_slug in VideoBotsPage.legacy_api_slugs():
+for slug in VideoBotsPage.slug_versions:
+    is_latest = slug == VideoBotsPage.canonical_slug()
     app.add_api_route(
-        f"/v2/{legacy_slug}/broadcast/send/",
-        broadcast_api_json,
         methods=["POST"],
-        include_in_schema=False,
+        path=f"/v2/{slug}/broadcast/send/",
+        endpoint=broadcast_api_json,
+        operation_id=slug + "__broadcast",
+        tags=["Misc"],
+        name="Send Broadcast Message",
+        include_in_schema=is_latest,
     )
 
 

--- a/routers/broadcast_api.py
+++ b/routers/broadcast_api.py
@@ -44,7 +44,7 @@ class BotBroadcastRequestModel(BaseModel):
         None, description="Document URLs to send to all users"
     )
     integration_id: str | None = Field(
-        description="The Bot's Integration ID as shown in the Copilot Deploy tab or as variables in a function call."
+        description="The Bot's Integration ID as shown in the Agent Deploy tab or as variables in a function call."
     )
     buttons: list[ReplyButton] | None = Field(
         None, description="Buttons to send to all users"
@@ -144,6 +144,15 @@ def broadcast_api_json(
         )
 
     return {"status": "success", "count": total}
+
+
+for legacy_slug in VideoBotsPage.legacy_api_slugs():
+    app.add_api_route(
+        f"/v2/{legacy_slug}/broadcast/send/",
+        broadcast_api_json,
+        methods=["POST"],
+        include_in_schema=False,
+    )
 
 
 def ensure_slack_personal_channels(

--- a/routers/root.py
+++ b/routers/root.py
@@ -666,7 +666,7 @@ def render_recipe_page(
         raise RecipePageNotFound
 
     # ensure the latest slug is used
-    latest_slug = page_cls.slug_versions[-1]
+    latest_slug = page_cls.canonical_slug()
     if latest_slug != page_slug:
         new_url = furl(request.url)
         for i, seg in enumerate(new_url.path.segments):

--- a/routers/root.py
+++ b/routers/root.py
@@ -100,7 +100,7 @@ async def favicon():
     return FileResponse("static/favicon.ico")
 
 
-@app.get("/docs", include_in_schema=False)
+@app.get("/docs")
 async def redoc_html():
     return get_redoc_html(
         openapi_url="/openapi.json",

--- a/routers/slack_api.py
+++ b/routers/slack_api.py
@@ -265,7 +265,7 @@ def slack_oauth_shortcuts():
 
 @router.get("/__/slack/redirect/shortcuts/")
 def slack_connect_redirect_shortcuts(
-    request: Request, shortcut_name: str = "Start Copilot"
+    request: Request, shortcut_name: str = "Start Agent"
 ):
     retry_button = f'<a href="{slack_shortcuts_connect_url}">Retry</a>'
 

--- a/scripts/migrate_existing_subscriptions.py
+++ b/scripts/migrate_existing_subscriptions.py
@@ -58,7 +58,7 @@ available_subscriptions = {
         "display": {
             "name": "Premium Plan",
             "title": "$50/month + Bots",
-            "description": '10000 Credits (~2000 runs) for $50/month. Includes special access to build bespoke, embeddable <a href="/video-bots/">videobots</a>.',
+            "description": '10000 Credits (~2000 runs) for $50/month. Includes special access to build bespoke, embeddable <a href="/agent/">agents</a>.',
         },
         "stripe": {
             "price_data": {

--- a/tests/test_apis.py
+++ b/tests/test_apis.py
@@ -1,3 +1,4 @@
+import json
 import typing
 
 from starlette.testclient import TestClient
@@ -5,6 +6,7 @@ from starlette.testclient import TestClient
 from bots.models import Workflow, PublishedRun
 from daras_ai_v2.all_pages import all_test_pages
 from daras_ai_v2.base import BasePage
+from recipes.VideoBots import VideoBotsPage
 from server import app
 
 MAX_WORKERS = 20
@@ -25,6 +27,25 @@ def _test_api_sync(page_cls: typing.Type[BasePage], endpoint: str):
     r = client.post(
         endpoint,
         json=page_cls.get_example_request(state)[1],
+        headers={"Authorization": "Token None"},
+        follow_redirects=False,
+    )
+    assert r.status_code == 200, r.text
+
+
+def test_agent_legacy_api_sync_alias(
+    mock_celery_tasks, db_fixtures, force_authentication
+):
+    _test_api_sync(VideoBotsPage, "/v2/video-bots/")
+
+
+def test_agent_legacy_api_form_alias(
+    mock_celery_tasks, db_fixtures, force_authentication
+):
+    state = VideoBotsPage.get_root_pr().saved_run.state
+    r = client.post(
+        "/v2/video-bots/form/",
+        data={"json": json.dumps(VideoBotsPage.get_example_request(state)[1])},
         headers={"Authorization": "Token None"},
         follow_redirects=False,
     )
@@ -64,6 +85,33 @@ def _test_api_async(page_cls: typing.Type[BasePage], endpoint: str):
     assert status, data
     if status == "completed":
         assert "output" in data, data
+
+
+def test_agent_legacy_api_async_alias(
+    mock_celery_tasks, db_fixtures, force_authentication
+):
+    _test_api_async(VideoBotsPage, "/v3/video-bots/async/")
+
+
+def test_agent_legacy_api_async_form_and_status_aliases(
+    mock_celery_tasks, db_fixtures, force_authentication
+):
+    state = VideoBotsPage.get_root_pr().saved_run.state
+    r = client.post(
+        "/v3/video-bots/async/form/",
+        data={"json": json.dumps(VideoBotsPage.get_example_request(state)[1])},
+        headers={"Authorization": "Token None"},
+        follow_redirects=False,
+    )
+    assert r.status_code == 202, r.text
+
+    r = client.get(
+        "/v3/video-bots/status/",
+        params={"run_id": r.json()["run_id"]},
+        headers={"Authorization": "Token None"},
+        follow_redirects=False,
+    )
+    assert r.status_code == 200, r.text
 
 
 def test_apis_examples(

--- a/tests/test_apis.py
+++ b/tests/test_apis.py
@@ -1,4 +1,3 @@
-import json
 import typing
 
 from starlette.testclient import TestClient
@@ -6,8 +5,8 @@ from starlette.testclient import TestClient
 from bots.models import Workflow, PublishedRun
 from daras_ai_v2.all_pages import all_test_pages
 from daras_ai_v2.base import BasePage
-from recipes.VideoBots import VideoBotsPage
 from server import app
+from tests.test_public_endpoints import random_slug
 
 MAX_WORKERS = 20
 
@@ -18,7 +17,7 @@ def test_apis_sync(
     mock_celery_tasks, db_fixtures, force_authentication, threadpool_subtest
 ):
     for page_cls in all_test_pages:
-        endpoint = f"/v2/{page_cls.slug_versions[0]}/"
+        endpoint = f"/v2/{random_slug(page_cls)}/"
         threadpool_subtest(_test_api_sync, page_cls, endpoint, msg=endpoint)
 
 
@@ -33,30 +32,11 @@ def _test_api_sync(page_cls: typing.Type[BasePage], endpoint: str):
     assert r.status_code == 200, r.text
 
 
-def test_agent_legacy_api_sync_alias(
-    mock_celery_tasks, db_fixtures, force_authentication
-):
-    _test_api_sync(VideoBotsPage, "/v2/video-bots/")
-
-
-def test_agent_legacy_api_form_alias(
-    mock_celery_tasks, db_fixtures, force_authentication
-):
-    state = VideoBotsPage.get_root_pr().saved_run.state
-    r = client.post(
-        "/v2/video-bots/form/",
-        data={"json": json.dumps(VideoBotsPage.get_example_request(state)[1])},
-        headers={"Authorization": "Token None"},
-        follow_redirects=False,
-    )
-    assert r.status_code == 200, r.text
-
-
 def test_apis_async(
     mock_celery_tasks, db_fixtures, force_authentication, threadpool_subtest
 ):
     for page_cls in all_test_pages:
-        endpoint = f"/v3/{page_cls.slug_versions[0]}/async/"
+        endpoint = f"/v3/{random_slug(page_cls)}/async/"
         threadpool_subtest(_test_api_async, page_cls, endpoint, msg=endpoint)
 
 
@@ -87,40 +67,13 @@ def _test_api_async(page_cls: typing.Type[BasePage], endpoint: str):
         assert "output" in data, data
 
 
-def test_agent_legacy_api_async_alias(
-    mock_celery_tasks, db_fixtures, force_authentication
-):
-    _test_api_async(VideoBotsPage, "/v3/video-bots/async/")
-
-
-def test_agent_legacy_api_async_form_and_status_aliases(
-    mock_celery_tasks, db_fixtures, force_authentication
-):
-    state = VideoBotsPage.get_root_pr().saved_run.state
-    r = client.post(
-        "/v3/video-bots/async/form/",
-        data={"json": json.dumps(VideoBotsPage.get_example_request(state)[1])},
-        headers={"Authorization": "Token None"},
-        follow_redirects=False,
-    )
-    assert r.status_code == 202, r.text
-
-    r = client.get(
-        "/v3/video-bots/status/",
-        params={"run_id": r.json()["run_id"]},
-        headers={"Authorization": "Token None"},
-        follow_redirects=False,
-    )
-    assert r.status_code == 200, r.text
-
-
 def test_apis_examples(
     mock_celery_tasks, db_fixtures, force_authentication, threadpool_subtest
 ):
     qs = PublishedRun.objects.filter(PublishedRun.approved_example_q())
     for pr in qs:
         page_cls = Workflow(pr.workflow).page_cls
-        endpoint = f"/v2/{page_cls.slug_versions[0]}/?example_id={pr.published_run_id}"
+        endpoint = f"/v2/{random_slug(page_cls)}/?example_id={pr.published_run_id}"
         body = page_cls.get_example_request(pr.saved_run.state)[1]
         threadpool_subtest(_test_apis_examples, endpoint, body, msg=endpoint)
 

--- a/tests/test_public_endpoints.py
+++ b/tests/test_public_endpoints.py
@@ -12,6 +12,7 @@ from bots.models import (
     PublishedRun,
     Workflow,
 )
+from daras_ai_v2.base import BasePage
 from daras_ai_v2.fastapi_tricks import get_route_path
 from routers import facebook_api
 from routers.root import RecipeTabs, integrations_stats_route
@@ -88,7 +89,7 @@ def test_integration_stats_route(db_fixtures, force_authentication, threadpool_s
 def test_all_post(db_fixtures, force_authentication, threadpool_subtest):
     for pr in PublishedRun.objects.all():
         for tab in RecipeTabs:
-            slug = random.choice(Workflow(pr.workflow).page_cls.slug_versions)
+            slug = random_slug(Workflow(pr.workflow).page_cls)
             url_path = tab.url_path(slug, "test-run-slug", pr.published_run_id)
             if RecipeTabs in [RecipeTabs.run, RecipeTabs.run_as_api]:
                 test_content = [pr.title]
@@ -109,3 +110,7 @@ def _test_post_path(url, *test_content):
         return
     else:
         assert False, f"Too many redirects: {url}"
+
+
+def random_slug(page_cls: type[BasePage]) -> str:
+    return random.choice(page_cls.slug_versions)


### PR DESCRIPTION
Put agent at slug_versions[0] for API and canonical UI URLs. Register hidden legacy /v2/video-bots/ routes and 301 old UI slugs to /agent/.

### Q/A checklist

- [ ] I have tested my UI changes on mobile and they look acceptable
- [ ] I have tested changes to the workflows in both the API and the UI
- [ ] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [ ] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
