### PR TITLE
Exclude Outlook from verified email credits

### DIFF
--- a/daras_ai_v2/settings.py
+++ b/daras_ai_v2/settings.py
@@ -400,7 +400,6 @@ VERIFIED_EMAIL_USER_FREE_CREDITS = config(
 VERIFIED_EMAIL_DOMAINS = {
     "gmail.com",
     "googlemail.com",
-    "outlook.com",
     "hotmail.com",
     "live.com",
     "icloud.com",


### PR DESCRIPTION
Summary - remove `outlook.com` from `VERIFIED_EMAIL_DOMAINS`- leave anonymous initialization and all credit defaults unchanged\n- preserve verified-email credit behavior for every other allowlisted domain