### PR TITLE
feat: add `to_llm_body` utility for message field validation and refa…

### DIFF
--- a/daras_ai_v2/language_model.py
+++ b/daras_ai_v2/language_model.py
@@ -39,6 +39,7 @@ from daras_ai_v2.custom_enum import GooeyEnum
 from daras_ai_v2.exceptions import raise_for_status, UserError
 from daras_ai_v2.functional import flatten
 from daras_ai_v2.gpu_server import call_celery_task
+from daras_ai_v2.language_model_body import to_llm_body
 from daras_ai_v2.language_model_openai_audio import run_openai_audio
 from daras_ai_v2.redis_cache import redis_cache_decorator
 from daras_ai_v2.text_splitter import default_length_function, default_separators
@@ -681,6 +682,8 @@ def run_openai_responses(
 ) -> list[ConversationEntry] | typing.Generator[list[ConversationEntry], None, None]:
     from daras_ai_v2.safety_checker import capture_openai_content_policy_violation
 
+    messages = to_llm_body(messages)
+
     kwargs = {}
 
     if model.llm_is_thinking_model:
@@ -770,6 +773,8 @@ def run_openai_chat(
 ) -> list[ConversationEntry] | typing.Generator[list[ConversationEntry], None, None]:
     from openai import NOT_GIVEN
     from daras_ai_v2.safety_checker import capture_openai_content_policy_violation
+
+    messages = to_llm_body(messages)
 
     kwargs = {}
 
@@ -1402,7 +1407,7 @@ def _run_groq_chat(
 
     data = dict(
         model=model,
-        messages=messages,
+        messages=to_llm_body(messages),
         max_tokens=max_tokens,
         temperature=temperature,
     )
@@ -1450,35 +1455,9 @@ def _run_fireworks_chat(
     from usage_costs.cost_utils import record_cost_auto
     from usage_costs.models import ModelSku
 
-    fireworks_msgs = []
-    for msg in messages:
-        fireworks_msg = {
-            "role": msg.get("role") or CHATML_ROLE_USER,
-            "content": msg.get("content"),
-        }
-        tool_call_id = msg.get("tool_call_id")
-        if tool_call_id:
-            fireworks_msg["tool_call_id"] = tool_call_id
-        tool_calls = msg.get("tool_calls")
-        if tool_calls:
-            fireworks_tool_calls = []
-            for tool_call in tool_calls:
-                function = tool_call.get("function") or {}
-                fireworks_tool_call = {
-                    "id": tool_call.get("id") or "",
-                    "type": tool_call.get("type") or "function",
-                    "function": {
-                        "name": function.get("name") or "",
-                        "arguments": function.get("arguments") or "",
-                    },
-                }
-                fireworks_tool_calls.append(fireworks_tool_call)
-            fireworks_msg["tool_calls"] = fireworks_tool_calls
-        fireworks_msgs.append(fireworks_msg)
-
     data = dict(
         model=model,
-        messages=fireworks_msgs,
+        messages=to_llm_body(messages),
         max_tokens=max_tokens,
         n=num_outputs,
         temperature=temperature,
@@ -1531,7 +1510,7 @@ def _run_mistral_chat(
 
     data = dict(
         model=model,
-        messages=messages,
+        messages=to_llm_body(messages),
         max_tokens=max_tokens,
         n=num_outputs,
         temperature=temperature,

--- a/daras_ai_v2/language_model_body.py
+++ b/daras_ai_v2/language_model_body.py
@@ -1,0 +1,62 @@
+import typing
+
+import pydantic
+
+CHATML_ROLE_USER = "user"
+
+
+class LLMFunction(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(extra="ignore")
+
+    name: str = ""
+    arguments: str = ""
+
+    @pydantic.field_validator("name", "arguments", mode="before")
+    @classmethod
+    def _none_to_empty(cls, v):
+        return v or ""
+
+
+class LLMToolCall(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(extra="ignore")
+
+    id: str = ""
+    type: typing.Literal["function"] = "function"
+    function: LLMFunction = LLMFunction()
+
+    @pydantic.field_validator("id", mode="before")
+    @classmethod
+    def _id_none_to_empty(cls, v):
+        return v or ""
+
+    @pydantic.field_validator("type", mode="before")
+    @classmethod
+    def _type_default(cls, v):
+        return v or "function"
+
+    @pydantic.field_validator("function", mode="before")
+    @classmethod
+    def _function_default(cls, v):
+        return v or {}
+
+
+class LLMMessage(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(extra="ignore")
+
+    role: typing.Literal["system", "user", "assistant", "tool"] = CHATML_ROLE_USER
+    content: str | list[dict] | None = None
+    tool_calls: list[LLMToolCall] | None = None
+    tool_call_id: str | None = None
+
+    @pydantic.field_validator("role", mode="before")
+    @classmethod
+    def _role_default(cls, v):
+        return v or CHATML_ROLE_USER
+
+
+def to_llm_body(messages: list[dict]) -> list[dict]:
+    """Whitelist outgoing message fields so internal keys (chunk, run_url, metrics, ...) don't cause HTTP 400s."""
+    return [
+        LLMMessage.model_validate(entry).model_dump(exclude_none=True)
+        for entry in messages
+    ]

--- a/tests/test_llm_body.py
+++ b/tests/test_llm_body.py
@@ -1,0 +1,67 @@
+from daras_ai_v2.language_model_body import to_llm_body
+
+
+def test_to_llm_body_strips_internal_keys():
+    messages = [
+        {"role": "system", "content": "be helpful"},
+        {
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": "https://foo/img.png"}},
+                {"type": "text", "text": "what is this?"},
+            ],
+            "run_url": "https://gooey.ai/run/123",
+        },
+        {
+            "role": "assistant",
+            "content": "let me check",
+            "chunk": "",
+            "finish_reason": "tool_calls",
+            "metrics": {"thinking_duration_sec": 3},
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": None,
+                    "function": {"name": "search", "arguments": None},
+                    "label": "Search",
+                    "url": "https://gooey.ai/tool/search",
+                    "icon": "🔍",
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "42"},
+    ]
+    assert to_llm_body(messages) == [
+        {"role": "system", "content": "be helpful"},
+        {
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": "https://foo/img.png"}},
+                {"type": "text", "text": "what is this?"},
+            ],
+        },
+        {
+            "role": "assistant",
+            "content": "let me check",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": ""},
+                }
+            ],
+        },
+        {"role": "tool", "content": "42", "tool_call_id": "call_1"},
+    ]
+
+
+def test_to_llm_body_defaults():
+    assert to_llm_body([{"content": "hi"}]) == [{"role": "user", "content": "hi"}]
+    # assistant msg with tool_calls and no content: content key must be dropped
+    body = to_llm_body(
+        [{"role": "assistant", "content": None, "tool_calls": [{"id": "x"}]}]
+    )
+    assert "content" not in body[0]
+    assert body[0]["tool_calls"] == [
+        {"id": "x", "type": "function", "function": {"name": "", "arguments": ""}}
+    ]


### PR DESCRIPTION
…ctor message handling

- Introduced `to_llm_body` function to standardize outgoing message fields, ensuring internal keys (e.g., `chunk`, `run_url`, `metrics`) are excluded.
- Added `LLMMessage`, `LLMToolCall`, and `LLMFunction` models with default values and validation via Pydantic.
- Refactored message preprocessing across all relevant functions to use `to_llm_body`.
- Added unit tests for `to_llm_body` to validate filtering and default behavior.

### Q/A checklist

- [ ] I have tested my UI changes on mobile and they look acceptable
- [ ] I have tested changes to the workflows in both the API and the UI
- [ ] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [ ] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
