### PR TITLE
fix: realtime_pull from both workflow and builder channels

### DIFF
--- a/daras_ai_v2/base.py
+++ b/daras_ai_v2/base.py
@@ -372,11 +372,14 @@ class BasePage:
             gui.realtime_clear_subs()
             return
 
+        sr = self.current_sr
+        workflow_channel = self.realtime_channel_name(sr.run_id, sr.uid)
+
         if is_builder_running:
             builder_channel = VideoBotsPage.realtime_channel_name(
                 builder_sr.run_id, builder_sr.uid
             )
-            gui.realtime_pull([builder_channel])
+            gui.realtime_pull([workflow_channel, builder_channel])
 
             new_state = self.current_sr_to_session_state()
             for k in ["--prev-request-hash"]:
@@ -387,9 +390,7 @@ class BasePage:
             gui.session_state.clear()
             gui.session_state.update(new_state)
         else:
-            sr = self.current_sr
-            channel = self.realtime_channel_name(sr.run_id, sr.uid)
-            output = gui.realtime_pull([channel])[0]
+            output = gui.realtime_pull([workflow_channel])[0]
             if output:
                 gui.session_state.update(output)
 


### PR DESCRIPTION
### Q/A checklist

- [ ] I have tested my UI changes on mobile and they look acceptable
- [ ] I have tested changes to the workflows in both the API and the UI
- [ ] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [ ] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
