### PR TITLE
refactor: use shared LLM loop in Video Bots

### DIFF
--- a/recipes/VideoBots.py
+++ b/recipes/VideoBots.py
@@ -1,10 +1,7 @@
 import json
 import math
-import traceback
 import typing
-from itertools import zip_longest
 
-import sentry_sdk
 import typing_extensions
 from pydantic import BaseModel, Field
 
@@ -21,7 +18,7 @@ from bots.models import (
 )
 from bots.models.message_thread import MessageThread
 from daras_ai.image_input import truncate_text_words
-from daras_ai_v2 import exceptions, settings
+from daras_ai_v2 import settings
 from daras_ai_v2.asr import (
     AsrModels,
     TranslationModels,
@@ -55,6 +52,7 @@ from daras_ai_v2.fastapi_tricks import get_api_route_url, get_app_route_url
 from daras_ai_v2.field_render import field_desc, field_title, field_title_desc
 from daras_ai_v2.functional import flatapply_parallel
 from daras_ai_v2.glossary import validate_glossary_document
+from daras_ai_v2.harness import llm_loop
 from daras_ai_v2.integrations_tab import render_integrations_tab
 from daras_ai_v2.language_filters import (
     asr_languages_without_dialects,
@@ -62,15 +60,12 @@ from daras_ai_v2.language_filters import (
     tts_languages_without_dialects,
 )
 from daras_ai_v2.language_model import (
-    CHATML_ROLE_ASSISTANT,
     CHATML_ROLE_SYSTEM,
     CHATML_ROLE_USER,
-    SUPERSCRIPT,
     ConversationEntry,
     calc_appx_tokens,
     format_chat_entry,
     get_entry_text,
-    run_language_model,
 )
 from daras_ai_v2.language_model_openai_audio import is_realtime_audio_url
 from daras_ai_v2.language_model_settings_widgets import (
@@ -83,12 +78,7 @@ from daras_ai_v2.lipsync_settings_widgets import lipsync_settings
 from daras_ai_v2.loom_video_widget import youtube_video
 from daras_ai_v2.pydantic_validation import HttpUrlStr, OptionalHttpUrlStr
 from daras_ai_v2.query_generator import generate_final_search_query
-from daras_ai_v2.search_ref import (
-    CitationStyles,
-    apply_response_formattings_prefix,
-    apply_response_formattings_suffix,
-    parse_refs,
-)
+from daras_ai_v2.search_ref import CitationStyles
 from daras_ai_v2.text_output_widget import text_output
 from daras_ai_v2.text_to_speech_settings_widgets import (
     TextToSpeechProviders,
@@ -107,13 +97,8 @@ from daras_ai_v2.web_widget_embed import (
     get_chat_widget_messages,
     load_chat_widget_lib,
 )
-from functions.base_llm_tool import (
-    BaseLLMTool,
-    get_tool_from_call,
-)
 from functions.inbuilt_tools import GooeyToolkit, UpdateConversationTitleLLMTool
 from functions.models import FunctionTrigger
-from functions.workflow_tools import DynamicLLMToolLoader
 from recipes.DocExtract import document_intelligence_settings
 from recipes.DocSearch import get_top_k_references, references_as_prompt
 from recipes.GoogleGPT import SearchReference
@@ -414,12 +399,14 @@ Translation Glossary for LLM Language (English) -> User Langauge
             ),
         )
 
-        yield from self.llm_loop(
+        yield from llm_loop(
             request=request,
             response=response,
             model=llm_model,
             asr_msg=asr_msg,
             tools_by_name=tools_by_name,
+            current_sr=self.current_sr,
+            active_tool_names=self.active_tool_names,
         )
 
         yield from self.tts_step(model=llm_model, request=request, response=response)
@@ -664,193 +651,6 @@ Translation Glossary for LLM Language (English) -> User Langauge
     def __init__(self, *args, **kwargs):
         self.active_tool_names = set()
         super().__init__(*args, **kwargs)
-
-    def llm_loop(
-        self,
-        *,
-        request: "VideoBotsPage.RequestModel",
-        response: "VideoBotsPage.ResponseModel",
-        model: AIModelSpec,
-        asr_msg: str | None = None,
-        prev_output_text: list[str] | None = None,
-        tools_by_name: dict[str, BaseLLMTool],
-    ) -> typing.Iterator[str | None]:
-        from functions.gooey_builder_tools import get_current_builder_tools
-
-        yield f"Summarizing with {model.label}..."
-
-        audio_session_extra = None
-        if model.llm_is_audio_model:
-            audio_session_extra = {}
-            if request.openai_voice_name:
-                audio_session_extra["voice"] = request.openai_voice_name
-
-        tools_by_name |= get_current_builder_tools(self.current_sr)
-
-        loader = DynamicLLMToolLoader(tools_by_name, self.active_tool_names)
-        tools_by_name[loader.name] = loader
-        active_tools = [
-            tool for tool in tools_by_name.values() if loader.is_tool_active(tool)
-        ]
-        response.final_prompt[0]["tools"] = [
-            tool.spec_function for tool in active_tools
-        ]
-
-        chunks: typing.Generator[list[dict], None, None] = run_language_model(
-            model=model.name,
-            messages=response.final_prompt,
-            max_tokens=request.max_tokens,
-            num_outputs=request.num_outputs,
-            temperature=request.sampling_temperature,
-            avoid_repetition=request.avoid_repetition,
-            response_format_type=request.response_format_type,
-            reasoning_effort=request.reasoning_effort,
-            tools=active_tools,
-            stream=True,
-            audio_url=request.input_audio,
-            audio_session_extra=audio_session_extra,
-        )
-
-        tool_calls = None
-        output_text = None
-        response.final_prompt.append({"role": CHATML_ROLE_ASSISTANT, "content": ""})
-
-        for i, choices in enumerate(chunks):
-            if not choices:
-                continue
-
-            metrics = choices[0].get("metrics")
-            if metrics:
-                response.metrics = metrics
-
-            output_text = [
-                "\n\n".join(filter(None, (prev_text, entry.get("content"))))
-                for prev_text, entry in zip_longest(
-                    (prev_output_text or []), choices, fillvalue=""
-                )
-            ]
-            response.final_prompt[-1]["content"] = choices[0]["content"] or ""
-
-            tool_calls = choices[0].get("tool_calls")
-            if tool_calls:
-                for call in tool_calls:
-                    tool = tools_by_name[call["function"]["name"]]
-                    call["label"] = tool.label
-                    call["icon"] = tool.get_icon()
-                response.final_prompt[-1]["tool_calls"] = tool_calls
-
-            try:
-                response.raw_input_text = choices[0]["input_audio_transcript"]
-            except KeyError:
-                pass
-            try:
-                response.output_audio += [choices[0]["audio_url"]]
-            except KeyError:
-                pass
-
-            # save raw model response without citations and translation for history
-            response.raw_output_text = [
-                "".join(snippet for snippet, _ in parse_refs(text, response.references))
-                for text in output_text
-            ]
-
-            output_text = yield from self.output_translation_step(
-                request, response, output_text
-            )
-
-            if response.references:
-                citation_style = (
-                    request.citation_style and CitationStyles[request.citation_style]
-                ) or None
-                all_refs_list = apply_response_formattings_prefix(
-                    output_text, response.references, citation_style
-                )
-            else:
-                citation_style = None
-                all_refs_list = None
-
-            if asr_msg:
-                output_text = [asr_msg + "\n\n" + text for text in output_text]
-
-            response.output_text = output_text
-
-            finish_reason = [entry.get("finish_reason") for entry in choices]
-            if all(finish_reason):
-                if all_refs_list:
-                    apply_response_formattings_suffix(
-                        all_refs_list, response.output_text, citation_style
-                    )
-                response.finish_reason = finish_reason
-            else:
-                yield f"Streaming{str(i + 1).translate(SUPERSCRIPT)} {model.label}..."
-
-        if response.output_text:
-            response.output_text = [text.strip() for text in response.output_text]
-
-        if not tool_calls:
-            return
-        for call in tool_calls:
-            tool, arguments = get_tool_from_call(call["function"], tools_by_name)
-            if not arguments:
-                continue
-            yield f"🛠 {tool.label}..."
-            try:
-                output = tool.call_json(arguments)
-            except Exception as e:
-                output = json.dumps(dict(error=str(e)))
-                error_type = getattr(e, "error_type", type(e).__name__)
-                if error_type and exceptions.get_error_renderer(error_type):
-                    # bubble up error so the parent run's standard error pipeline renders it
-                    raise
-                else:
-                    traceback.print_exc()
-                    sentry_sdk.capture_exception(e)
-            finally:
-                response.final_prompt.append(
-                    dict(
-                        role="tool",
-                        content=output,
-                        tool_call_id=call["id"],
-                        run_url=tool.get_url(),
-                    ),
-                )
-
-        yield from self.llm_loop(
-            request=request,
-            response=response,
-            model=model,
-            prev_output_text=output_text,
-            tools_by_name=tools_by_name,
-        )
-
-    def output_translation_step(self, request, response, output_text):
-        from daras_ai_v2.bots import parse_bot_html
-
-        # translate response text
-        if should_translate_lang(request.user_language):
-            yield f"Translating response to {request.user_language}..."
-            output_text = run_translate(
-                texts=output_text,
-                source_language="en",
-                target_language=request.user_language,
-                glossary_url=request.output_glossary_document,
-                model=request.translation_model,
-            )
-            # save translated response for tts
-            tts_source = [
-                "".join(snippet for snippet, _ in parse_refs(text, response.references))
-                for text in output_text
-            ]
-            response.raw_tts_text = tts_source
-        else:
-            tts_source = output_text
-
-        # remove html tags from the output text for tts
-        raw_tts_text = [parse_bot_html(text)[1].strip() for text in tts_source]
-        if raw_tts_text != output_text:
-            response.raw_tts_text = raw_tts_text
-
-        return output_text
 
     def tts_step(self, model, request, response):
         if request.tts_provider and not model.llm_is_audio_model:


### PR DESCRIPTION
- Video Bots retained a duplicate of the extracted LLM loop and response translation flow, leaving two implementations to keep synchronized.

- Call the shared harness with the current saved run and active tool state, preserving builder tools and recursive tool behavior while removing the duplicate methods and imports.

### Q/A checklist

- [ ] I have tested my UI changes on mobile and they look acceptable
- [ ] I have tested changes to the workflows in both the API and the UI
- [ ] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [ ] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
