### PR TITLE
feat: filter TTS providers and voices by language

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -134,5 +134,6 @@ jobs:
           TEST_SLACK_TEAM_ID: ${{ secrets.TEST_SLACK_TEAM_ID }}
           TEST_SLACK_USER_ID: ${{ secrets.TEST_SLACK_USER_ID }}
           TEST_SLACK_AUTH_TOKEN: ${{ secrets.TEST_SLACK_AUTH_TOKEN }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           poetry run ./scripts/run-tests.sh

--- a/daras_ai_v2/asr.py
+++ b/daras_ai_v2/asr.py
@@ -39,8 +39,9 @@ from daras_ai_v2.gpu_server import call_celery_task
 from daras_ai_v2.language_filters import (
     filter_languages,
     filter_models_by_language,
+    lang_format_func,
     normalised_lang_in_collection,
-    are_languages_same,
+    sort_language_options,
 )
 from daras_ai_v2.redis_cache import redis_cache_decorator
 from daras_ai_v2.scraping_proxy import SCRAPING_PROXIES, get_scraping_proxy_cert_path
@@ -725,58 +726,6 @@ def asr_language_selector(
         options=options,
         allow_none=allow_none,
     )
-
-
-def sort_language_options(options: list[str | None], sort_by: str | None):
-    sort_by = sort_by or "en"
-    options.sort(key=lambda tag: tag and are_languages_same(tag, sort_by), reverse=True)
-
-
-def language_filter_selector(
-    *,
-    options: list[str],
-    label: str = '<i class="fa-sharp-duotone fa-solid fa-bars-filter"></i> &nbsp; Filter by Language',
-    key: str = "language_filter",
-) -> str:
-    clear_key = key + ":clear"
-    if gui.session_state.pop(clear_key, None):
-        gui.session_state[key] = None
-
-    with gui.div(className="d-flex align-items-center"):
-        if label:
-            with gui.div(className="me-3 text-muted"):
-                gui.caption(label, unsafe_allow_html=True)
-
-        with gui.div(style=dict(minWidth="200px")):
-            language_filter = gui.selectbox(
-                label="",
-                label_visibility="collapsed",
-                key=key,
-                format_func=lambda tag: lang_format_func(tag, default="All Languages"),
-                options=options,
-                allow_none=True,
-            )
-
-        if language_filter:
-            gui.button(
-                '<i class="fa-solid fa-circle-xmark"></i>',
-                type="tertiary",
-                key=clear_key,
-                className="px-2 py-1 ms-1",
-            )
-
-    return language_filter
-
-
-def lang_format_func(tag: str, *, default: str = "Auto Detect") -> str:
-    import langcodes
-
-    if not tag:
-        return default
-    try:
-        return f"{langcodes.Language.get(tag).display_name()} | {tag}"
-    except langcodes.LanguageTagError:
-        return tag
 
 
 def run_translate(

--- a/daras_ai_v2/language_filters.py
+++ b/daras_ai_v2/language_filters.py
@@ -39,7 +39,6 @@ def asr_languages_without_dialects() -> list[str]:
     )
 
 
-@redis_cache_decorator(ex=settings.REDIS_MODELS_CACHE_EXPIRY)
 def tts_languages_without_dialects() -> list[str]:
     from daras_ai_v2.text_to_speech_settings_widgets import (
         tts_supported_languages_by_provider,

--- a/daras_ai_v2/language_filters.py
+++ b/daras_ai_v2/language_filters.py
@@ -101,28 +101,35 @@ def language_filter_selector(
     if gui.session_state.pop(clear_key, None):
         gui.session_state[key] = None
 
-    with gui.div(className="d-flex align-items-center"):
+    with gui.div(
+        className="d-flex flex-column flex-md-row align-items-md-center gap-2"
+    ):
         if label:
-            with gui.div(className="me-3 text-muted"):
+            with gui.div(className="text-muted flex-shrink-0"):
                 gui.caption(label, unsafe_allow_html=True)
 
-        with gui.div(style=dict(minWidth="200px")):
-            language_filter = gui.selectbox(
-                label="",
-                label_visibility="collapsed",
-                key=key,
-                format_func=lambda tag: lang_format_func(tag, default="All Languages"),
-                options=options,
-                allow_none=True,
-            )
+        with gui.div(className="d-flex align-items-center w-100 w-md-auto"):
+            with gui.div(
+                className="flex-grow-1 flex-md-grow-0", style=dict(minWidth="200px")
+            ):
+                language_filter = gui.selectbox(
+                    label="",
+                    label_visibility="collapsed",
+                    key=key,
+                    format_func=lambda tag: lang_format_func(
+                        tag, default="All Languages"
+                    ),
+                    options=options,
+                    allow_none=True,
+                )
 
-        if language_filter:
-            gui.button(
-                '<i class="fa-solid fa-circle-xmark"></i>',
-                type="tertiary",
-                key=clear_key,
-                className="px-2 py-1 ms-1",
-            )
+            if language_filter:
+                gui.button(
+                    '<i class="fa-solid fa-circle-xmark"></i>',
+                    type="tertiary",
+                    key=clear_key,
+                    className="px-2 py-1 ms-1 flex-shrink-0",
+                )
 
     return language_filter
 

--- a/daras_ai_v2/language_filters.py
+++ b/daras_ai_v2/language_filters.py
@@ -93,7 +93,7 @@ def filter_languages(
 def language_filter_selector(
     *,
     options: list[str],
-    label: str = '<i class="fa-sharp-duotone fa-solid fa-bars-filter"></i> &nbsp; Filter by Language',
+    label: str = '<i class="fa-sharp-duotone fa-solid fa-bars-filter"></i> &nbsp; Filter to',
     key: str = "language_filter",
 ) -> str | None:
     clear_key = key + ":clear"

--- a/daras_ai_v2/language_filters.py
+++ b/daras_ai_v2/language_filters.py
@@ -1,5 +1,7 @@
 import typing
 
+
+import gooey_gui as gui
 import langcodes
 
 from daras_ai_v2 import settings
@@ -38,6 +40,26 @@ def asr_languages_without_dialects() -> list[str]:
     )
 
 
+@redis_cache_decorator(ex=settings.REDIS_MODELS_CACHE_EXPIRY)
+def tts_languages_without_dialects() -> list[str]:
+    from daras_ai_v2.text_to_speech_settings_widgets import (
+        tts_supported_languages_by_provider,
+    )
+
+    return sorted(
+        set(
+            lang
+            for tag in flatten(tts_supported_languages_by_provider().values())
+            if (lang := normalized_lang_or_none(tag))
+        )
+    )
+
+
+def sort_language_options(options: list[str | None], sort_by: str | None):
+    sort_by = sort_by or "en"
+    options.sort(key=lambda tag: tag and are_languages_same(tag, sort_by), reverse=True)
+
+
 def filter_models_by_language(
     language_filter: str | None,
     supported_languages_by_model: dict[T, typing.Iterable[str]],
@@ -67,6 +89,51 @@ def filter_languages(
             collection,
         )
     )
+
+
+def language_filter_selector(
+    *,
+    options: list[str],
+    label: str = '<i class="fa-sharp-duotone fa-solid fa-bars-filter"></i> &nbsp; Filter by Language',
+    key: str = "language_filter",
+) -> str | None:
+    clear_key = key + ":clear"
+    if gui.session_state.pop(clear_key, None):
+        gui.session_state[key] = None
+
+    with gui.div(className="d-flex align-items-center"):
+        if label:
+            with gui.div(className="me-3 text-muted"):
+                gui.caption(label, unsafe_allow_html=True)
+
+        with gui.div(style=dict(minWidth="200px")):
+            language_filter = gui.selectbox(
+                label="",
+                label_visibility="collapsed",
+                key=key,
+                format_func=lambda tag: lang_format_func(tag, default="All Languages"),
+                options=options,
+                allow_none=True,
+            )
+
+        if language_filter:
+            gui.button(
+                '<i class="fa-solid fa-circle-xmark"></i>',
+                type="tertiary",
+                key=clear_key,
+                className="px-2 py-1 ms-1",
+            )
+
+    return language_filter
+
+
+def lang_format_func(tag: str, *, default: str = "Auto Detect") -> str:
+    if not tag:
+        return default
+    try:
+        return f"{langcodes.Language.get(tag).display_name()} | {tag}"
+    except langcodes.LanguageTagError:
+        return tag
 
 
 def are_languages_same(tag1: str, tag2: str) -> bool:

--- a/daras_ai_v2/language_filters.py
+++ b/daras_ai_v2/language_filters.py
@@ -1,6 +1,5 @@
 import typing
 
-
 import gooey_gui as gui
 import langcodes
 
@@ -144,11 +143,7 @@ def lang_format_func(tag: str, *, default: str = "Auto Detect") -> str:
 
 
 def are_languages_same(tag1: str, tag2: str) -> bool:
-    import langcodes
-
-    """
-    Check if two language codes represent the same language.
-    """
+    """Check if two language codes represent the same language."""
     try:
         return (
             langcodes.Language.get(tag1).language
@@ -159,8 +154,6 @@ def are_languages_same(tag1: str, tag2: str) -> bool:
 
 
 def normalised_lang_in_collection(tag: str, collection: typing.Iterable[str]) -> str:
-    import langcodes
-
     if tag in collection:
         return tag
 

--- a/daras_ai_v2/redis_cache.py
+++ b/daras_ai_v2/redis_cache.py
@@ -20,14 +20,17 @@ def get_redis_cache():
 F = typing.TypeVar("F", bound=typing.Callable[..., typing.Any])
 
 
-def redis_cache_decorator(fn: F | None = None, ex=None) -> F:
+def redis_cache_decorator(fn: F | None = None, *, ex=None, version: int = 1) -> F:
     def decorator(fn: F) -> F:
         @wraps(fn)
         def wrapper(*args, **kwargs):
             # hash the args and kwargs so they are not too long
             args_hash = hashlib.sha256(f"{args}{kwargs}".encode()).hexdigest()
             # create a readable cache key
-            cache_key = f"gooey/redis-cache-decorator/v1/{fn.__name__}/{args_hash}"
+            # bump version when cached return shape changes
+            cache_key = (
+                f"gooey/redis-cache-decorator/v{version}/{fn.__name__}/{args_hash}"
+            )
             # lock the cache key so that only one thread can run the function
             with redis_lock(cache_key):
                 # get the redis cache

--- a/daras_ai_v2/text_to_speech_settings_widgets.py
+++ b/daras_ai_v2/text_to_speech_settings_widgets.py
@@ -139,6 +139,7 @@ BARK_ALLOWED_PROMPTS = {
 }
 
 
+@redis_cache_decorator(ex=settings.REDIS_MODELS_CACHE_EXPIRY)
 def tts_supported_languages_by_provider() -> dict[TextToSpeechProviders, list[str]]:
     from modal_functions.mms_tts import MMS_TTS_SUPPORTED_LANGUAGES
 

--- a/daras_ai_v2/text_to_speech_settings_widgets.py
+++ b/daras_ai_v2/text_to_speech_settings_widgets.py
@@ -633,7 +633,7 @@ def google_tts_language_codes() -> list[str]:
         return []
 
 
-@redis_cache_decorator(ex=settings.REDIS_MODELS_CACHE_EXPIRY)
+@redis_cache_decorator(ex=settings.REDIS_MODELS_CACHE_EXPIRY, version=2)
 def google_tts_voices() -> dict[str, "texttospeech.Voice"]:
     from google.cloud import texttospeech
 

--- a/daras_ai_v2/text_to_speech_settings_widgets.py
+++ b/daras_ai_v2/text_to_speech_settings_widgets.py
@@ -9,6 +9,10 @@ from daras_ai_v2.azure_asr import azure_auth_header
 from daras_ai_v2.custom_enum import GooeyEnum
 from daras_ai_v2.enum_selector_widget import enum_selector
 from daras_ai_v2.exceptions import raise_for_status
+from daras_ai_v2.language_filters import (
+    filter_languages,
+    filter_models_by_language,
+)
 from daras_ai_v2.redis_cache import redis_cache_decorator
 from managed_secrets.models import ManagedSecret
 from managed_secrets.widgets import edit_secret_button_with_dialog
@@ -103,69 +107,70 @@ ELEVEN_LABS_MODELS = {
     "eleven_multilingual_v1": "Multilingual V1",
 }
 
-ELEVEN_LABS_SUPPORTED_LANGS = [
-    "English",
-    "Japanese",
-    "Chinese",
-    "German",
-    "Hindi",
-    "French",
-    "Korean",
-    "Portuguese",
-    "Italian",
-    "Spanish",
-    "Indonesian",
-    "Dutch",
-    "Turkish",
-    "Filipino",
-    "Polish",
-    "Swedish",
-    "Bulgarian",
-    "Romanian",
-    "Arabic",
-    "Czech",
-    "Greek",
-    "Finnish",
-    "Croatian",
-    "Malay",
-    "Slovak",
-    "Danish",
-    "Tamil",
-    "Ukrainian",
-    "Russian",
-]
+ELEVEN_LABS_TTS_SUPPORTED_LANGUAGES = [
+    ("English", "en"), ("Japanese", "ja"), ("Chinese", "zh"), ("German", "de"), ("Hindi", "hi"), ("French", "fr"),
+    ("Korean", "ko"), ("Portuguese", "pt"), ("Italian", "it"), ("Spanish", "es"), ("Indonesian", "id"),
+    ("Dutch", "nl"), ("Turkish", "tr"), ("Filipino", "fil"), ("Polish", "pl"), ("Swedish", "sv"),
+    ("Bulgarian", "bg"), ("Romanian", "ro"), ("Arabic", "ar"), ("Czech", "cs"), ("Greek", "el"),
+    ("Finnish", "fi"), ("Croatian", "hr"), ("Malay", "ms"), ("Slovak", "sk"), ("Danish", "da"),
+    ("Tamil", "ta"), ("Ukrainian", "uk"), ("Russian", "ru"),
+]  # fmt: skip
 
-BARK_SUPPORTED_LANGS = [
-    ("English", "en"),
-    ("German", "de"),
-    ("Spanish", "es"),
-    ("French", "fr"),
-    ("Hindi", "hi"),
-    ("Italian", "it"),
-    ("Japanese", "ja"),
-    ("Korean", "ko"),
-    ("Polish", "pl"),
-    ("Portuguese", "pt"),
-    ("Russian", "ru"),
-    ("Turkish", "tr"),
+# https://platform.openai.com/docs/guides/text-to-speech
+OPENAI_TTS_SUPPORTED_LANGUAGES: list[str] = [
+    "af", "ar", "hy", "az", "be", "bs", "bg", "ca", "zh", "hr", "cs", "da", "nl", "en", "et", "fi", "fr", "gl", "de",
+    "el", "he", "hi", "hu", "is", "id", "it", "ja", "kn", "kk", "ko", "lv", "lt", "mk", "ms", "mr", "mi", "ne", "no",
+    "fa", "pl", "pt", "ro", "ru", "sr", "sk", "sl", "es", "sw", "sv", "tl", "ta", "th", "tr", "uk", "ur", "vi", "cy",
+]  # fmt: skip
+
+BARK_TTS_SUPPORTED_LANGUAGES = [
+    ("English", "en"), ("German", "de"), ("Spanish", "es"), ("French", "fr"), ("Hindi", "hi"), ("Italian", "it"),
+    ("Japanese", "ja"), ("Korean", "ko"), ("Polish", "pl"), ("Portuguese", "pt"), ("Russian", "ru"), ("Turkish", "tr"),
     ("Chinese", "zh"),
-]
+]  # fmt: skip
 
 BARK_ALLOWED_PROMPTS = {
     None: "———",
     "announcer": "Announcer",
 } | {
     f"{code}_speaker_{n}": f"Speaker {n} ({lang})"
-    for lang, code in BARK_SUPPORTED_LANGS
+    for lang, code in BARK_TTS_SUPPORTED_LANGUAGES
     for n in range(10)
 }
 
 
-def text_to_speech_provider_selector(page):
+def tts_supported_languages_by_provider() -> dict[TextToSpeechProviders, list[str]]:
+    from modal_functions.mms_tts import MMS_TTS_SUPPORTED_LANGUAGES
+
+    return {
+        TextToSpeechProviders.GOOGLE_TTS: google_tts_language_codes(),
+        TextToSpeechProviders.AZURE_TTS: azure_tts_language_codes(),
+        TextToSpeechProviders.MMS_TTS: MMS_TTS_SUPPORTED_LANGUAGES,
+        TextToSpeechProviders.BARK: [code for _, code in BARK_TTS_SUPPORTED_LANGUAGES],
+        TextToSpeechProviders.ELEVEN_LABS: [
+            code for _, code in ELEVEN_LABS_TTS_SUPPORTED_LANGUAGES
+        ],
+        TextToSpeechProviders.OPEN_AI: OPENAI_TTS_SUPPORTED_LANGUAGES,
+        TextToSpeechProviders.UBERDUCK: ["en"],
+        TextToSpeechProviders.GHANA_NLP: ["tw"],
+    }
+
+
+def text_to_speech_provider_selector(page, *, language_filter: str | None = None):
+    tts_provider_options = TextToSpeechProviders
+    if language_filter:
+        tts_provider_options = filter_models_by_language(
+            language_filter, tts_supported_languages_by_provider()
+        )
+        if not tts_provider_options:
+            gui.session_state["tts_provider"] = None
+            gui.error("No TTS provider available for the selected language.", icon="⚠️")
+            return None
+
     col1, col2 = gui.columns(2)
     with col1:
         tts_provider = enum_selector(
-            TextToSpeechProviders,
+            tts_provider_options,
             "###### Text-to-Speech Provider",
             key="tts_provider",
             use_selectbox=True,
@@ -173,21 +178,21 @@ def text_to_speech_provider_selector(page):
     with col2:
         match tts_provider:
             case TextToSpeechProviders.BARK.name:
-                bark_selector()
+                bark_selector(language_filter=language_filter)
             case TextToSpeechProviders.GOOGLE_TTS.name:
-                google_tts_selector()
+                google_tts_selector(language_filter=language_filter)
             case TextToSpeechProviders.UBERDUCK.name:
                 uberduck_selector()
             case TextToSpeechProviders.ELEVEN_LABS.name:
                 elevenlabs_selector(page)
             case TextToSpeechProviders.AZURE_TTS.name:
-                azure_tts_selector()
+                azure_tts_selector(language_filter=language_filter)
             case TextToSpeechProviders.OPEN_AI.name:
                 openai_tts_selector()
             case TextToSpeechProviders.GHANA_NLP.name:
                 ghana_nlp_tts_selector()
             case TextToSpeechProviders.MMS_TTS.name:
-                mms_tts_selector()
+                mms_tts_selector(language_filter=language_filter)
     return tts_provider
 
 
@@ -216,15 +221,18 @@ def ghana_nlp_tts_selector():
     )
 
 
-def mms_tts_selector():
+def mms_tts_selector(*, language_filter: str = ""):
     options = mms_tts_language_options()
+    language_options = list(options.keys())
+    if language_filter:
+        language_options = filter_languages(language_filter, language_options)
     gui.selectbox(
         label="""
         ###### MMS TTS Language
         """,
         key="mms_tts_language",
         format_func=lambda lang: options[lang],
-        options=options,
+        options=language_options,
     )
 
 
@@ -263,18 +271,24 @@ def openai_tts_settings():
     )
 
 
-def azure_tts_selector():
+def azure_tts_selector(*, language_filter: str = ""):
     if settings.AZURE_SPEECH_KEY:
         voices = azure_tts_voices()
     else:
         voices = {}
+    voice_options = list(voices.keys())
+    if language_filter:
+        voice_options = filter_models_by_language(
+            language_filter,
+            {voice: [voices[voice]["Locale"]] for voice in voice_options},
+        )
     gui.selectbox(
         label="""
         ###### Azure TTS Voice name
         """,
         key="azure_voice_name",
         format_func=lambda voice: f"{voices[voice].get('DisplayName')} - {voices[voice].get('LocaleName')}",
-        options=voices.keys(),
+        options=voice_options,
     )
 
 
@@ -302,6 +316,12 @@ def azure_tts_settings():
     )
 
 
+def azure_tts_language_codes() -> list[str]:
+    if not settings.AZURE_SPEECH_KEY:
+        return []
+    return sorted({voice["Locale"] for voice in azure_tts_voices().values()})
+
+
 @redis_cache_decorator(ex=settings.REDIS_MODELS_CACHE_EXPIRY)
 def azure_tts_voices() -> dict[str, dict[str, str]]:
     # E.g., {"af-ZA-AdriNeural": {
@@ -325,18 +345,24 @@ def azure_tts_voices() -> dict[str, dict[str, str]]:
     return {voice.get("ShortName", "Unknown"): voice for voice in res.json()}
 
 
-def bark_selector():
+def bark_selector(*, language_filter: str = ""):
+    voice_options = list(BARK_ALLOWED_PROMPTS)
+    if language_filter:
+        voice_options = [None] + filter_models_by_language(
+            language_filter,
+            {key: [key.split("_")[0]] for key in voice_options if key is not None},
+        )
     gui.selectbox(
         label="""
         ###### Bark History Prompt
         """,
         key="bark_history_prompt",
         format_func=BARK_ALLOWED_PROMPTS.__getitem__,
-        options=BARK_ALLOWED_PROMPTS.keys(),
+        options=voice_options,
     )
 
 
-def google_tts_selector():
+def google_tts_selector(*, language_filter: str | None = None):
     import google.auth.exceptions
 
     try:
@@ -344,13 +370,19 @@ def google_tts_selector():
     except google.auth.exceptions.DefaultCredentialsError:
         gui.error("Error fetching Google TTS voices. Please check your credentials.")
         return
+    voice_options = list(voices.keys())
+    if language_filter:
+        voice_options = filter_models_by_language(
+            language_filter,
+            {voice: [voices[voice].language_codes[0]] for voice in voice_options},
+        )
     gui.selectbox(
         label="""
         ###### Voice name (Google TTS)
         """,
         key="google_voice_name",
-        format_func=voices.__getitem__,
-        options=voices.keys(),
+        format_func=lambda voice: _pretty_voice(voices[voice]),
+        options=voice_options,
     )
     gui.caption(
         "*Please refer to the list of voice names [here](https://cloud.google.com/text-to-speech/docs/voices)*",
@@ -583,19 +615,24 @@ def elevenlabs_settings():
     ):
         gui.caption("With Multilingual V2 voice model", style={"fontSize": "0.8rem"})
         gui.caption(
-            ", ".join(ELEVEN_LABS_SUPPORTED_LANGS), style={"fontSize": "0.8rem"}
+            ", ".join(label for label, _ in ELEVEN_LABS_TTS_SUPPORTED_LANGUAGES),
+            style={"fontSize": "0.8rem"},
         )
 
 
+def google_tts_language_codes() -> list[str]:
+    return sorted({voice.language_codes[0] for voice in google_tts_voices().values()})
+
+
 @redis_cache_decorator(ex=settings.REDIS_MODELS_CACHE_EXPIRY)
-def google_tts_voices() -> dict[str, str]:
+def google_tts_voices() -> dict[str, "texttospeech.Voice"]:
     from google.cloud import texttospeech
 
     voices: list[texttospeech.Voice] = list(
         texttospeech.TextToSpeechClient().list_voices().voices
     )
     voices.sort(key=_voice_sort_key)
-    return {voice.name: _pretty_voice(voice) for voice in voices}
+    return {voice.name: voice for voice in voices if voice.language_codes}
 
 
 def _pretty_voice(voice) -> str:

--- a/daras_ai_v2/text_to_speech_settings_widgets.py
+++ b/daras_ai_v2/text_to_speech_settings_widgets.py
@@ -426,7 +426,6 @@ def uberduck_selector():
         ###### Voice name (Uberduck)
         """,
         key="uberduck_voice_name",
-        format_func=lambda option: f"{option}",
         options=UBERDUCK_VOICES.keys(),
     )
 
@@ -624,7 +623,14 @@ def elevenlabs_settings():
 
 
 def google_tts_language_codes() -> list[str]:
-    return sorted({voice.language_codes[0] for voice in google_tts_voices().values()})
+    import google.auth.exceptions
+
+    try:
+        return sorted(
+            {voice.language_codes[0] for voice in google_tts_voices().values()}
+        )
+    except google.auth.exceptions.DefaultCredentialsError:
+        return []
 
 
 @redis_cache_decorator(ex=settings.REDIS_MODELS_CACHE_EXPIRY)
@@ -635,7 +641,7 @@ def google_tts_voices() -> dict[str, "texttospeech.Voice"]:
         texttospeech.TextToSpeechClient().list_voices().voices
     )
     voices.sort(key=_voice_sort_key)
-    return {voice.name: voice for voice in voices if voice.language_codes}
+    return {voice.name: voice for voice in voices}
 
 
 def _pretty_voice(voice) -> str:

--- a/daras_ai_v2/text_to_speech_settings_widgets.py
+++ b/daras_ai_v2/text_to_speech_settings_widgets.py
@@ -348,10 +348,13 @@ def azure_tts_voices() -> dict[str, dict[str, str]]:
 def bark_selector(*, language_filter: str = ""):
     voice_options = list(BARK_ALLOWED_PROMPTS)
     if language_filter:
-        voice_options = [None] + filter_models_by_language(
-            language_filter,
-            {key: [key.split("_")[0]] for key in voice_options if key is not None},
-        )
+        voice_options = [
+            None,
+            *filter_models_by_language(
+                language_filter,
+                {key: [key.split("_")[0]] for key in voice_options if key is not None},
+            ),
+        ]
     gui.selectbox(
         label="""
         ###### Bark History Prompt

--- a/recipes/BulkRunner.py
+++ b/recipes/BulkRunner.py
@@ -718,6 +718,6 @@ def list_view_editor(
             render_labels()
     gui.session_state[key] = new_lst
     if add_btn_label:
-        with gui.center():
+        with gui.center(className="mb-3"):
             gui.button(f"{icons.add} {add_btn_label}", key=add_key, type=add_btn_type)
     return new_lst

--- a/recipes/TextToSpeech.py
+++ b/recipes/TextToSpeech.py
@@ -16,6 +16,10 @@ from daras_ai_v2.asr import GHANA_API_AUTH_HEADERS
 from daras_ai_v2.base import BasePage
 from daras_ai_v2.exceptions import UserError, raise_for_status
 from daras_ai_v2.gpu_server import call_celery_task_outfile
+from daras_ai_v2.language_filters import (
+    language_filter_selector,
+    tts_languages_without_dialects,
+)
 from daras_ai_v2.loom_video_widget import youtube_video
 from daras_ai_v2.pydantic_validation import HttpUrlStr
 from daras_ai_v2.text_to_speech_settings_widgets import (
@@ -103,7 +107,10 @@ class TextToSpeechPage(BasePage):
             """,
             key="text_prompt",
         )
-        text_to_speech_provider_selector(self)
+        selected_filter_language = language_filter_selector(
+            options=tts_languages_without_dialects(),
+        )
+        text_to_speech_provider_selector(self, language_filter=selected_filter_language)
 
     def validate_form_v2(self):
         assert gui.session_state.get("text_prompt"), "Text input cannot be empty"

--- a/recipes/Translation.py
+++ b/recipes/Translation.py
@@ -9,12 +9,14 @@ from daras_ai_v2.asr import (
     translation_model_selector,
     translation_language_selector,
     run_translate,
-    language_filter_selector,
 )
 from daras_ai_v2.base import BasePage
 from daras_ai_v2.doc_search_settings_widgets import SUPPORTED_SPREADSHEET_TYPES
 from daras_ai_v2.field_render import field_title_desc, field_title
-from daras_ai_v2.language_filters import translation_languages_without_dialects
+from daras_ai_v2.language_filters import (
+    language_filter_selector,
+    translation_languages_without_dialects,
+)
 from daras_ai_v2.pydantic_validation import OptionalHttpUrlStr
 from daras_ai_v2.text_output_widget import text_outputs
 from daras_ai_v2.workflow_url_input import del_button

--- a/recipes/VideoBots.py
+++ b/recipes/VideoBots.py
@@ -990,7 +990,7 @@ Translation Glossary for LLM Language (English) -> User Langauge
                 options=asr_languages_without_dialects()
             )
 
-            col1, col2 = gui.columns(2, responsive=False)
+            col1, col2 = gui.columns(2)
             with col1:
                 asr_model = asr_model_selector(
                     key="asr_model",

--- a/recipes/VideoBots.py
+++ b/recipes/VideoBots.py
@@ -58,6 +58,7 @@ from daras_ai_v2.glossary import validate_glossary_document
 from daras_ai_v2.language_filters import (
     asr_languages_without_dialects,
     language_filter_selector,
+    tts_languages_without_dialects,
 )
 from daras_ai_v2.language_model import (
     CHATML_ROLE_ASSISTANT,
@@ -987,7 +988,8 @@ Translation Glossary for LLM Language (English) -> User Langauge
 
             # drop down to filter models based on the selected language
             selected_filter_language = language_filter_selector(
-                options=asr_languages_without_dialects()
+                options=asr_languages_without_dialects(),
+                key="asr_language_filter",
             )
 
             col1, col2 = gui.columns(2)
@@ -1063,7 +1065,8 @@ Translation Glossary for LLM Language (English) -> User Langauge
     def text_to_speech_settings(self):
         with gui.div(className="pt-2 ps-1"):
             selected_filter_language = language_filter_selector(
-                options=asr_languages_without_dialects()
+                options=tts_languages_without_dialects(),
+                key="tts_language_filter",
             )
             text_to_speech_provider_selector(
                 self, language_filter=selected_filter_language

--- a/recipes/VideoBots.py
+++ b/recipes/VideoBots.py
@@ -26,7 +26,6 @@ from daras_ai_v2.asr import (
     TranslationModels,
     asr_language_selector,
     asr_model_selector,
-    language_filter_selector,
     run_asr,
     run_translate,
     should_translate_lang,
@@ -56,7 +55,10 @@ from daras_ai_v2.exceptions import UserError
 from daras_ai_v2.field_render import field_desc, field_title, field_title_desc
 from daras_ai_v2.functional import flatapply_parallel
 from daras_ai_v2.glossary import validate_glossary_document
-from daras_ai_v2.language_filters import asr_languages_without_dialects
+from daras_ai_v2.language_filters import (
+    asr_languages_without_dialects,
+    language_filter_selector,
+)
 from daras_ai_v2.language_model import (
     CHATML_ROLE_ASSISTANT,
     CHATML_ROLE_SYSTEM,
@@ -1060,7 +1062,12 @@ Translation Glossary for LLM Language (English) -> User Langauge
 
     def text_to_speech_settings(self):
         with gui.div(className="pt-2 ps-1"):
-            text_to_speech_provider_selector(self)
+            selected_filter_language = language_filter_selector(
+                options=asr_languages_without_dialects()
+            )
+            text_to_speech_provider_selector(
+                self, language_filter=selected_filter_language
+            )
 
         gui.newline()
 

--- a/recipes/asr_page.py
+++ b/recipes/asr_page.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel, Field
 
 from bots.models import Workflow, SavedRun, PublishedRun
 from daras_ai_v2.asr import (
-    language_filter_selector,
     asr_language_selector,
     AsrModels,
     AsrOutputFormat,
@@ -27,7 +26,10 @@ from daras_ai_v2.doc_search_settings_widgets import (
 from daras_ai_v2.enum_selector_widget import enum_selector
 from daras_ai_v2.field_render import field_title_desc, field_title
 from daras_ai_v2.functional import map_parallel
-from daras_ai_v2.language_filters import asr_languages_without_dialects
+from daras_ai_v2.language_filters import (
+    asr_languages_without_dialects,
+    language_filter_selector,
+)
 from daras_ai_v2.pydantic_validation import HttpUrlStr
 from daras_ai_v2.text_output_widget import text_outputs
 from recipes.DocSearch import render_documents


### PR DESCRIPTION
- Text-to-Speech and VideoBots exposed every provider and voice even when only a subset supports the user's target language, so finding a compatible voice required scrolling through long unrelated lists.

- Move shared language filter helpers into language_filters.py, derive filter options from per-provider TTS language metadata, and pass the selected language through provider and voice selectors so unsupported options are hidden while ASR and translation pages keep using the same shared filter widget.


### Q/A checklist

- [ ] I have tested my UI changes on mobile and they look acceptable
- [ ] I have tested changes to the workflows in both the API and the UI
- [ ] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [ ] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
