### PR TITLE
feat: carry run metadata on chat history messages for widget export

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -122,5 +122,17 @@ def clear_pytest_outbox():
 
 @pytest.fixture(scope="session", autouse=True)
 def patch_django_supports_color():
-    with patch("django.core.management.color.supports_color", return_value=False):
+    from django.core.management.base import OutputWrapper
+
+    with (
+        patch("django.core.management.color.supports_color", return_value=False),
+        patch.object(OutputWrapper, "isatty", _safe_django_output_isatty),
+    ):
         yield
+
+
+def _safe_django_output_isatty(self):
+    try:
+        return hasattr(self._out, "isatty") and self._out.isatty()
+    except ValueError:
+        return False

--- a/daras_ai_v2/language_model.py
+++ b/daras_ai_v2/language_model.py
@@ -39,7 +39,7 @@ from daras_ai_v2.custom_enum import GooeyEnum
 from daras_ai_v2.exceptions import raise_for_status, UserError
 from daras_ai_v2.functional import flatten
 from daras_ai_v2.gpu_server import call_celery_task
-from daras_ai_v2.language_model_body import to_llm_body
+from daras_ai_v2.language_model_body import LLMMessageExtraContent, to_llm_body
 from daras_ai_v2.language_model_openai_audio import run_openai_audio
 from daras_ai_v2.redis_cache import redis_cache_decorator
 from daras_ai_v2.text_splitter import default_length_function, default_separators
@@ -122,6 +122,9 @@ class ConversationEntry(typing_extensions.TypedDict, total=False):
     tool_call_id: typing_extensions.NotRequired[str]
 
     run_url: typing_extensions.NotRequired[str]
+    extra_content: typing_extensions.NotRequired[
+        LLMMessageExtraContent | dict[str, typing.Any]
+    ]
 
 
 def remove_images_from_entry(entry: ConversationEntry) -> ConversationEntry | None:

--- a/daras_ai_v2/language_model_body.py
+++ b/daras_ai_v2/language_model_body.py
@@ -45,6 +45,19 @@ class LLMToolCall(pydantic.BaseModel):
         return v or {}
 
 
