### PR TITLE
fix: migrate OpenAI realtime websocket to GA

### DIFF
--- a/daras_ai_v2/language_model.py
+++ b/daras_ai_v2/language_model.py
@@ -421,7 +421,6 @@ def _run_chat_model(
                 audio_url=audio_url,
                 audio_session_extra=audio_session_extra,
                 messages=messages,
-                temperature=temperature,
                 tools=tools,
             )
         case ModelProvider.openai:

--- a/daras_ai_v2/language_model_openai_audio.py
+++ b/daras_ai_v2/language_model_openai_audio.py
@@ -14,7 +14,6 @@ from daras_ai_v2 import settings
 from daras_ai_v2.asr import audio_url_to_wav
 from daras_ai_v2.exceptions import ffmpeg
 from daras_ai_v2.language_model_openai_realtime import RealtimeSession
-from daras_ai_v2.utils import clamp
 from functions.base_llm_tool import BaseLLMTool
 from .language_model_openai_ws_tools import send_json, recv_json, send_recv_json
 
@@ -28,15 +27,12 @@ def run_openai_audio(
     audio_url: str | None,
     audio_session_extra: dict | None,
     messages: list,
-    temperature: float | None = None,
     tools: list[BaseLLMTool] | None = None,
     start_chunk_size: int = 50,
     stop_chunk_size: int = 400,
     step_chunk_size: int = 300,
 ):
     openai_ws, created = get_or_create_ws(model)
-
-    temperature = clamp(temperature, 0.6, 1.2)
 
     twilio_ws = None
     audio_data = None
@@ -61,7 +57,6 @@ def run_openai_audio(
             audio_data=audio_data,
             audio_session_extra=audio_session_extra,
             messages=messages,
-            temperature=temperature,
             tools=tools,
         )
         if twilio_ws:
@@ -129,7 +124,6 @@ def init_ws_session(
     audio_data: str | None,
     audio_session_extra: dict | None,
     messages: list,
-    temperature: float | None = None,
     tools: list[BaseLLMTool] | None = None,
 ):
     from daras_ai_v2.language_model import get_entry_text, msgs_to_prompt_str

--- a/daras_ai_v2/language_model_openai_audio.py
+++ b/daras_ai_v2/language_model_openai_audio.py
@@ -44,8 +44,8 @@ def run_openai_audio(
         # if the audio_url is a websocket url, connect to it
         twilio_ws = connect(audio_url)
         audio_session_extra = (audio_session_extra or {}) | {
-            "input_audio_format": "g711_ulaw",
-            "output_audio_format": "g711_ulaw",
+            "input_audio_format": {"type": "audio/pcmu"},
+            "output_audio_format": {"type": "audio/pcmu"},
             "turn_detection": {"type": "server_vad"},
         }
     elif audio_url and created:
@@ -117,7 +117,6 @@ def get_or_create_ws(model) -> tuple[ClientConnection, bool]:
             ).url,
             additional_headers={
                 "Authorization": "Bearer " + settings.OPENAI_API_KEY,
-                "OpenAI-Beta": "realtime=v1",
             },
         )
         created = True
@@ -170,14 +169,28 @@ def init_ws_session(
 
     # https://platform.openai.com/docs/api-reference/realtime-client-events/session/update
     session_data = {
+        "type": "realtime",
         "instructions": system_message,
-        "input_audio_transcription": {"model": "whisper-1"},
-        "turn_detection": None,
-        "temperature": temperature,
-        # "max_response_output_tokens": "inf",
+        "audio": {
+            "input": {
+                "transcription": {"model": "whisper-1"},
+                "turn_detection": None,
+            },
+        },
     }
     if audio_session_extra:
-        session_data |= audio_session_extra
+        audio_output = {}
+
+        if turn_detection := audio_session_extra.get("turn_detection"):
+            session_data["audio"]["input"]["turn_detection"] = turn_detection
+        if input_audio_format := audio_session_extra.get("input_audio_format"):
+            session_data["audio"]["input"]["format"] = input_audio_format
+        if output_audio_format := audio_session_extra.get("output_audio_format"):
+            audio_output["format"] = output_audio_format
+        if voice := audio_session_extra.get("voice"):
+            audio_output["voice"] = voice
+        if audio_output:
+            session_data["audio"]["output"] = audio_output
     if tools:
         session_data["tools"] = [tool.spec_openai_audio for tool in tools]
     send_recv_json(ws, {"type": "session.update", "session": session_data})
@@ -208,7 +221,9 @@ def stream_ws_response(
     while output is None or (wait_for_transcript and input_audio_transcript is None):
         event = recv_json(ws)
         match event.get("type"):
-            case "response.audio_transcript.delta" | "response.text.delta":
+            case (
+                "response.output_audio_transcript.delta" | "response.output_text.delta"
+            ):
                 entry["chunk"] += event["delta"]
                 if is_llm_chunk_large_enough(entry, chunk_size):
                     # increase the chunk size, but don't go over the max
@@ -216,7 +231,7 @@ def stream_ws_response(
                     # stream the chunk
                     yield entry
 
-            case "response.audio.delta":
+            case "response.output_audio.delta":
                 output_pcm += base64.b64decode(event["delta"])
 
             case "conversation.item.input_audio_transcription.completed":

--- a/daras_ai_v2/language_model_openai_realtime.py
+++ b/daras_ai_v2/language_model_openai_realtime.py
@@ -70,7 +70,7 @@ class RealtimeSession:
 
         dispatch = {
             "input_audio_buffer.speech_started": self.on_speech_started,
-            "response.audio.delta": self.on_audio_delta,
+            "response.output_audio.delta": self.on_audio_delta,
             "conversation.item.input_audio_transcription.completed": self.on_transcription_completed,
             "response.output_item.done": self.on_output_item_done,
             "response.done": self.on_response_done,


### PR DESCRIPTION
- OpenAI rejected Realtime websocket connections that still sent the beta negotiation header, and the old flat session/event shape could fail after the connection moved to the GA interface.

- Remove the beta header, send the session audio config in the GA shape, and keep legacy event names alongside GA names so existing streaming and Twilio paths continue to work.

https://developers.openai.com/api/docs/guides/realtime#beta-to-ga-migration

### Q/A checklist

- [ ] I have tested my UI changes on mobile and they look acceptable
- [ ] I have tested changes to the workflows in both the API and the UI
- [ ] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [ ] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
