### PR TITLE
fix: sanitize Mistral conversation messages

### DIFF
--- a/daras_ai_v2/language_model.py
+++ b/daras_ai_v2/language_model.py
@@ -1531,7 +1531,7 @@ def _run_mistral_chat(
 
     data = dict(
         model=model,
-        messages=_format_mistral_messages(messages),
+        messages=[chat_completion_msg_to_mistral_msg(msg) for msg in messages],
         max_tokens=max_tokens,
         n=num_outputs,
         temperature=temperature,
@@ -1565,32 +1565,34 @@ def _run_mistral_chat(
     return list(_parse_mistral_output(out))
 
 
-def _format_mistral_messages(
-    messages: list[ConversationEntry],
-) -> list[ConversationEntry]:
-    mistral_messages = []
-    for message in messages:
-        mistral_message = {
-            "role": message.get("role") or CHATML_ROLE_USER,
-            "content": message.get("content"),
-        }
-        if tool_call_id := message.get("tool_call_id"):
-            mistral_message["tool_call_id"] = tool_call_id
-        if tool_calls := message.get("tool_calls"):
-            mistral_message["tool_calls"] = [
+def chat_completion_msg_to_mistral_msg(msg: dict) -> dict:
+    if msg["role"] == "assistant" and "tool_calls" in msg:
+        # function calls
+        return {
+            "role": msg["role"],
+            "content": msg.get("content"),
+            "tool_calls": [
                 {
-                    "id": tool_call.get("id") or "",
-                    "type": tool_call.get("type") or "function",
+                    "id": tool_call.get("id", ""),
+                    "type": tool_call.get("type", "function"),
                     "function": {
-                        "name": (tool_call.get("function") or {}).get("name") or "",
-                        "arguments": (tool_call.get("function") or {}).get("arguments")
-                        or "",
+                        "name": tool_call["function"]["name"],
+                        "arguments": tool_call["function"]["arguments"],
                     },
                 }
-                for tool_call in tool_calls
-            ]
-        mistral_messages.append(mistral_message)
-    return mistral_messages
+                for tool_call in msg["tool_calls"]
+            ],
+        }
+
+    if msg["role"] == "tool":
+        # function call output
+        return {
+            "role": msg["role"],
+            "content": msg["content"],
+            "tool_call_id": msg["tool_call_id"],
+        }
+
+    return {"role": msg["role"], "content": msg["content"]}
 
 
 def _parse_mistral_output(out: dict) -> typing.Iterable[dict]:

--- a/daras_ai_v2/language_model.py
+++ b/daras_ai_v2/language_model.py
@@ -1531,7 +1531,7 @@ def _run_mistral_chat(
 
     data = dict(
         model=model,
-        messages=messages,
+        messages=_format_mistral_messages(messages),
         max_tokens=max_tokens,
         n=num_outputs,
         temperature=temperature,
@@ -1563,6 +1563,34 @@ def _run_mistral_chat(
         quantity=out["usage"]["completion_tokens"],
     )
     return list(_parse_mistral_output(out))
+
+
+def _format_mistral_messages(
+    messages: list[ConversationEntry],
+) -> list[ConversationEntry]:
+    mistral_messages = []
+    for message in messages:
+        mistral_message = {
+            "role": message.get("role") or CHATML_ROLE_USER,
+            "content": message.get("content"),
+        }
+        if tool_call_id := message.get("tool_call_id"):
+            mistral_message["tool_call_id"] = tool_call_id
+        if tool_calls := message.get("tool_calls"):
+            mistral_message["tool_calls"] = [
+                {
+                    "id": tool_call.get("id") or "",
+                    "type": tool_call.get("type") or "function",
+                    "function": {
+                        "name": (tool_call.get("function") or {}).get("name") or "",
+                        "arguments": (tool_call.get("function") or {}).get("arguments")
+                        or "",
+                    },
+                }
+                for tool_call in tool_calls
+            ]
+        mistral_messages.append(mistral_message)
+    return mistral_messages
 
 
 def _parse_mistral_output(out: dict) -> typing.Iterable[dict]:


### PR DESCRIPTION
- Gooey stores tool definitions and display metadata in final_prompt, but Mistral rejects those extra fields when they are nested inside conversation messages.

- Build a clean Mistral request copy that preserves tool-call history while leaving the persisted multi-turn final_prompt unchanged.

### Q/A checklist

- [ ] I have tested my UI changes on mobile and they look acceptable
- [ ] I have tested changes to the workflows in both the API and the UI
- [ ] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [ ] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
