### PR TITLE
fix: home saved card — LineClamp description & cap thumbnail height

### DIFF
--- a/gooey-gui/app/components/HomePage/HomePage.css
+++ b/gooey-gui/app/components/HomePage/HomePage.css
@@ -25,6 +25,7 @@
 .saved-card-thumb {
   width: 72px;
   min-height: 72px;
+  max-height: 72px;
   align-self: stretch;
   object-fit: cover;
 }

--- a/gooey-gui/app/components/HomePage/workflows.tsx
+++ b/gooey-gui/app/components/HomePage/workflows.tsx
@@ -190,8 +190,10 @@ export function SavedWorkflowCard({ card }: { card: WorkflowCardData }) {
             </span>
           </div>
           {card.description && (
-            <div className="text-muted small line-clamp-2 text-break mt-1">
-              {card.description}
+            <div className="text-muted small text-break mt-1">
+              <LineClamp lines={2} expandable={false}>
+                {card.description}
+              </LineClamp>
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary

- Replace raw `line-clamp-2` CSS class with `<LineClamp lines={2} expandable={false}>` component on the description in `SavedWorkflowCard`
- Add `max-height: 72px` to `.saved-card-thumb` so the thumbnail image never grows beyond its fixed size regardless of description length

## Before
The card description rendered the full text (no clamping) and the thumbnail image stretched vertically alongside it.

## Test plan
- [ ] Open the home page while logged in
- [ ] Verify saved workflow cards show description clamped to 2 lines
- [ ] Verify the thumbnail image stays at 72×72px even for cards with long descriptions

---
_Generated by [Claude Code](https://claude.ai/code/session_01CccKsMmDdY3EobpPCRdd4x)_