### PR TITLE
fix: refresh dynamic tools in reused Realtime sessions

### DIFF
--- a/daras_ai_v2/language_model_openai_audio.py
+++ b/daras_ai_v2/language_model_openai_audio.py
@@ -129,7 +129,19 @@ def init_ws_session(
     from daras_ai_v2.language_model import get_entry_text, msgs_to_prompt_str
 
     if not created:
-        # session already exists, just send back the most recent tool outputs
+        # Keep the persistent session in sync with tools activated since the
+        # previous response, then send back the most recent tool outputs.
+        if tools:
+            send_recv_json(
+                ws,
+                {
+                    "type": "session.update",
+                    "session": {
+                        "type": "realtime",
+                        "tools": [tool.spec_openai_audio for tool in tools],
+                    },
+                },
+            )
         for entry in reversed(messages):
             if entry.get("role") != "tool":
                 break


### PR DESCRIPTION
- OpenAI Realtime WebSockets kept the tool definitions from session creation, so tools activated by load_tools were absent from the next response and the model repeatedly invoked the loader.

- Send the current tool schemas before returning function outputs on reused sessions, while preserving the existing session state when no tools are supplied.

### Q/A checklist

- [ ] I have tested my UI changes on mobile and they look acceptable
- [ ] I have tested changes to the workflows in both the API and the UI
- [ ] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [ ] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