+class LLMMessageExtraContent(pydantic.BaseModel):
+    """
+    saved run data carried on a message so historic turns can be exported with
+    their originating run metadata. Never sent to the LLM.
+    """
+
+    model_config = pydantic.ConfigDict(extra="allow")
+
+    display_content: str | None = None
+    output_video: list[str] | None = None
+    output_audio: list[str] | None = None
+
+
 class LLMMessage(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(extra="ignore")
 
@@ -52,6 +65,9 @@ class LLMMessage(pydantic.BaseModel):
     content: str | list[dict] | None = None
     tool_calls: list[LLMToolCall] | None = None
     tool_call_id: str | None = None
+
+    run_url: str | None = None
+    extra_content: LLMMessageExtraContent | None = None
 
     @pydantic.field_validator("role", mode="before")
     @classmethod
@@ -62,11 +78,10 @@ class LLMMessage(pydantic.BaseModel):
 def to_llm_body(
     messages: list[dict], *, model: AIModelSpec | None = None
 ) -> list[dict]:
-    """Whitelist outgoing message fields so internal keys (chunk, run_url, metrics, ...) don't cause HTTP 400s."""
-    if model and model.is_google_model():
-        exclude = None
-    else:
-        exclude = {"tool_calls": {"__all__": {"extra_content"}}}
+    """Whitelist outgoing message fields so internal keys (chunk, run_url, extra_content, metrics, ...) don't cause HTTP 400s."""
+    exclude = {"run_url": True, "extra_content": True}
+    if not (model and model.is_google_model()):
+        exclude["tool_calls"] = {"__all__": {"extra_content"}}
     return [
         LLMMessage.model_validate(entry).model_dump(
             exclude=exclude,

--- a/daras_ai_v2/language_model_body.py
+++ b/daras_ai_v2/language_model_body.py
@@ -54,8 +54,9 @@ class LLMMessageExtraContent(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(extra="allow")
 
     display_content: str | None = None
-    output_video: list[str] | None = None
-    output_audio: list[str] | None = None
+    audio: str | list[str] | None = None
+    video: list[str] | None = None
+    documents: list[str] | None = None
 
 
 class LLMMessage(pydantic.BaseModel):

--- a/daras_ai_v2/web_widget_embed.py
+++ b/daras_ai_v2/web_widget_embed.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Iterator
 
 import gooey_gui as gui
 from bots.models import SavedRun
@@ -68,14 +68,19 @@ def chat_widget_input_to_request_body(
             # input_audio=prev_input_audio,
             input_documents=prev_input_documents,
         )
+        extra_content = user_extra_content(
+            state, get_entry_text(user_entry), prev_input_audio, prev_input_documents
+        )
+        if extra_content:
+            user_entry["extra_content"] = extra_content
 
         assistant_entry = format_chat_entry(
             role=CHATML_ROLE_ASSISTANT,
             content_text=prev_output,
-        ) | {
-            "run_url": sr.get_app_url(),
-            "extra_content": _extra_content_from_state(state, prev_output),
-        }
+        ) | {"run_url": sr.get_app_url()}
+        extra_content = assistant_extra_content(state, prev_output)
+        if extra_content:
+            assistant_entry["extra_content"] = extra_content
 
         # append previous input to the history
         ret["messages"] = state.get("messages", []) + [user_entry, assistant_entry]
@@ -89,17 +94,34 @@ def chat_widget_input_to_request_body(
     return ret, message_thread
 
 
-def _extra_content_from_state(state: dict, raw_output_text: str) -> dict[str, Any]:
+def user_extra_content(
+    state: dict,
+    raw_input_text: str,
+    input_audio: str | None,
+    input_documents: list[str] | None,
+) -> dict[str, Any]:
     ret = {}
-    output_text = state.get("output_text")
+    input_prompt = state.get("input_prompt")
+    if input_prompt is not None and input_prompt != raw_input_text:
+        ret["display_content"] = input_prompt
+    if input_audio:
+        ret["audio"] = input_audio
+    if input_documents:
+        ret["documents"] = input_documents
+    return ret
+
+
+def assistant_extra_content(state: dict, raw_output_text: str) -> dict[str, Any]:
+    ret = {}
+    output_text = (state.get("output_text") or [""])[0]
     if output_text and output_text != raw_output_text:
-        ret["display_content"] = output_text[0] or ""
+        ret["display_content"] = output_text
     output_video = state.get("output_video")
     if output_video:
-        ret["output_video"] = output_video
+        ret["video"] = output_video
     output_audio = state.get("output_audio")
     if output_audio:
-        ret["output_audio"] = output_audio
+        ret["audio"] = output_audio
     return ret
 
 
@@ -118,46 +140,10 @@ def get_chat_widget_messages(state: dict, web_url: str | None = None) -> list[An
     else:
         entries = state.get("messages", []).copy()
 
-    for entry in entries:
-        role = entry.get("role")
-        if role == CHATML_ROLE_USER:
-            messages.append(
-                dict(
-                    role=role,
-                    input_prompt=get_entry_text(entry),
-                    input_images=get_entry_images(entry) or [],
-                )
-            )
-        elif role == CHATML_ROLE_ASSISTANT:
-            extra_content = entry.get("extra_content") or {}
-            display_content = extra_content.get("display_content") or get_entry_text(
-                entry
-            )
-            buttons, text = parse_bot_html(display_content)[:2]
-            run_url = entry.get("run_url") or extra_content.get("run_url")
-            output_video = extra_content.get("output_video") or []
-            output_audio = extra_content.get("output_audio") or []
-            messages.append(
-                dict(
-                    role=role,
-                    type="final_response",
-                    status="completed",
-                    output_text=[text],
-                    text=text,
-                    display_content=display_content,
-                    output_video=output_video,
-                    output_audio=output_audio,
-                    buttons=buttons,
-                    web_url=run_url,
-                )
-            )
+    messages.extend(history_entries_to_widget_messages(entries))
 
     # add last input to history if present
-    show_raw_msgs = False
-    if show_raw_msgs:
-        input_prompt = state.get("raw_input_text") or ""
-    else:
-        input_prompt = state.get("input_prompt") or ""
+    input_prompt = state.get("input_prompt") or ""
 
     if input_prompt or input_images or input_audio or input_documents:
         messages.append(
@@ -226,3 +212,47 @@ def get_chat_widget_messages(state: dict, web_url: str | None = None) -> list[An
             )
         )
     return messages
+
+
+def history_entries_to_widget_messages(entries: list[Any]) -> Iterator[Any]:
+    from daras_ai_v2.bots import parse_bot_html
+
+    for entry in entries:
+        role = entry.get("role")
+
+        run_url = entry.get("run_url")
+        extra_content = entry.get("extra_content") or {}
+        text = extra_content.get("display_content", get_entry_text(entry)) or ""
+        audio = extra_content.get("audio")
+        video = extra_content.get("video")
+        documents = extra_content.get("documents")
+
+        if role == CHATML_ROLE_USER:
+            msg = dict(
+                role=role,
+                input_prompt=text,
+                input_images=get_entry_images(entry) or [],
+            )
+            if audio:
+                msg["input_audio"] = audio
+            if documents:
+                msg["input_documents"] = documents
+            yield msg
+
+        elif role == CHATML_ROLE_ASSISTANT:
+            text = parse_bot_html(text)[1]
+            # buttons, text = parse_bot_html(text)[:2]
+            msg = dict(
+                role=role,
+                type="final_response",
+                status="completed",
+                output_text=[text],
+                buttons=[],
+            )
+            if run_url:
+                msg["web_url"] = run_url
+            if audio:
+                msg["output_audio"] = audio
+            if video:
+                msg["output_video"] = video
+            yield msg

--- a/daras_ai_v2/web_widget_embed.py
+++ b/daras_ai_v2/web_widget_embed.py
@@ -1,9 +1,8 @@
 from typing import Any
 
+import gooey_gui as gui
 from bots.models import SavedRun
 from bots.models.message_thread import MessageThread
-import gooey_gui as gui
-
 from daras_ai_v2 import settings
 from daras_ai_v2.csv_lines import csv_decode_row
 from daras_ai_v2.language_model import (
@@ -13,6 +12,7 @@ from daras_ai_v2.language_model import (
     get_entry_images,
     get_entry_text,
 )
+from daras_ai_v2.language_model_body import LLMMessageExtraContent
 from daras_ai_v2.language_model_openai_audio import is_realtime_audio_url
 
 
@@ -61,20 +61,24 @@ def chat_widget_input_to_request_body(
     )
     prev_output = (state.get("raw_output_text") or [""])[0]
     if prev_chat_input and prev_output:
+        user_entry = format_chat_entry(
+            role=CHATML_ROLE_USER,
+            content_text=prev_input,
+            input_images=prev_input_images,
+            # input_audio=prev_input_audio,
+            input_documents=prev_input_documents,
+        )
+
+        assistant_entry = format_chat_entry(
+            role=CHATML_ROLE_ASSISTANT,
+            content_text=prev_output,
+        ) | {
+            "run_url": sr.get_app_url(),
+            "extra_content": _extra_content_from_state(state, prev_output),
+        }
+
         # append previous input to the history
-        ret["messages"] = state.get("messages", []) + [
-            format_chat_entry(
-                role=CHATML_ROLE_USER,
-                content_text=prev_input,
-                input_images=prev_input_images,
-                # input_audio=prev_input_audio,
-                input_documents=prev_input_documents,
-            ),
-            format_chat_entry(
-                role=CHATML_ROLE_ASSISTANT,
-                content_text=prev_output,
-            ),
-        ]
+        ret["messages"] = state.get("messages", []) + [user_entry, assistant_entry]
 
     any_prev_input = prev_chat_input or state.get("input_prompt")
     if any_prev_input and sr.message_thread and sr.message_thread.last_run_id == sr.id:
@@ -85,9 +89,23 @@ def chat_widget_input_to_request_body(
     return ret, message_thread
 
 
+def _extra_content_from_state(state: dict, raw_output_text: str) -> dict[str, Any]:
+    ret = {}
+    output_text = state.get("output_text")
+    if output_text and output_text != raw_output_text:
+        ret["display_content"] = output_text[0] or ""
+    output_video = state.get("output_video")
+    if output_video:
+        ret["output_video"] = output_video
+    output_audio = state.get("output_audio")
+    if output_audio:
+        ret["output_audio"] = output_audio
+    return ret
+
+
 def get_chat_widget_messages(state: dict, web_url: str | None = None) -> list[Any]:
-    from daras_ai_v2.bots import parse_bot_html
     from daras_ai_v2.base import BasePage, RecipeRunState, StateKeys
+    from daras_ai_v2.bots import parse_bot_html
 
     messages = []  # chat widget internal mishmash format
     input_audio = state.get("input_audio") or ""
@@ -111,12 +129,26 @@ def get_chat_widget_messages(state: dict, web_url: str | None = None) -> list[An
                 )
             )
         elif role == CHATML_ROLE_ASSISTANT:
+            extra_content = entry.get("extra_content") or {}
+            display_content = extra_content.get("display_content") or get_entry_text(
+                entry
+            )
+            buttons, text = parse_bot_html(display_content)[:2]
+            run_url = entry.get("run_url") or extra_content.get("run_url")
+            output_video = extra_content.get("output_video") or []
+            output_audio = extra_content.get("output_audio") or []
             messages.append(
                 dict(
                     role=role,
                     type="final_response",
                     status="completed",
-                    output_text=[parse_bot_html(get_entry_text(entry))[1]],
+                    output_text=[text],
+                    text=text,
+                    display_content=display_content,
+                    output_video=output_video,
+                    output_audio=output_audio,
+                    buttons=buttons,
+                    web_url=run_url,
                 )
             )
 

--- a/recipes/VideoBots.py
+++ b/recipes/VideoBots.py
@@ -1313,7 +1313,9 @@ Translation Glossary for LLM Language (English) -> User Langauge
             gui.session_state["final_search_query"] = ""
             gui.rerun()
 
-        messages = get_chat_widget_messages(gui.session_state)
+        messages = get_chat_widget_messages(
+            gui.session_state, web_url=self.current_app_url()
+        )
 
         # fill branding with bot integration data if available
         bot_integration = (
@@ -1343,6 +1345,7 @@ Translation Glossary for LLM Language (English) -> User Langauge
             enablePhotoUpload=True,
             enableConversations=True,
             showToolCalls=True,
+            showRunLink=True,
             branding=bot_branding,
             fillParent=True,
             enableSourcePreview=False,

--- a/tests/test_llm_body.py
+++ b/tests/test_llm_body.py
@@ -65,8 +65,8 @@ def test_to_llm_body_strips_message_extra_content():
                 "run_url": "https://gooey.ai/run/123",
                 "extra_content": {
                     "display_content": "hola",
-                    "output_video": ["https://gooey.ai/video.mp4"],
-                    "output_audio": ["https://gooey.ai/audio.mp3"],
+                    "video": ["https://gooey.ai/video.mp4"],
+                    "audio": ["https://gooey.ai/audio.mp3"],
                 },
             }
         ]

--- a/tests/test_llm_body.py
+++ b/tests/test_llm_body.py
@@ -56,6 +56,24 @@ def test_to_llm_body_strips_internal_keys():
     ]
 
 
+def test_to_llm_body_strips_message_extra_content():
+    body = to_llm_body(
+        [
+            {
+                "role": "assistant",
+                "content": "hi there",
+                "run_url": "https://gooey.ai/run/123",
+                "extra_content": {
+                    "display_content": "hola",
+                    "output_video": ["https://gooey.ai/video.mp4"],
+                    "output_audio": ["https://gooey.ai/audio.mp3"],
+                },
+            }
+        ]
+    )
+    assert body == [{"role": "assistant", "content": "hi there"}]
+
+
 def test_to_llm_body_defaults():
     assert to_llm_body([{"content": "hi"}]) == [{"role": "user", "content": "hi"}]
     # assistant msg with tool_calls and no content: content key must be dropped

--- a/tests/test_message_thread.py
+++ b/tests/test_message_thread.py
@@ -8,7 +8,10 @@ from bots.models import (
     get_default_published_run_workspace,
 )
 from bots.models.message_thread import MessageThread
-from daras_ai_v2.web_widget_embed import chat_widget_input_to_request_body
+from daras_ai_v2.web_widget_embed import (
+    chat_widget_input_to_request_body,
+    get_chat_widget_messages,
+)
 from recipes.VideoBots import VideoBotsPage
 from routers.api import create_new_run
 from workspaces.models import Workspace
@@ -94,6 +97,89 @@ def test_chat_widget_continues_thread_with_prior_media(db_fixtures):
     )
 
     assert message_thread == thread
+
+
+def test_chat_widget_moves_run_metadata_into_history(db_fixtures):
+    sr, _ = _make_sr_with_thread(uid="user-a", title="prior")
+    request_body, _ = chat_widget_input_to_request_body(
+        sr,
+        {
+            "input_prompt": "hello",
+            "raw_input_text": "hello",
+            "raw_output_text": ["raw reply"],
+            "output_text": ["display reply"],
+            "output_video": ["https://example.com/video.mp4"],
+            "output_audio": ["https://example.com/audio.mp3"],
+        },
+        {"input_prompt": "follow up"},
+    )
+
+    assistant_msg = request_body["messages"][1]
+    assert assistant_msg["role"] == "assistant"
+    assert assistant_msg["content"] == "raw reply"
+    assert assistant_msg["run_url"] == sr.get_app_url()
+    assert assistant_msg["extra_content"] == {
+        "display_content": "display reply",
+        "output_video": ["https://example.com/video.mp4"],
+        "output_audio": ["https://example.com/audio.mp3"],
+    }
+
+
+def test_get_chat_widget_messages_exports_historical_run_metadata():
+    messages = get_chat_widget_messages(
+        {
+            "messages": [
+                {"role": "user", "content": "hello"},
+                {
+                    "role": "assistant",
+                    "content": "raw reply",
+                    "run_url": "https://example.com/run-123",
+                    "extra_content": {
+                        "display_content": "display reply",
+                        "output_video": ["https://example.com/video.mp4"],
+                        "output_audio": ["https://example.com/audio.mp3"],
+                    },
+                },
+            ]
+        }
+    )
+
+    assistant_msg = messages[1]
+    assert assistant_msg["role"] == "assistant"
+    assert assistant_msg["output_text"] == ["display reply"]
+    assert assistant_msg["text"] == "display reply"
+    assert assistant_msg["display_content"] == "display reply"
+    assert assistant_msg["run_url"] == "https://example.com/run-123"
+    assert assistant_msg["web_url"] == "https://example.com/run-123"
+    assert assistant_msg["output_video"] == ["https://example.com/video.mp4"]
+    assert assistant_msg["output_audio"] == ["https://example.com/audio.mp3"]
+
+
+def test_video_bots_messages_model_preserves_widget_metadata():
+    request = VideoBotsPage.RequestModel.model_validate(
+        {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": "raw reply",
+                    "run_url": "https://example.com/run-123",
+                    "extra_content": {
+                        "display_content": "display reply",
+                        "output_video": ["https://example.com/video.mp4"],
+                        "output_audio": ["https://example.com/audio.mp3"],
+                    },
+                }
+            ]
+        }
+    )
+
+    assert isinstance(request.messages[0], dict)
+    assert request.messages[0]["run_url"] == "https://example.com/run-123"
+    assert request.messages[0]["extra_content"] == {
+        "display_content": "display reply",
+        "output_video": ["https://example.com/video.mp4"],
+        "output_audio": ["https://example.com/audio.mp3"],
+    }
 
 
 def test_create_new_run_creates_thread_and_sets_first_last(

--- a/tests/test_message_thread.py
+++ b/tests/test_message_thread.py
@@ -120,8 +120,8 @@ def test_chat_widget_moves_run_metadata_into_history(db_fixtures):
     assert assistant_msg["run_url"] == sr.get_app_url()
     assert assistant_msg["extra_content"] == {
         "display_content": "display reply",
-        "output_video": ["https://example.com/video.mp4"],
-        "output_audio": ["https://example.com/audio.mp3"],
+        "video": ["https://example.com/video.mp4"],
+        "audio": ["https://example.com/audio.mp3"],
     }
 
 
@@ -136,8 +136,8 @@ def test_get_chat_widget_messages_exports_historical_run_metadata():
                     "run_url": "https://example.com/run-123",
                     "extra_content": {
                         "display_content": "display reply",
-                        "output_video": ["https://example.com/video.mp4"],
-                        "output_audio": ["https://example.com/audio.mp3"],
+                        "video": ["https://example.com/video.mp4"],
+                        "audio": ["https://example.com/audio.mp3"],
                     },
                 },
             ]
