### PR TITLE
Gate document intelligence providers by configuration

### DIFF
--- a/recipes/DocExtract.py
+++ b/recipes/DocExtract.py
@@ -607,7 +607,19 @@ def document_intelligence_settings(title: str, help: str | None = None):
     document_models = {}
     if settings.AZURE_FORM_RECOGNIZER_KEY:
         document_models |= azure_document_intelligence_models()
-    document_models |= {"mistral-ocr": "Mistral OCR"}
+    if settings.MISTRAL_API_KEY:
+        document_models |= {"mistral-ocr": "Mistral OCR"}
+    if not document_models:
+        gui.session_state["document_model"] = None
+        gui.error(
+            "OCR is unavailable, so documents will use standard text extraction. "
+            "To extract text from scanned PDFs or images, configure "
+            "`AZURE_FORM_RECOGNIZER_KEY` or `MISTRAL_API_KEY` by adding your "
+            "[own API key](https://github.com/GooeyAI/gooey-server/blob/master/configuration.md).",
+            icon="⚠️",
+            color="#ffe8b2",
+        )
+        return
     gui.selectbox(
         title,
         key="document_model",


### PR DESCRIPTION
## Summary

- expose Azure Form Recognizer models only when `AZURE_FORM_RECOGNIZER_KEY` is configured
- expose Mistral OCR only when `MISTRAL_API_KEY` is configured
- show a linked configuration error and clear stale GUI model state when neither provider is available

## Why

Local deployments currently expose Mistral OCR without credentials and can retain the default Azure model even when no document-intelligence provider is configured. Users can then submit a model that is guaranteed to fail at runtime.

This keeps the existing request/API default intact for production compatibility while making GUI provider availability reflect the configured credentials.

## Validation

- `ruff check recipes/DocExtract.py`
- `git diff --check`
