### PR TITLE
refactor: replace ExploreBuilderPrompt with AskGooeyNew component and…

### DIFF
--- a/daras_ai_v2/gooey_builder.py
+++ b/daras_ai_v2/gooey_builder.py
@@ -100,6 +100,73 @@ def render_gooey_builder(
 ):
     if not can_launch_gooey_builder(request, page.current_workspace):
         return
+
+    builder_sr = page.current_sr.parent_builder_saved_run
+    handle_gooey_builder_redirect(builder_sr)
+
+    if builder_sr and not gui.session_state.get("builderOnNewConversation"):
+        builder_run_url = builder_sr.get_app_url()
+        messages = get_chat_widget_messages(
+            builder_sr.to_dict(), web_url=builder_run_url
+        )
+    else:
+        builder_run_url = None
+        messages = []
+
+    render_gooey_builder_embed(
+        sidebar_key=sidebar_key,
+        builder_run_url=builder_run_url,
+        messages=messages,
+        workflow_state={
+            field_name: gui.session_state[field_name]
+            for field_name in page.fields_to_save()
+            if field_name in gui.session_state
+        },
+    )
+
+
+def render_standalone_gooey_builder(
+    *,
+    sidebar_key: str,
+    request: fastapi.Request,
+    builder_sr: SavedRun,
+):
+    """Render only the gooey builder chat for a builder prompt run, without any
+    associated workflow page."""
+    if not can_launch_gooey_builder(request, None):
+        return
+
+    handle_gooey_builder_redirect(builder_sr)
+
+    if builder_sr.run_status:
+        # subscribe to the builder run so the page re-renders while it's
+        # running and picks up the redirect_url set by the builder's
+        # workflow tools as soon as it lands
+        channel = Workflow(builder_sr.workflow).page_cls.realtime_channel_name(
+            builder_sr.run_id, builder_sr.uid
+        )
+        gui.realtime_pull([channel])
+
+    builder_run_url = builder_sr.get_app_url()
+    render_gooey_builder_embed(
+        sidebar_key=sidebar_key,
+        builder_run_url=builder_run_url,
+        messages=get_chat_widget_messages(
+            builder_sr.to_dict(), web_url=builder_run_url
+        ),
+        workflow_state={},
+        builder_only=True,
+    )
+
+
+def render_gooey_builder_embed(
+    *,
+    sidebar_key: str,
+    builder_run_url: str | None,
+    messages: list,
+    workflow_state: dict,
+    builder_only: bool = False,
+):
     if not settings.GOOEY_BUILDER_INTEGRATION_ID:
         return
     bi = BotIntegration.objects.select_related("published_run").get(
@@ -114,26 +181,10 @@ def render_gooey_builder(
     config["showRunLink"] = True
     config["showToolCalls"] = True
     config["enableSourcePreview"] = False
-    config["enableConversations"] = True
+    # builder-only pages (e.g. ask gooey) have no workflow to attach conversations to
+    config["enableConversations"] = not builder_only
     branding = config.setdefault("branding", {})
     branding["showPoweredByGooey"] = False
-
-    builder_sr = page.current_sr.parent_builder_saved_run
-
-    redirect_url = builder_sr and builder_sr.redirect_url
-    if redirect_url:
-        builder_sr.redirect_url = ""
-        builder_sr.save(update_fields=["redirect_url"])
-        raise gui.RedirectException(redirect_url)
-
-    if builder_sr and not gui.session_state.get("builderOnNewConversation"):
-        builder_run_url = builder_sr.get_app_url()
-        messages = get_chat_widget_messages(
-            builder_sr.to_dict(), web_url=builder_sr.get_app_url()
-        )
-    else:
-        builder_run_url = bi.published_run.get_app_url()
-        messages = []
 
     load_chat_widget_lib()
     gui.component(
@@ -141,13 +192,20 @@ def render_gooey_builder(
         config=config,
         sidebar_key=sidebar_key,
         messages=messages,
-        builder_run_url=builder_run_url,
-        workflow_state={
-            field_name: gui.session_state[field_name]
-            for field_name in page.fields_to_save()
-            if field_name in gui.session_state
-        },
+        builder_run_url=builder_run_url or bi.published_run.get_app_url(),
+        workflow_state=workflow_state,
+        builder_only=builder_only,
     )
+
+
+def handle_gooey_builder_redirect(builder_sr: SavedRun | None):
+    """Redirect to the child workflow whenever the gooey builder has updated it."""
+    redirect_url = builder_sr and builder_sr.redirect_url
+    if not redirect_url:
+        return
+    builder_sr.redirect_url = ""
+    builder_sr.save(update_fields=["redirect_url"])
+    raise gui.RedirectException(redirect_url)
 
 
 def can_launch_gooey_builder(
@@ -167,7 +225,7 @@ router = CustomAPIRouter()
 
 
 class GooeyBuilderSendMessage(pydantic.BaseModel):
-    workflow_url: str
+    workflow_url: str | None = None
     builder_run_url: str | None = None
     input_data: dict | None = None
     workflow_state: dict = {}
@@ -178,22 +236,30 @@ def gooey_builder_send_message(request: fastapi.Request, body: GooeyBuilderSendM
     from daras_ai_v2.workflow_url_input import url_to_runs
     from functions.gooey_builder_tools import insert_gooey_builder_variables
 
+    # inline import to avoid a circular dependency with routers.ask_gooey_new
+    from routers.ask_gooey_new import get_gooey_builder_run_url
+
     workspace = get_current_workspace(request.user, request.session)
 
-    # copy the workflow_url into a new run linked to
-    # builder_sr so the chat widget can navigate the user to a workflow page
-    # that knows which builder iteration produced it
-    workflow_page_cls, workflow_sr, workflow_pr = url_to_runs(body.workflow_url)
-    workflow_sr = workflow_sr.clone(
-        parent_pr=workflow_pr,
-        uid=request.user.uid,
-        workspace_id=workspace.id,
-        surface=SavedRun.Surface.builder_child,
-    )
-    workflow_sr.state.update(body.workflow_state)
-    workflow_sr.save()
+    if body.workflow_url:
+        # copy the workflow_url into a new run linked to
+        # builder_sr so the chat widget can navigate the user to a workflow page
+        # that knows which builder iteration produced it
+        workflow_page_cls, workflow_sr, workflow_pr = url_to_runs(body.workflow_url)
+        workflow_sr = workflow_sr.clone(
+            parent_pr=workflow_pr,
+            uid=request.user.uid,
+            workspace_id=workspace.id,
+            surface=SavedRun.Surface.builder_child,
+        )
+        workflow_sr.state.update(body.workflow_state)
+        workflow_sr.save()
+        workflow_url = workflow_sr.get_app_url()
+    else:
+        # no workflow attached - user is chatting with just the builder
+        workflow_sr = None
+        workflow_url = ""
 
-    workflow_url = workflow_sr.get_app_url()
     builder_run_url = body.builder_run_url or get_default_builder_pr().get_app_url()
     builder_page_cls, builder_sr, builder_pr = url_to_runs(builder_run_url)
     request_body, message_thread = chat_widget_input_to_request_body(
@@ -201,16 +267,21 @@ def gooey_builder_send_message(request: fastapi.Request, body: GooeyBuilderSendM
     )
     insert_gooey_builder_variables(request_body, workflow_url)
 
-    workflow_sr.parent_builder_saved_run = builder_pr.submit_api_call(
+    builder_prompt_sr = builder_pr.submit_api_call(
         current_user=request.user,
         workspace=workspace,
         request_body=request_body,
         surface=SavedRun.Surface.builder_prompt,
         message_thread=message_thread,
     )[1]
-    workflow_sr.save(update_fields=["parent_builder_saved_run"])
-
-    return workflow_url
+    if workflow_sr:
+        workflow_sr.parent_builder_saved_run = builder_prompt_sr
+        workflow_sr.save(update_fields=["parent_builder_saved_run"])
+        return workflow_url
+    else:
+        # no workflow attached - navigate to the standalone builder page,
+        # which redirects to the child workflow once the builder creates one
+        return get_gooey_builder_run_url(builder_prompt_sr)
 
 
 def get_default_builder_pr() -> PublishedRun:

--- a/functions/gooey_builder_tools.py
+++ b/functions/gooey_builder_tools.py
@@ -1,23 +1,21 @@
 from __future__ import annotations
 
-
+import gooey_gui as gui
+from bots.models import SavedRun
+from daras_ai_v2.workflow_url_input import url_to_runs
 from functions.base_llm_tool import (
     BaseLLMTool,
 )
-
-from bots.models import SavedRun
-
-from daras_ai_v2.workflow_url_input import url_to_runs
 from functions.gooey_builder_deploy_tool import DeployWorkflowLLMTool
 from functions.gooey_builder_workflow_tools import (
     WORKFLOW_URL_KEY,
     FetchWorkflowStateLLMTool,
-    UpdateWorkflowStateLLMTool,
     RunWorkflowLLMTool,
-    SaveWorkflowLLMTool,
     SaveAsNewWorkflowLLMTool,
+    SaveWorkflowLLMTool,
+    SearchWorkflowsLLMTool,
+    UpdateWorkflowStateLLMTool,
 )
-import gooey_gui as gui
 
 
 def insert_gooey_builder_variables(state: dict, workflow_url: str):
@@ -29,16 +27,25 @@ def insert_gooey_builder_variables(state: dict, workflow_url: str):
 
 
 def get_current_builder_tools(builder_sr: SavedRun) -> dict[str, BaseLLMTool]:
-    workflow_url = gui.session_state.get("variables", {}).get(WORKFLOW_URL_KEY, "")
-    if not workflow_url:
+    variables = gui.session_state.get("variables", {})
+    try:
+        workflow_url = variables[WORKFLOW_URL_KEY]
+    except KeyError:
         return {}
-    page_cls, sr, pr = url_to_runs(workflow_url)
+    if workflow_url:
+        page_cls, sr, pr = url_to_runs(workflow_url)
+    else:
+        page_cls, sr, pr = None, None, None
     tools = [
+        SearchWorkflowsLLMTool(builder_sr.uid),
         FetchWorkflowStateLLMTool(page_cls),
         UpdateWorkflowStateLLMTool(page_cls, sr, pr, builder_sr),
         RunWorkflowLLMTool(page_cls, sr, pr, builder_sr),
         SaveWorkflowLLMTool(page_cls, sr, pr, builder_sr),
         SaveAsNewWorkflowLLMTool(page_cls, sr, pr, builder_sr),
-        DeployWorkflowLLMTool(page_cls, sr, pr, builder_sr),
     ]
+    if workflow_url:
+        tools += [
+            DeployWorkflowLLMTool(page_cls, sr, pr, builder_sr),
+        ]
     return {tool.name: tool for tool in tools}

--- a/functions/gooey_builder_workflow_tools.py
+++ b/functions/gooey_builder_workflow_tools.py
@@ -4,6 +4,7 @@ from bots.models import WorkflowAccessLevel, PublishedRun, SavedRun
 import typing
 
 from app_users.models import AppUser
+from bots.models.workflow import Workflow
 from daras_ai_v2.crypto import get_random_doc_id
 from functions.base_llm_tool import (
     BaseLLMTool,
@@ -17,9 +18,77 @@ import gooey_gui as gui
 import json
 from fastapi.encoders import jsonable_encoder
 
+from widgets.workflow_search import SearchFilters, get_filtered_published_runs
 from workspaces.models import Workspace
 
 WORKFLOW_URL_KEY = "builder_workflow_url"
+
+MAX_SEARCH_RESULTS = 10
+
+
+class SearchWorkflowsLLMTool(BaseLLMTool):
+    disable_dynamic_loader = True
+
+    name = "search_workflows"
+
+    def __init__(self, uid: str):
+        self.uid = uid
+        super().__init__(
+            name=self.name,
+            label="Search Workflows",
+            description=(
+                "Search Gooey.AI's workflow library (same search as the /explore page) "
+                "to find a workflow to use as the starting point for the user's request. "
+                "This is a keyword (full-text) search, NOT semantic search: every word in "
+                "the query must literally match the workflow's title/description/tags, so "
+                "long free-form queries usually return nothing. "
+                "Use 1-3 short generic keywords (e.g. 'image', 'lipsync', 'copilot') and "
+                "broaden the query further if there are no results. "
+            ),
+            properties={
+                "search": {
+                    "type": "string",
+                    "description": (
+                        "Keyword search query. All words must match, so keep it to 1-3 "
+                        "short keywords, e.g. 'image', 'lipsync video', 'qr code'. "
+                        "Do NOT paste the user's full request here."
+                    ),
+                },
+            },
+            required=["search"],
+        )
+
+    def call(self, search: str) -> dict:
+        user = AppUser.objects.filter(uid=self.uid).first()
+        search_filters = SearchFilters(search=search)
+        qs = get_filtered_published_runs(user, search_filters)
+
+        results = [
+            dict(
+                title=pr.title,
+                description=(pr.notes or "")[:300],
+                workflow=Workflow(pr.workflow).label,
+                run_url=pr.get_app_url(),
+            )
+            for pr in qs[:MAX_SEARCH_RESULTS]
+        ]
+        if not results:
+            return dict(
+                results=[],
+                message=(
+                    "No workflows found. This is a keyword search where every word "
+                    "must match - retry with fewer, more generic keywords "
+                    "(e.g. a single word like 'image')."
+                ),
+            )
+
+        return dict(results=results)
+
+
+NO_CURRENT_WORKFLOW_ERROR = (
+    "No workflow is currently selected and no run_url was provided. "
+    f"Call `{SearchWorkflowsLLMTool.name}` to find a workflow and pass its run_url to this tool."
+)
 
 
 class FetchWorkflowStateLLMTool(BaseLLMTool):
@@ -27,7 +96,7 @@ class FetchWorkflowStateLLMTool(BaseLLMTool):
 
     name = "fetch_workflow_state"
 
-    def __init__(self, page_cls: typing.Type[BasePage]):
+    def __init__(self, page_cls: typing.Type[BasePage] | None):
         self.page_cls = page_cls
         super().__init__(
             name=self.name,
@@ -37,8 +106,6 @@ class FetchWorkflowStateLLMTool(BaseLLMTool):
         )
 
     def call(self, run_url: str) -> typing.Any:
-        from daras_ai_v2.workflow_url_input import url_to_runs
-
         page_cls, sr, pr = url_to_runs(run_url)
         ret = dict(success=True, state=sr.state)
 
@@ -58,9 +125,9 @@ class FetchWorkflowStateLLMTool(BaseLLMTool):
 class GooeyBuilderLLMTool(BaseLLMTool):
     disable_dynamic_loader = True
 
-    page_cls: typing.Type[BasePage]
-    sr: SavedRun
-    pr: PublishedRun
+    page_cls: typing.Type[BasePage] | None
+    sr: SavedRun | None
+    pr: PublishedRun | None
     builder_sr: SavedRun
 
     def handle_redirect(self, background: bool):
@@ -78,8 +145,9 @@ class GooeyBuilderLLMTool(BaseLLMTool):
     ) -> tuple[typing.Type[BasePage], SavedRun, PublishedRun]:
         if run_url:
             return url_to_runs(run_url)
-        else:
-            return self.page_cls, self.sr, self.pr
+        if not self.sr:
+            raise ValueError(NO_CURRENT_WORKFLOW_ERROR)
+        return self.page_cls, self.sr, self.pr
 
     def get_current_user(self) -> AppUser:
         return AppUser.objects.get(uid=self.builder_sr.uid)
@@ -106,9 +174,9 @@ class UpdateWorkflowStateLLMTool(GooeyBuilderLLMTool):
 
     def __init__(
         self,
-        page_cls: typing.Type[BasePage],
-        sr: SavedRun,
-        pr: PublishedRun,
+        page_cls: typing.Type[BasePage] | None,
+        sr: SavedRun | None,
+        pr: PublishedRun | None,
         builder_sr: SavedRun,
     ):
         self.page_cls = page_cls
@@ -116,30 +184,38 @@ class UpdateWorkflowStateLLMTool(GooeyBuilderLLMTool):
         self.pr = pr
         self.builder_sr = builder_sr
 
-        state = sr.state
+        if sr:
+            state = sr.state
+            properties = page_cls.get_tool_call_schema(state)
 
-        properties = page_cls.get_tool_call_schema(state)
+            current_workflow_state = dict(
+                request=extract_model_fields(page_cls.RequestModel, state),
+                response=extract_model_fields(page_cls.ResponseModel, state),
+            )
+            description = (
+                "Call this tool to update the current workflow state without running it.\n\n"
+                f"Once updated you can run the updated workflow by calling the `{RunWorkflowLLMTool.name}` tool.\n"
+                "By default, this tool will update the current workflow state. "
+                f"You may call `{FetchWorkflowStateLLMTool.name}` to get the state of any workflow given its run_url "
+                "and then call this tool with the run_url to update.\n\n"
+                f"Current Workflow State: {json.dumps(jsonable_encoder(current_workflow_state))}"
+            )
+        else:
+            properties = {}
+            description = (
+                "Call this tool to update a workflow's state without running it.\n\n"
+                "There is no currently selected workflow, so you MUST pass `run_url`. "
+                f"Call `{SearchWorkflowsLLMTool.name}` to find a workflow, then call "
+                f"`{FetchWorkflowStateLLMTool.name}` with its run_url to get the "
+                "workflow's state and schema properties before calling this tool.\n"
+                f"Once updated you can run the updated workflow by calling the `{RunWorkflowLLMTool.name}` tool."
+            )
+
         properties.update(
             {
-                "run_url": {
-                    "type": "string",
-                    "description": "(optional) The run_url of the workflow to update. Defaults to the current workflow.",
-                },
+                "run_url": run_url_prop("update", sr),
                 "background": BACKGROUND_PROP,
             }
-        )
-
-        current_workflow_state = dict(
-            request=extract_model_fields(page_cls.RequestModel, state),
-            response=extract_model_fields(page_cls.ResponseModel, state),
-        )
-        description = (
-            "Call this tool to update the current workflow state without running it.\n\n"
-            f"Once updated you can run the updated workflow by calling the `{RunWorkflowLLMTool.name}` tool.\n"
-            "By default, this tool will update the current workflow state. "
-            f"You may call `{FetchWorkflowStateLLMTool.name}` to get the state of any workflow given its run_url "
-            "and then call this tool with the run_url to update.\n\n"
-            f"Current Workflow State: {json.dumps(jsonable_encoder(current_workflow_state))}"
         )
         super().__init__(
             name=self.name,
@@ -187,24 +263,22 @@ class RunWorkflowLLMTool(GooeyBuilderLLMTool):
 
     def __init__(
         self,
-        page_cls: typing.Type[BasePage],
-        sr: SavedRun,
-        pr: PublishedRun,
+        page_cls: typing.Type[BasePage] | None,
+        sr: SavedRun | None,
+        pr: PublishedRun | None,
         builder_sr: SavedRun,
     ):
         self.page_cls = page_cls
         self.sr = sr
         self.pr = pr
         self.builder_sr = builder_sr
+
         super().__init__(
             name=self.name,
             label="Run Workflow",
             description="Submit and Run the workflow",
             properties={
-                "run_url": {
-                    "type": "string",
-                    "description": "(optional) The url of the workflow to run. Defaults to the current workflow.",
-                },
+                "run_url": run_url_prop("run", sr),
                 "background": BACKGROUND_PROP,
             },
         )
@@ -252,9 +326,9 @@ class SaveWorkflowLLMTool(GooeyBuilderLLMTool):
 
     def __init__(
         self,
-        page_cls: typing.Type[BasePage],
-        sr: SavedRun,
-        pr: PublishedRun,
+        page_cls: typing.Type[BasePage] | None,
+        sr: SavedRun | None,
+        pr: PublishedRun | None,
         builder_sr: SavedRun,
     ):
         self.page_cls = page_cls
@@ -262,18 +336,26 @@ class SaveWorkflowLLMTool(GooeyBuilderLLMTool):
         self.pr = pr
         self.builder_sr = builder_sr
 
+        if pr:
+            current_title = f"\n\nCurrent title: {pr.title}"
+            current_description = f"\n\nCurrent description: {pr.notes}"
+            last_change_notes = f"\n\nLast change notes: {sr.parent_version and sr.parent_version.change_notes}"
+        else:
+            current_title = ""
+            current_description = ""
+            last_change_notes = ""
+
         super().__init__(
             name=self.name,
             label="Save Workflow",
             description=(
-                "Save changes to the current published workflow as a new version. "
-                "Call this when the user asks to save, publish, or update the current workflow "
+                "Save changes to a published workflow as a new version. "
+                "Call this when the user asks to save, publish, or update a workflow "
                 "(including its title or description) in place. "
                 "If the user wants to copy/duplicate/fork the workflow into a new one, "
                 f"call `{SaveAsNewWorkflowLLMTool.name}` instead. "
                 "Pass `run_url` to save a specific saved run "
-                f"(e.g. the `run_url` returned by `{UpdateWorkflowStateLLMTool.name}`); "
-                "otherwise the currently open workflow run is saved."
+                f"(e.g. the `run_url` returned by `{UpdateWorkflowStateLLMTool.name}`)."
             ),
             properties={
                 "title": {
@@ -282,8 +364,8 @@ class SaveWorkflowLLMTool(GooeyBuilderLLMTool):
                     "description": (
                         "Optional new value for the 'Title' "
                         "field in the Save Workflow dialog. "
-                        "Leave unset to keep the existing title.\n\n"
-                        f"Current title: {self.pr.title}"
+                        "Leave unset to keep the existing title."
+                        f"{current_title}"
                     ),
                 },
                 "description": {
@@ -292,20 +374,17 @@ class SaveWorkflowLLMTool(GooeyBuilderLLMTool):
                     "description": (
                         "Optional new value for the 'Description' "
                         "field in the Save Workflow dialog "
-                        "Leave unset to keep the existing description.\n\n"
-                        f"Current description: {self.pr.notes}"
+                        "Leave unset to keep the existing description."
+                        f"{current_description}"
                     ),
                 },
                 "change_notes": {
                     "type": "string",
                     "title": "Add change notes",
-                    "description": "Used as the changelog entry for the new version.\n\n"
-                    f"Last change notes: {self.sr.parent_version and self.sr.parent_version.change_notes}",
+                    "description": "Used as the changelog entry for the new version."
+                    f"{last_change_notes}",
                 },
-                "run_url": {
-                    "type": "string",
-                    "description": "(optional) The url of the workflow to save. Defaults to the current workflow.",
-                },
+                "run_url": run_url_prop("save", sr),
                 "background": BACKGROUND_PROP,
             },
         )
@@ -354,9 +433,9 @@ class SaveAsNewWorkflowLLMTool(GooeyBuilderLLMTool):
 
     def __init__(
         self,
-        page_cls: typing.Type[BasePage],
-        sr: SavedRun,
-        pr: PublishedRun,
+        page_cls: typing.Type[BasePage] | None,
+        sr: SavedRun | None,
+        pr: PublishedRun | None,
         builder_sr: SavedRun,
     ):
         self.page_cls = page_cls
@@ -368,7 +447,7 @@ class SaveAsNewWorkflowLLMTool(GooeyBuilderLLMTool):
             name=self.name,
             label="Save as New Workflow",
             description=(
-                "Create a new published workflow that is a copy of the current one. "
+                "Create a new published workflow that is a copy of an existing one. "
                 "Call this when the user asks to save as new workflow, save as new version, duplicate, fork, clone, etc. "
                 f"Use `{SaveWorkflowLLMTool.name}` instead if the user wants to update an existing workflow in place. "
             ),
@@ -389,13 +468,7 @@ class SaveAsNewWorkflowLLMTool(GooeyBuilderLLMTool):
                         "Defaults to the original description."
                     ),
                 },
-                "run_url": {
-                    "type": "string",
-                    "description": (
-                        "(optional) The url of the workflow to save as new. "
-                        "Defaults to the current workflow."
-                    ),
-                },
+                "run_url": run_url_prop("save as new", sr),
                 "background": BACKGROUND_PROP,
             },
         )
@@ -428,3 +501,18 @@ class SaveAsNewWorkflowLLMTool(GooeyBuilderLLMTool):
         self.url = new_pr.get_app_url()
         self.handle_redirect(background)
         return dict(success=True, run_url=self.url)
+
+
+def run_url_prop(action: str, sr: SavedRun | None) -> dict:
+    if sr:
+        description = (
+            f"(optional) The url of the workflow to {action}. "
+            "Defaults to the current workflow."
+        )
+    else:
+        description = (
+            f"The url of the workflow to {action}. "
+            "Required because there is no currently selected workflow - "
+            f"call `{SearchWorkflowsLLMTool.name}` to find one."
+        )
+    return {"type": "string", "description": description}

--- a/gooey-gui/app/components/AskGooeyNew.tsx
+++ b/gooey-gui/app/components/AskGooeyNew.tsx
@@ -5,14 +5,12 @@ import { fetchServerAPI } from "~/fetchServerAPI";
 import type { CustomComponentProps } from "~/components";
 
 type AskGooeyNewProps = CustomComponentProps & {
-  workflow_url: string;
   title?: string;
   highlight?: string;
   placeholder?: string;
 };
 
 export function AskGooeyNew({
-  workflow_url,
   title = "What do you want to build today?",
   highlight = "build",
   placeholder = "India stock market today",
@@ -37,7 +35,6 @@ export function AskGooeyNew({
       const redirectUrl = await fetchServerAPI<string | null>(
         "/__/gooey-builder/send-message",
         {
-          workflow_url,
           input_data: { input_prompt: prompt },
         }
       );

--- a/gooey-gui/app/components/AskGooeyNew.tsx
+++ b/gooey-gui/app/components/AskGooeyNew.tsx
@@ -4,19 +4,19 @@ import { useNavigate } from "@remix-run/react";
 import { fetchServerAPI } from "~/fetchServerAPI";
 import type { CustomComponentProps } from "~/components";
 
-type ExploreBuilderPromptProps = CustomComponentProps & {
+type AskGooeyNewProps = CustomComponentProps & {
   workflow_url: string;
   title?: string;
   highlight?: string;
   placeholder?: string;
 };
 
-export function ExploreBuilderPrompt({
+export function AskGooeyNew({
   workflow_url,
   title = "What do you want to build today?",
   highlight = "build",
   placeholder = "India stock market today",
-}: ExploreBuilderPromptProps) {
+}: AskGooeyNewProps) {
   const navigate = useNavigate();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [value, setValue] = useState("");

--- a/gooey-gui/app/components/GooeyBuilderInlineEmbed.tsx
+++ b/gooey-gui/app/components/GooeyBuilderInlineEmbed.tsx
@@ -16,6 +16,7 @@ export function GooeyBuilderInlineEmbed(
     messages?: Record<string, any> | null;
     builder_run_url: string;
     workflow_state: Record<string, any>;
+    builder_only?: boolean;
   }
 ) {
   const { config, messages } = props;
@@ -37,11 +38,14 @@ export function GooeyBuilderInlineEmbed(
         return;
       }
 
-      config.onClose = function () {
-        window.dispatchEvent(
-          new CustomEvent(`${propsRef.current.sidebar_key}:close`)
-        );
-      };
+      // builder-only pages are standalone, so there's no sidebar to close
+      if (!propsRef.current.builder_only) {
+        config.onClose = function () {
+          window.dispatchEvent(
+            new CustomEvent(`${propsRef.current.sidebar_key}:close`)
+          );
+        };
+      }
 
       controllerRef.current = {
         messages,
@@ -49,7 +53,10 @@ export function GooeyBuilderInlineEmbed(
           let redirectUrl = await fetchServerAPI<string | null>(
             "/__/gooey-builder/send-message",
             {
-              workflow_url: window.location.href,
+              // builder-only pages have no associated workflow to clone
+              workflow_url: propsRef.current.builder_only
+                ? null
+                : window.location.href,
               builder_run_url: propsRef.current.builder_run_url,
               workflow_state: propsRef.current.workflow_state,
               input_data,
@@ -62,15 +69,20 @@ export function GooeyBuilderInlineEmbed(
         onNewConversation: async () => {
           ctx.current.update_session_state({ builderOnNewConversation: true });
         },
-        fetchConversations: () =>
-          fetchServerAPI("/__/gooey-builder/fetch-conversations", {
-            run_url: propsRef.current.builder_run_url,
-          }),
+        // builder-only pages have no workflow_url, so no conversations sidebar
+        fetchConversations: propsRef.current.builder_only
+          ? undefined
+          : () =>
+              fetchServerAPI("/__/gooey-builder/fetch-conversations", {
+                run_url: propsRef.current.builder_run_url,
+              }),
         rerun: async (run_url: string) => {
           let redirectUrl = await fetchServerAPI<string | null>(
             "/__/gooey-builder/send-message",
             {
-              workflow_url: window.location.href,
+              workflow_url: propsRef.current.builder_only
+                ? null
+                : window.location.href,
               builder_run_url: run_url,
               workflow_state: propsRef.current.workflow_state,
             }

--- a/gooey-gui/app/components/index.ts
+++ b/gooey-gui/app/components/index.ts
@@ -10,7 +10,7 @@ export type CustomComponentProps = {
 export * from "./WorkspaceMemoryTable";
 export * from "./bulkProgress/BulkProgressCard";
 export * from "./ComposioAuthRequired";
-export * from "./ExploreBuilderPrompt";
+export * from "./AskGooeyNew";
 export * from "./ForgotPasswordForm";
 export * from "./GooeyBuilderInlineEmbed";
 export * from "./GooeyPopover";

--- a/routers/ask_gooey_new.py
+++ b/routers/ask_gooey_new.py
@@ -6,15 +6,25 @@ from bots.models import PublishedRun
 from daras_ai_v2 import settings
 from daras_ai_v2.gooey_builder import can_launch_gooey_builder
 from daras_ai_v2.meta_content import raw_build_meta_tags
+from routers.custom_api_router import CustomAPIRouter
+from routers.root import get_og_url_path, page_wrapper
 from workspaces.models import Workspace
-
 
 META_TITLE = "Explore | Gooey.AI"
 META_DESCRIPTION = "Find, fork and run your field’s favorite AI recipes on Gooey.AI"
 
+app = CustomAPIRouter()
 
-def render(request: Request):
-    render_explore_builder_prompt(request=request, workspace=None)
+
+@gui.route(app, "/new/")
+@gui.route(app, "/explore2/")
+def ask_gooey_new_page(request: Request):
+    with page_wrapper(request, show_search_bar=False):
+        render_ask_gooey_new(request=request, workspace=None)
+
+    return {
+        "meta": build_meta_tags(url=get_og_url_path(request)),
+    }
 
 
 def build_meta_tags(url: str):
@@ -25,7 +35,7 @@ def build_meta_tags(url: str):
     )
 
 
-def render_explore_builder_prompt(
+def render_ask_gooey_new(
     request: fastapi.Request,
     workspace: Workspace | None,
     title: str = "What do you want to build today?",
@@ -51,7 +61,7 @@ def render_explore_builder_prompt(
     except PublishedRun.DoesNotExist:
         return
     gui.component(
-        "ExploreBuilderPrompt",
+        "AskGooeyNew",
         workflow_url=bot_generator_pr.get_app_url(),
         title=title,
         highlight=highlight,

--- a/routers/ask_gooey_new.py
+++ b/routers/ask_gooey_new.py
@@ -1,10 +1,17 @@
 import fastapi
 import gooey_gui as gui
+from django.utils.text import slugify
+from furl import furl
 from starlette.requests import Request
 
-from bots.models import PublishedRun
+from bots.models import SavedRun
+from daras_ai.image_input import truncate_text_words
 from daras_ai_v2 import settings
-from daras_ai_v2.gooey_builder import can_launch_gooey_builder
+from daras_ai_v2.fastapi_tricks import get_route_path
+from daras_ai_v2.gooey_builder import (
+    can_launch_gooey_builder,
+    render_standalone_gooey_builder,
+)
 from daras_ai_v2.meta_content import raw_build_meta_tags
 from routers.custom_api_router import CustomAPIRouter
 from routers.root import get_og_url_path, page_wrapper
@@ -27,6 +34,61 @@ def ask_gooey_new_page(request: Request):
     }
 
 
+@gui.route(app, "/new/{title}-{run_id}/")
+def gooey_builder_run_route(request: Request, title: str, run_id: str):
+    """Renders only the gooey builder chat for a builder prompt run, without
+    the associated workflow. Redirects to the child workflow whenever the
+    builder updates it."""
+    if not request.user or request.user.is_anonymous:
+        raise gui.RedirectException(
+            str(furl("/login", query_params={"next": str(request.url)}))
+        )
+
+    try:
+        builder_sr = SavedRun.objects.get(
+            run_id=run_id, surface=SavedRun.Surface.builder_prompt
+        )
+    except SavedRun.DoesNotExist:
+        raise fastapi.HTTPException(status_code=404)
+    if builder_sr.uid != request.user.uid and not request.user.is_admin():
+        raise fastapi.HTTPException(status_code=404)
+
+    # the builder embed sets this flag on "new conversation"; the standalone
+    # page is tied to one builder run, so start fresh from the hero page
+    if gui.session_state.pop("builderOnNewConversation", None):
+        raise gui.RedirectException(get_route_path(ask_gooey_new_page))
+
+    with page_wrapper(request, show_search_bar=False):
+        with gui.div(
+            className="w-100 mx-auto",
+            style={"maxWidth": "900px", "height": "calc(100vh - 200px)"},
+        ):
+            render_standalone_gooey_builder(
+                sidebar_key="gooey-builder",
+                request=request,
+                builder_sr=builder_sr,
+            )
+
+    return {
+        "meta": build_meta_tags(url=get_og_url_path(request)),
+    }
+
+
+def get_gooey_builder_run_url(builder_sr: SavedRun) -> str:
+    slug = (
+        slugify(
+            truncate_text_words(builder_sr.state.get("input_prompt") or "", maxlen=40)
+        )
+        or "untitled"
+    )
+    return str(
+        furl(settings.APP_BASE_URL)
+        / get_route_path(
+            gooey_builder_run_route, dict(title=slug, run_id=builder_sr.run_id)
+        )
+    )
+
+
 def build_meta_tags(url: str):
     return raw_build_meta_tags(
         url=url,
@@ -44,25 +106,14 @@ def render_ask_gooey_new(
 ):
     """Centered "What can I help with?" hero prompt for /explore.
 
-    On submit it calls ``gooey_builder_on_send_message`` and the React
-    component navigates the user to the newly-created workflow run.
+    On submit it starts a builder-only conversation (no workflow attached) and
+    the React component navigates the user to the standalone builder page at
+    ``/new/<title>-<run_id>/``.
     """
     if not can_launch_gooey_builder(request, workspace):
         return
-    if not settings.BOT_GENERATOR_EXAMPLE_ID:
-        return
-
-    from recipes.VideoBots import VideoBotsPage
-
-    try:
-        bot_generator_pr = VideoBotsPage.get_pr_from_example_id(
-            example_id=settings.BOT_GENERATOR_EXAMPLE_ID
-        )
-    except PublishedRun.DoesNotExist:
-        return
     gui.component(
         "AskGooeyNew",
-        workflow_url=bot_generator_pr.get_app_url(),
         title=title,
         highlight=highlight,
         placeholder=placeholder,

--- a/routers/root.py
+++ b/routers/root.py
@@ -220,18 +220,6 @@ def explore_page(
     }
 
 
-@gui.route(app, "/explore2/")
-def explore2_page(request: Request):
-    from widgets import explore2
-
-    with page_wrapper(request, show_search_bar=False):
-        explore2.render(request)
-
-    return {
-        "meta": explore2.build_meta_tags(url=get_og_url_path(request)),
-    }
-
-
 @gui.route(app, "/home/")
 def home_page(request: Request):
     from widgets import home

--- a/server.py
+++ b/server.py
@@ -31,6 +31,7 @@ from daras_ai_v2.settings import templates
 from memory import routers as memory_routers
 from routers import (
     account,
+    ask_gooey_new,
     facebook_api,
     api,
     root,
@@ -86,6 +87,7 @@ for router in api_routers:
 
 app_routers = [
     account.app,
+    ask_gooey_new.app,
     memory_routers.app,
     facebook_api.app,
     onedrive_api.app,


### PR DESCRIPTION
… update relevant routes

- Removed ExploreBuilderPrompt in favor of the new AskGooeyNew component.
- Updated /explore2/ route to render AskGooeyNew.
- Adjusted imports and component references to reflect the new naming convention.
- Refactored associated backend and frontend logic for consistency.### Q/A checklist

- [ ] I have tested my UI changes on mobile and they look acceptable
- [ ] I have tested changes to the workflows in both the API and the UI
- [ ] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [ ] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
