### PR TITLE
feat: Add tag filter to explore search

### DIFF
--- a/gooey_gui/core/exceptions.py
+++ b/gooey_gui/core/exceptions.py
@@ -10,7 +10,7 @@ class RedirectException(Exception):
 class QueryParamsRedirectException(RedirectException):
     def __init__(self, query_params: dict, status_code=303):
         query_params = {k: v for k, v in query_params.items() if v is not None}
-        url = "?" + urllib.parse.urlencode(query_params)
+        url = "?" + urllib.parse.urlencode(query_params, doseq=True)
         super().__init__(url, status_code)
 
 

--- a/widgets/base_header.py
+++ b/widgets/base_header.py
@@ -76,7 +76,7 @@ def render_breadcrumbs_with_author(
             return
 
         for tag in pr.tags.all():
-            query_params = SearchFilters(tag=tag.name).get_query_params()
+            query_params = SearchFilters(tag=[tag.name]).get_query_params()
             render_pill_with_link(
                 tag.render(),
                 link_to=get_app_route_url(explore_page, query_params=query_params),

--- a/widgets/base_header.py
+++ b/widgets/base_header.py
@@ -76,7 +76,7 @@ def render_breadcrumbs_with_author(
             return
 
         for tag in pr.tags.all():
-            query_params = SearchFilters(search=tag.name).get_query_params()
+            query_params = SearchFilters(tag=tag.name).get_query_params()
             render_pill_with_link(
                 tag.render(),
                 link_to=get_app_route_url(explore_page, query_params=query_params),

--- a/widgets/explore.py
+++ b/widgets/explore.py
@@ -34,7 +34,7 @@ def build_meta_tags(url: str, search_filters: SearchFilters | None):
     if not search_filters:
         search_filters = SearchFilters()
 
-    match search_filters.search, search_filters.workflow:
+    match search_filters.search or search_filters.tag, search_filters.workflow:
         case "", "":
             title = META_TITLE
         case query, "":
@@ -72,7 +72,7 @@ def render(request: Request, search_filters: SearchFilters | None):
             search_filters=search_filters,
             max_width="600px",
         )
-        if not search_filters.search:
+        if not search_filters.search or search_filters.tag:
             render_search_suggestions(search_filters=search_filters)
         with gui.div(className="mt-3"):
             new_filters = render_search_filters(

--- a/widgets/explore.py
+++ b/widgets/explore.py
@@ -34,7 +34,8 @@ def build_meta_tags(url: str, search_filters: SearchFilters | None):
     if not search_filters:
         search_filters = SearchFilters()
 
-    match search_filters.search or search_filters.tag, search_filters.workflow:
+    tag_query = ", ".join(search_filters.tag)
+    match search_filters.search or tag_query, search_filters.workflow:
         case "", "":
             title = META_TITLE
         case query, "":

--- a/widgets/explore.py
+++ b/widgets/explore.py
@@ -73,8 +73,7 @@ def render(request: Request, search_filters: SearchFilters | None):
             search_filters=search_filters,
             max_width="600px",
         )
-        if not search_filters.search or search_filters.tag:
-            render_search_suggestions(search_filters=search_filters)
+        render_search_suggestions(search_filters=search_filters)
         with gui.div(className="mt-3"):
             new_filters = render_search_filters(
                 current_user=request.user,

--- a/widgets/home.py
+++ b/widgets/home.py
@@ -255,7 +255,7 @@ def _saved_workflows_href(workspace: Workspace | None) -> str:
 def _industry_tile_href(tag: Tag) -> str:
     if tag.landing_page:
         return tag.landing_page
-    return str(furl("/explore/", query_params={"search": tag.name}))
+    return str(furl("/explore/", query_params={"tag": tag.name}))
 
 
 def _load_news_items() -> list[NewsItemData]:

--- a/widgets/saved_workflow.py
+++ b/widgets/saved_workflow.py
@@ -145,7 +145,7 @@ def render_title_pills(
                 gui.html(label)
 
         for tag in published_run.tags.all():
-            new_filters = search_filters.model_copy(update={"search": tag.name})
+            new_filters = search_filters.model_copy(update={"tag": tag.name})
             link_to = get_app_route_url(
                 explore_page, query_params=new_filters.get_query_params()
             )

--- a/widgets/saved_workflow.py
+++ b/widgets/saved_workflow.py
@@ -145,7 +145,7 @@ def render_title_pills(
                 gui.html(label)
 
         for tag in published_run.tags.all():
-            new_filters = search_filters.model_copy(update={"tag": tag.name})
+            new_filters = search_filters.toggle_tag(tag.name)
             link_to = get_app_route_url(
                 explore_page, query_params=new_filters.get_query_params()
             )

--- a/widgets/workflow_search.py
+++ b/widgets/workflow_search.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import html
 import re
 import typing
 
@@ -99,10 +100,13 @@ class SearchFilters(BaseModel):
     search: str = ""
     workspace: str = ""
     workflow: str = ""
+    tag: str = ""
     sort: str = ""
 
     def __bool__(self):
-        return bool(self.search or self.workspace or self.workflow or self.sort)
+        return bool(
+            self.search or self.workspace or self.workflow or self.tag or self.sort
+        )
 
     @field_validator("sort", "workflow", mode="before")
     @classmethod
@@ -122,8 +126,11 @@ def render_search_filters(
         search_filters = SearchFilters()
 
     show_workspace_filter = bool(current_user and not current_user.is_anonymous)
-    show_sort_option = (
-        search_filters.search or search_filters.workflow or search_filters.workspace
+    show_sort_option = bool(
+        search_filters.search
+        or search_filters.workflow
+        or search_filters.workspace
+        or search_filters.tag
     )
     with gui.div(className="row container-margin-reset", style={"fontSize": "0.9rem"}):
         if not show_sort_option:
@@ -316,14 +323,29 @@ def render_search_suggestions(search_filters: SearchFilters):
 
     with gui.div(className="my-2"):
         for tag in Tag.get_options():
+            is_active = search_filters.tag.lower() == tag.name.lower()
+            if is_active:
+                # clicking the active tag clears the filter
+                new_tag = ""
+            else:
+                new_tag = tag.name
             url = get_app_route_url(
                 explore_page,
                 query_params=search_filters.model_copy(
-                    update={"search": tag.name}
+                    update={"tag": new_tag}
                 ).get_query_params(),
             )
             with gui.link(to=url, className="me-2 mb-1"):
-                gui.pill(tag.render())
+                if is_active:
+                    # trailing x hints that clicking the tag removes the filter
+                    gui.pill(
+                        f"{html.escape(tag.render())}"
+                        f' <span class="ms-1 small">{icons.cancel}</span>',
+                        unsafe_allow_html=True,
+                        text_bg="secondary",
+                    )
+                else:
+                    gui.pill(tag.render(), text_bg="light")
 
 
 def get_placeholder_by_search_filters(
@@ -530,6 +552,15 @@ def build_search_filter(
             pass
         else:
             qs = qs.filter(workflow=workflow_page.workflow.value)
+
+    if search_filters.tag:
+        # filter to runs carrying this tag via a subquery to avoid join
+        # duplication / interference with the search-vector tag aggregation below
+        qs = qs.filter(
+            id__in=Tag.objects.filter(name__iexact=search_filters.tag).values(
+                "published_runs"
+            )
+        )
 
     if search_filters.search:
         # add tag_names as a single aggregated field to remove duplicates

--- a/widgets/workflow_search.py
+++ b/widgets/workflow_search.py
@@ -122,11 +122,14 @@ class SearchFilters(BaseModel):
         return self.model_dump(exclude_defaults=True)
 
     def toggle_tag(self, tag: str) -> SearchFilters:
-        tags = [
-            selected for selected in self.tag if selected.casefold() != tag.casefold()
-        ]
-        if len(tags) == len(self.tag) and len(tags) < MAX_TAG_FILTERS:
-            tags.append(tag)
+        tags = list(self.tag)
+        for selected in tags:
+            if selected.casefold() == tag.casefold():
+                tags.remove(selected)
+                break
+        else:
+            if len(tags) < MAX_TAG_FILTERS:
+                tags.append(tag)
         return self.model_copy(update={"tag": tags})
 
 

--- a/widgets/workflow_search.py
+++ b/widgets/workflow_search.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import html
 import re
 import typing
 
@@ -17,7 +16,7 @@ from django.db.models import (
     When,
 )
 from django.utils.translation import ngettext
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from app_users.models import AppUser
 from bots.models import PublishedRun, Tag, WorkflowAccessLevel
@@ -94,13 +93,14 @@ class SortOptions(SortOption, GooeyEnum):
 
 
 SEARCH_TOKEN_ALLOWED_CHARS = re.compile(r"[\w]+")
+MAX_TAG_FILTERS = 10
 
 
 class SearchFilters(BaseModel):
     search: str = ""
     workspace: str = ""
     workflow: str = ""
-    tag: str = ""
+    tag: list[str] = Field(default_factory=list)
     sort: str = ""
 
     def __bool__(self):
@@ -113,8 +113,21 @@ class SearchFilters(BaseModel):
     def to_lower(cls, v):
         return v.lower() if isinstance(v, str) else v
 
-    def get_query_params(self) -> dict[str, str]:
+    @field_validator("tag")
+    @classmethod
+    def limit_tags(cls, tags: list[str]) -> list[str]:
+        return tags[:MAX_TAG_FILTERS]
+
+    def get_query_params(self) -> dict[str, str | list[str]]:
         return self.model_dump(exclude_defaults=True)
+
+    def toggle_tag(self, tag: str) -> SearchFilters:
+        tags = [
+            selected for selected in self.tag if selected.casefold() != tag.casefold()
+        ]
+        if len(tags) == len(self.tag) and len(tags) < MAX_TAG_FILTERS:
+            tags.append(tag)
+        return self.model_copy(update={"tag": tags})
 
 
 def render_search_filters(
@@ -321,31 +334,52 @@ def render_search_bar(
 def render_search_suggestions(search_filters: SearchFilters):
     from routers.root import explore_page
 
-    with gui.div(className="my-2"):
+    with (
+        gui.styled("""
+        & .tag-filter-chip .badge {
+            transition: background-color 150ms ease, border-color 150ms ease;
+        }
+        & .tag-filter-chip:hover .badge,
+        & .tag-filter-chip:focus-visible .badge {
+            background-color: rgba(var(--bs-secondary-rgb), 0.18) !important;
+            border-color: var(--bs-secondary) !important;
+        }
+        & .tag-filter-chip:hover .tag-filter-chip-selected,
+        & .tag-filter-chip:focus-visible .tag-filter-chip-selected {
+            background-color: rgba(var(--bs-secondary-rgb), 0.85) !important;
+        }
+        """),
+        gui.div(className="my-2 d-flex flex-wrap align-items-center gap-2"),
+    ):
         for tag in Tag.get_options():
-            is_active = search_filters.tag.lower() == tag.name.lower()
+            is_active = any(
+                selected.casefold() == tag.name.casefold()
+                for selected in search_filters.tag
+            )
+            pill_class = "border px-3 py-2"
             if is_active:
-                # clicking the active tag clears the filter
-                new_tag = ""
-            else:
-                new_tag = tag.name
+                pill_class += " tag-filter-chip-selected border-secondary"
             url = get_app_route_url(
                 explore_page,
-                query_params=search_filters.model_copy(
-                    update={"tag": new_tag}
-                ).get_query_params(),
+                query_params=search_filters.toggle_tag(tag.name).get_query_params(),
             )
-            with gui.link(to=url, className="me-2 mb-1"):
-                if is_active:
-                    # trailing x hints that clicking the tag removes the filter
-                    gui.pill(
-                        f"{html.escape(tag.render())}"
-                        f' <span class="ms-1 small">{icons.cancel}</span>',
-                        unsafe_allow_html=True,
-                        text_bg="secondary",
-                    )
-                else:
-                    gui.pill(tag.render(), text_bg="light")
+            with gui.link(
+                to=url,
+                className=(
+                    "tag-filter-chip d-inline-flex align-items-center "
+                    "text-decoration-none"
+                ),
+                style={"minHeight": "48px"},
+                **{
+                    "aria-label": f"{tag.name}, "
+                    f"{'selected' if is_active else 'not selected'}"
+                },
+            ):
+                gui.pill(
+                    tag.render(),
+                    text_bg="secondary" if is_active else "light",
+                    className=pill_class,
+                )
 
 
 def get_placeholder_by_search_filters(
@@ -554,13 +588,10 @@ def build_search_filter(
             qs = qs.filter(workflow=workflow_page.workflow.value)
 
     if search_filters.tag:
-        # filter to runs carrying this tag via a subquery to avoid join
-        # duplication / interference with the search-vector tag aggregation below
-        qs = qs.filter(
-            id__in=Tag.objects.filter(name__iexact=search_filters.tag).values(
-                "published_runs"
+        for tag in search_filters.tag:
+            qs = qs.filter(
+                id__in=Tag.objects.filter(name__iexact=tag).values("published_runs")
             )
-        )
 
     if search_filters.search:
         # add tag_names as a single aggregated field to remove duplicates


### PR DESCRIPTION
- Add `tag` field to SearchFilters and filter published runs by tag membership (case-insensitive, via subquery)
- Route tag pills/links (explore suggestions, home industry tiles, saved-workflow and header tags) through `tag=` instead of full-text `search=`, so tag pages use the featured/example_priority ordering rather than text rank
- Highlight the active tag pill with a clear (x) icon that removes the filter, and show the sort dropdown when a tag is selected
- Weight tag matches above title in the search vector (tags A, title B, workspace/author C, notes D)

### Q/A checklist

- [ ] I have tested my UI changes on mobile and they look acceptable
- [ ] I have tested changes to the workflows in both the API and the UI
- [ ] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [ ] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