@@ -147,9 +147,6 @@ def test_get_chat_widget_messages_exports_historical_run_metadata():
     assistant_msg = messages[1]
     assert assistant_msg["role"] == "assistant"
     assert assistant_msg["output_text"] == ["display reply"]
-    assert assistant_msg["text"] == "display reply"
-    assert assistant_msg["display_content"] == "display reply"
-    assert assistant_msg["run_url"] == "https://example.com/run-123"
     assert assistant_msg["web_url"] == "https://example.com/run-123"
     assert assistant_msg["output_video"] == ["https://example.com/video.mp4"]
     assert assistant_msg["output_audio"] == ["https://example.com/audio.mp3"]
@@ -165,8 +162,8 @@ def test_video_bots_messages_model_preserves_widget_metadata():
                     "run_url": "https://example.com/run-123",
                     "extra_content": {
                         "display_content": "display reply",
-                        "output_video": ["https://example.com/video.mp4"],
-                        "output_audio": ["https://example.com/audio.mp3"],
+                        "video": ["https://example.com/video.mp4"],
+                        "audio": ["https://example.com/audio.mp3"],
                     },
                 }
             ]
@@ -177,8 +174,8 @@ def test_video_bots_messages_model_preserves_widget_metadata():
     assert request.messages[0]["run_url"] == "https://example.com/run-123"
     assert request.messages[0]["extra_content"] == {
         "display_content": "display reply",
-        "output_video": ["https://example.com/video.mp4"],
-        "output_audio": ["https://example.com/audio.mp3"],
+        "video": ["https://example.com/video.mp4"],
+        "audio": ["https://example.com/audio.mp3"],
     }
 
 


### PR DESCRIPTION
Store run_url and extra_content (display_content, output_video, output_audio) on assistant entries appended to the chat widget history, export them from get_chat_widget_messages so historic turns render with their originating run's media and run link, and strip both fields in to_llm_body so they never reach the LLM API.

### Q/A checklist

- [ ] I have tested my UI changes on mobile and they look acceptable
- [ ] I have tested changes to the workflows in both the API and the UI
- [ ] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [ ] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
