### PR TITLE
fix: run Composio meta tools in a per-conversation tool-router session

### DIFF
--- a/functions/base_llm_tool.py
+++ b/functions/base_llm_tool.py
@@ -268,10 +268,7 @@ def functions_input(
             col2.node.children[0].props["className"] += " col-12"
 
     def render_section():
-        from functions.composio_tools import (
-            render_inbuilt_tools_selector,
-            render_composio_meta_tool_scope_warning,
-        )
+        from functions.composio_tools import render_inbuilt_tools_selector
 
         gui.session_state.setdefault(key, [{}])
         with gui.div(className="d-flex align-items-center gap-3 mb-2"):
@@ -286,7 +283,6 @@ def functions_input(
             render_inbuilt_tools_selector()
 
         list_view_editor(key=key, render_inputs=render_inputs)
-        render_composio_meta_tool_scope_warning(gui.session_state[key])
 
     functions_enabled = switch_with_section(
         f"##### {field_title_desc(BasePage.RequestModel, key)}",

--- a/functions/base_llm_tool.py
+++ b/functions/base_llm_tool.py
@@ -268,7 +268,10 @@ def functions_input(
             col2.node.children[0].props["className"] += " col-12"
 
     def render_section():
-        from functions.composio_tools import render_inbuilt_tools_selector
+        from functions.composio_tools import (
+            render_inbuilt_tools_selector,
+            render_composio_meta_tool_scope_warning,
+        )
 
         gui.session_state.setdefault(key, [{}])
         with gui.div(className="d-flex align-items-center gap-3 mb-2"):
@@ -283,6 +286,7 @@ def functions_input(
             render_inbuilt_tools_selector()
 
         list_view_editor(key=key, render_inputs=render_inputs)
+        render_composio_meta_tool_scope_warning(gui.session_state[key])
 
     functions_enabled = switch_with_section(
         f"##### {field_title_desc(BasePage.RequestModel, key)}",

--- a/functions/composio_tools.py
+++ b/functions/composio_tools.py
@@ -102,31 +102,6 @@ def is_composio_meta_tool(slug: str) -> bool:
     return slug.startswith("COMPOSIO_")
 
 
-def render_composio_meta_tool_scope_warning(functions: list[dict]) -> None:
-    # Meta tools share one Composio tool-router session per run, keyed to the first
-    # caller's scope.
-    from functions.base_llm_tool import get_external_tool_slug_from_url
-    from functions.models import FunctionScopes
-
-    composio_meta_tool_scopes = set()
-    for function in functions:
-        composio_tool_slug = get_external_tool_slug_from_url(
-            function.get("url") or ""
-        ) or function.get("slug")
-        if not composio_tool_slug or not is_composio_meta_tool(composio_tool_slug):
-            continue
-        composio_meta_tool_scopes.add(
-            function.get("scope") or FunctionScopes.workspace.name
-        )
-    if len(composio_meta_tool_scopes) <= 1:
-        return
-    gui.error(
-        "Set the same scope on all Composio tools.",
-        icon="⚠️",
-        color="#ffe8b2",
-    )
-
-
 def get_or_create_composio_tool_router_session_id(
     composio: Composio,
     *,

--- a/functions/composio_tools.py
+++ b/functions/composio_tools.py
@@ -45,9 +45,23 @@ class ComposioLLMTool(BaseLLMTool):
         import composio_client
         from composio import Composio
 
-        requires_auth = not self.tool.no_auth
-
         composio = Composio()
+        if is_composio_meta_tool(self.tool.slug):
+            session = composio.use(
+                get_or_create_composio_tool_router_session_id(
+                    composio,
+                    user_id=self.user_id,
+                    redirect_url=self.redirect_url,
+                )
+            )
+            response = session.execute(tool_slug=self.tool.slug, arguments=kwargs)
+            return {
+                "data": response.data or {},
+                "error": response.error,
+                "successful": not response.error,
+            }
+
+        requires_auth = not self.tool.no_auth
         try:
             return composio.tools.execute(
                 slug=self.tool.slug,
@@ -79,6 +93,51 @@ class ComposioLLMTool(BaseLLMTool):
             arguments=kwargs,
             dangerously_skip_version_check=True,
         )
+
+
+def is_composio_meta_tool(slug: str) -> bool:
+    return slug.startswith("COMPOSIO_")
+
+
+def render_composio_meta_tool_scope_warning(functions: list[dict]) -> None:
+    # Meta tools share one Composio tool-router session per run, keyed to the first
+    # caller's scope.
+    from functions.base_llm_tool import get_external_tool_slug_from_url
+    from functions.models import FunctionScopes
+
+    composio_meta_tool_scopes = set()
+    for function in functions:
+        composio_tool_slug = get_external_tool_slug_from_url(
+            function.get("url") or ""
+        ) or function.get("slug")
+        if not composio_tool_slug or not is_composio_meta_tool(composio_tool_slug):
+            continue
+        composio_meta_tool_scopes.add(
+            function.get("scope") or FunctionScopes.workspace.name
+        )
+    if len(composio_meta_tool_scopes) <= 1:
+        return
+    gui.error(
+        "Set the same scope on all Composio tools.",
+        icon="⚠️",
+        color="#ffe8b2",
+    )
+
+
+def get_or_create_composio_tool_router_session_id(
+    composio: Composio,
+    *,
+    user_id: str,
+    redirect_url: str,
+) -> str:
+    manage_connections = {"enable": True, "callback_url": redirect_url}
+
+    cache_key = f"composio_session_id:{user_id}"
+    if session_id := gui.session_state.get(cache_key):
+        return session_id
+    session = composio.create(user_id=user_id, manage_connections=manage_connections)
+    gui.session_state[cache_key] = session.session_id
+    return session.session_id
 
 
 def render_inbuilt_tools_selector(key: str = "inbuilt_tools_selector") -> None:

--- a/functions/composio_tools.py
+++ b/functions/composio_tools.py
@@ -24,6 +24,9 @@ if typing.TYPE_CHECKING:
     from composio_client.types.tool_proxy_response import ToolProxyResponse
 
 
+COMPOSIO_TOOL_ROUTER_SESSION_ID_KEY = "__composio_tool_router_session_id__"
+
+
 class ComposioLLMTool(BaseLLMTool):
     def __init__(self, tool: Tool, scope: str | None):
         self.tool = tool
@@ -132,11 +135,10 @@ def get_or_create_composio_tool_router_session_id(
 ) -> str:
     manage_connections = {"enable": True, "callback_url": redirect_url}
 
-    cache_key = f"composio_session_id:{user_id}"
-    if session_id := gui.session_state.get(cache_key):
+    if session_id := gui.session_state.get(COMPOSIO_TOOL_ROUTER_SESSION_ID_KEY):
         return session_id
     session = composio.create(user_id=user_id, manage_connections=manage_connections)
-    gui.session_state[cache_key] = session.session_id
+    gui.session_state[COMPOSIO_TOOL_ROUTER_SESSION_ID_KEY] = session.session_id
     return session.session_id
 
 


### PR DESCRIPTION
COMPOSIO_* tools require a Composio tool-router session, so persist composio_session_id on Conversation and route meta-tool calls through composio.use while keeping app tools on tools.execute.

### Q/A checklist

- [ ] I have tested my UI changes on mobile and they look acceptable
- [ ] I have tested changes to the workflows in both the API and the UI
- [ ] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [ ] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
