### PR TITLE
fix: batch WhatsApp image messages

### DIFF
--- a/bots/tasks.py
+++ b/bots/tasks.py
@@ -1,4 +1,6 @@
+import hashlib
 import json
+import uuid
 from datetime import timedelta
 from json import JSONDecodeError
 import random
@@ -18,10 +20,15 @@ from bots.models import (
     Platform,
     SavedRun,
 )
-from daras_ai_v2.bots import save_msg_pair_to_db
+from daras_ai_v2.bots import (
+    BotIntegrationLookupFailed,
+    msg_handler,
+    save_msg_pair_to_db,
+)
 from daras_ai_v2.facebook_bots import WhatsappBot
 from daras_ai_v2.functional import flatten, map_parallel
 from daras_ai_v2.language_model import CHATML_ROLE_ASSISTANT
+from daras_ai_v2.redis_cache import get_redis_cache, redis_lock
 from daras_ai_v2.slack_bot import (
     SlackBot,
     create_personal_channel,
@@ -35,6 +42,79 @@ from recipes.VideoBotsStats import (
 )
 
 MAX_PROMPT_LEN = 100_000
+WHATSAPP_MEDIA_BATCH_WAIT_SEC = 3
+WHATSAPP_MEDIA_BATCH_TTL_SEC = 60
+
+
+def enqueue_whatsapp_media(message: dict, metadata: dict):
+    cache_key = _whatsapp_media_batch_cache_key(message, metadata)
+    entry_id = uuid.uuid4().hex
+    entry = json.dumps(
+        {
+            "id": entry_id,
+            "message": message,
+            "metadata": metadata,
+        }
+    )
+    with redis_lock(cache_key):
+        redis_cache = get_redis_cache()
+        redis_cache.rpush(cache_key, entry)
+        redis_cache.expire(cache_key, WHATSAPP_MEDIA_BATCH_TTL_SEC)
+
+    process_whatsapp_media_batch.apply_async(
+        kwargs={
+            "cache_key": cache_key,
+            "last_entry_id": entry_id,
+        },
+        countdown=WHATSAPP_MEDIA_BATCH_WAIT_SEC,
+    )
+
+
+@shared_task
+def process_whatsapp_media_batch(*, cache_key: str, last_entry_id: str):
+    entries = _pop_whatsapp_media_batch(cache_key, last_entry_id)
+    if not entries:
+        return
+
+    image_messages = [
+        entry["message"] for entry in entries if entry["message"]["type"] == "image"
+    ]
+    input_message = image_messages or entries[-1]["message"]
+    try:
+        bot = WhatsappBot(input_message, entries[-1]["metadata"])
+    except BotIntegrationLookupFailed:
+        return
+    msg_handler(bot)
+
+
+def _whatsapp_media_batch_cache_key(message: dict, metadata: dict) -> str:
+    participant_key = f"{metadata['phone_number_id']}:{message['from']}"
+    participant_hash = hashlib.sha256(participant_key.encode()).hexdigest()
+    return f"gooey/whatsapp-media-batch/v1/{participant_hash}"
+
+
+def _pop_whatsapp_media_batch(cache_key: str, last_entry_id: str) -> list[dict] | None:
+    with redis_lock(cache_key):
+        redis_cache = get_redis_cache()
+        raw_entries = redis_cache.lrange(cache_key, 0, -1)
+        if not raw_entries:
+            return None
+
+        entries = [json.loads(entry) for entry in raw_entries]
+        if entries[-1]["id"] != last_entry_id:
+            return None
+
+        redis_cache.delete(cache_key)
+
+    seen_message_ids = set()
+    unique_entries = []
+    for entry in entries:
+        message_id = entry["message"]["id"]
+        if message_id in seen_message_ids:
+            continue
+        seen_message_ids.add(message_id)
+        unique_entries.append(entry)
+    return unique_entries
 
 
 @shared_task

--- a/daras_ai_v2/facebook_bots.py
+++ b/daras_ai_v2/facebook_bots.py
@@ -31,12 +31,13 @@ def get_wa_auth_header(access_token: str | None = None):
 class WhatsappBot(BotInterface):
     platform = Platform.WHATSAPP
 
-    def __init__(self, message: dict, metadata: dict):
-        self.input_message = message
-        self.user_msg_id = message["id"]
+    def __init__(self, message: dict | list[dict], metadata: dict):
+        self.input_messages = message if isinstance(message, list) else [message]
+        self.input_message = self.input_messages[-1]
+        self.user_msg_id = self.input_message["id"]
         self.bot_id = metadata["phone_number_id"]  # this is NOT the phone number
-        self.user_id = message["from"]  # this is a phone number
-        self.input_type = message["type"]
+        self.user_id = self.input_message["from"]  # this is a phone number
+        self.input_type = self.input_message["type"]
 
         user_phone_number = "+" + self.user_id
         try:
@@ -57,14 +58,15 @@ class WhatsappBot(BotInterface):
         super().__init__()
 
     def get_input_text(self) -> str | None:
-        try:
-            return self.input_message["text"]["body"]
-        except KeyError:
-            pass
-        try:
-            return self.input_message[self.input_type]["caption"]
-        except KeyError:
-            pass
+        for message in self.input_messages:
+            try:
+                return message["text"]["body"]
+            except KeyError:
+                pass
+            try:
+                return message[message["type"]]["caption"]
+            except KeyError:
+                pass
 
     def get_input_audio(self) -> str | None:
         try:
@@ -86,11 +88,12 @@ class WhatsappBot(BotInterface):
         )
 
     def get_input_images(self) -> list[str] | None:
-        try:
-            media_id = self.input_message["image"]["id"]
-        except KeyError:
-            return None
-        return [self._download_wa_media(media_id)]
+        media_ids = [
+            message["image"]["id"]
+            for message in self.input_messages
+            if message["type"] == "image"
+        ]
+        return [self._download_wa_media(media_id) for media_id in media_ids] or None
 
     def get_input_documents(self) -> list[str] | None:
         try:
@@ -146,7 +149,7 @@ class WhatsappBot(BotInterface):
     def mark_read(self):
         wa_mark_read(
             bot_number=self.bot_id,
-            message_id=self.input_message["id"],
+            message_ids=[message["id"] for message in self.input_messages],
             user_msg_id=self.user_msg_id,
             access_token=self.access_token,
         )
@@ -418,19 +421,23 @@ def send_wa_msgs_raw(
 
 
 def wa_mark_read(
-    bot_number: str, message_id: str, user_msg_id: str, access_token: str | None = None
+    bot_number: str,
+    message_ids: list[str],
+    user_msg_id: str,
+    access_token: str | None = None,
 ):
-    # send read receipt
-    r = requests.post(
-        f"https://graph.facebook.com/v16.0/{bot_number}/messages",
-        headers=get_wa_auth_header(access_token),
-        json={
-            "messaging_product": "whatsapp",
-            "status": "read",
-            "message_id": message_id,
-        },
-    )
-    print("wa_mark_read:", r.status_code, r.json())
+    for message_id in message_ids:
+        # send read receipt
+        r = requests.post(
+            f"https://graph.facebook.com/v16.0/{bot_number}/messages",
+            headers=get_wa_auth_header(access_token),
+            json={
+                "messaging_product": "whatsapp",
+                "status": "read",
+                "message_id": message_id,
+            },
+        )
+        print("wa_mark_read:", r.status_code, r.json())
 
     # send typing indicator
     r = requests.post(

--- a/routers/facebook_api.py
+++ b/routers/facebook_api.py
@@ -8,6 +8,7 @@ from starlette.requests import Request
 from starlette.responses import HTMLResponse, Response
 
 from bots.models import BotIntegration, Platform
+from bots.tasks import enqueue_whatsapp_media
 from daras_ai_v2 import settings, db
 from daras_ai_v2.bot_integration_connect import (
     connect_bot_to_published_run,
@@ -218,6 +219,9 @@ def fb_webhook(
             case "whatsapp_business_account":
                 value = glom.glom(entry, "changes.0.value", default={})
                 for message in value.get("messages", []):
+                    if message.get("type") in {"image", "unknown", "unsupported"}:
+                        enqueue_whatsapp_media(message, value["metadata"])
+                        continue
                     try:
                         bot = WhatsappBot(message, value["metadata"])
                     except BotIntegrationLookupFailed:

--- a/tests/test_facebook_api.py
+++ b/tests/test_facebook_api.py
@@ -1,0 +1,108 @@
+from contextlib import nullcontext
+from unittest.mock import Mock, patch
+
+from starlette.background import BackgroundTasks
+
+from bots import tasks
+from daras_ai_v2.facebook_bots import WhatsappBot
+from routers import facebook_api
+
+
+def test_fb_webhook_batches_whatsapp_images():
+    metadata = {"phone_number_id": "phone-number-id"}
+    unsupported_message = {
+        "from": "15550000000",
+        "id": "unsupported-message-id",
+        "timestamp": "1785488661",
+        "type": "unsupported",
+        "errors": [{"code": 131051}],
+    }
+    first_image = _image_message("first-message-id", "first-image-id")
+    second_image = _image_message("second-message-id", "second-image-id")
+    stored_entries = []
+    scheduled_tasks = []
+    redis_cache = Mock()
+    redis_cache.rpush.side_effect = lambda _, entry: stored_entries.append(entry)
+    redis_cache.lrange.side_effect = lambda *_: stored_entries.copy()
+    redis_cache.delete.side_effect = lambda *_: stored_entries.clear()
+
+    with (
+        patch.object(tasks, "get_redis_cache", return_value=redis_cache),
+        patch.object(tasks, "redis_lock", side_effect=lambda _: nullcontext()),
+        patch.object(
+            tasks.process_whatsapp_media_batch,
+            "apply_async",
+            side_effect=lambda **kwargs: scheduled_tasks.append(kwargs),
+        ),
+    ):
+        first_background_tasks = BackgroundTasks()
+        second_background_tasks = BackgroundTasks()
+        first_response = facebook_api.fb_webhook(
+            first_background_tasks,
+            _wa_webhook([unsupported_message, first_image], metadata),
+        )
+        second_response = facebook_api.fb_webhook(
+            second_background_tasks, _wa_webhook(second_image, metadata)
+        )
+
+        bot = Mock()
+        with (
+            patch.object(tasks, "WhatsappBot", return_value=bot) as whatsapp_bot,
+            patch.object(tasks, "msg_handler") as msg_handler,
+        ):
+            for scheduled_task in scheduled_tasks:
+                tasks.process_whatsapp_media_batch.run(**scheduled_task["kwargs"])
+
+    assert first_response.body == b"OK"
+    assert second_response.body == b"OK"
+    assert not first_background_tasks.tasks
+    assert not second_background_tasks.tasks
+    assert [task["countdown"] for task in scheduled_tasks] == [3, 3, 3]
+    whatsapp_bot.assert_called_once_with([first_image, second_image], metadata)
+    msg_handler.assert_called_once_with(bot)
+    assert not stored_entries
+
+
+def test_whatsapp_bot_downloads_all_batched_images():
+    bot = object.__new__(WhatsappBot)
+    bot.input_messages = [
+        _image_message("first-message-id", "first-image-id"),
+        _image_message("second-message-id", "second-image-id"),
+    ]
+    bot._download_wa_media = Mock(
+        side_effect=lambda media_id: f"https://example.com/{media_id}.jpg"
+    )
+
+    assert bot.get_input_images() == [
+        "https://example.com/first-image-id.jpg",
+        "https://example.com/second-image-id.jpg",
+    ]
+
+
+def _image_message(message_id: str, image_id: str) -> dict:
+    return {
+        "from": "15550000000",
+        "id": message_id,
+        "timestamp": "1785488661",
+        "type": "image",
+        "image": {"id": image_id},
+    }
+
+
+def _wa_webhook(message: dict | list[dict], metadata: dict) -> dict:
+    messages = message if isinstance(message, list) else [message]
+    return {
+        "object": "whatsapp_business_account",
+        "entry": [
+            {
+                "changes": [
+                    {
+                        "value": {
+                            "metadata": metadata,
+                            "messages": messages,
+                        }
+                    }
+                ]
+            }
+        ],
+    }


### PR DESCRIPTION
## What changed

- Buffer incoming WhatsApp image messages for the same business number and sender during a 3-second quiet window.
- Flush the batch once, deduplicate webhook deliveries, and pass all ordered images to a single `WhatsappBot` run.
- Preserve image captions and mark every batched image as read; adjacent unsupported companion events are ignored only when the batch contains real images.

## Root cause

WhatsApp delivers selected images as distinct message events. The webhook constructed and dispatched a bot for each event immediately, so two images created two independent agent runs instead of one run with two `input_images`.

The supplied examples confirmed that one WhatsApp conversation produced separate runs about 1.8 seconds apart, each containing one image and a different WhatsApp message ID.

## Impact

Sending multiple images together on WhatsApp now produces one agent invocation containing the full ordered image list. Single images still work through the same path after the short debounce, while text, audio, documents, interactive messages, and location handling remain unchanged.

## Validation

- `ruff check bots/tasks.py daras_ai_v2/facebook_bots.py routers/facebook_api.py tests/test_facebook_api.py`
- `pytest -q tests/test_facebook_api.py bots/tests.py::test_create_bot_integration_conversation_message bots/tests.py::test_create_fb_test_bot_integration` — 4 passed

Asana: https://app.asana.com/1/1199619908176999/project/1203067047205953/task/1215475188017676