### PR TITLE
fix: make message threads searchable in admin

### DIFF
--- a/bots/admin.py
+++ b/bots/admin.py
@@ -1147,6 +1147,7 @@ class TagAdmin(GooeyModelAdmin):
 
 @admin.register(MessageThread)
 class MessageThreadAdmin(GooeyModelAdmin):
+    search_fields = ["title"]
     list_display = [
         "truncated_title",
         "view_bot_conversation",


### PR DESCRIPTION
## What changed

- Added `search_fields = ["title"]` to `MessageThreadAdmin`.

## Why

`SavedRunAdmin.autocomplete_fields` now includes `message_thread`. Django requires the related `MessageThreadAdmin` to define `search_fields`; without it, the admin container exits during startup with `admin.E040`.

This restores local admin startup and allows message threads to be searched by title in the autocomplete widget.

## Validation

- `/Users/milovate/Library/Caches/pypoetry/virtualenvs/ddgai-R3ztAJnu-py3.10/bin/ruff check bots/admin.py`
- `/Users/milovate/Library/Caches/pypoetry/virtualenvs/ddgai-R3ztAJnu-py3.10/bin/python manage.py check`