### PR TITLE
docs: document OCR provider abstraction in platform independence

### DIFF
--- a/PLATFORM_INDEPENDENCE.md
+++ b/PLATFORM_INDEPENDENCE.md
@@ -20,6 +20,7 @@ Gooey Server itself is licensed under [Apache License 2.0](LICENSE).
 | Google Cloud Storage | File storage | Local filesystem storage | Feature flag (`GS_BUCKET_NAME`, default **unset**) | ✅ Abstracted |
 | Cloud LLM APIs (OpenAI, Anthropic, Google, etc.) | AI models | Any OpenAI-compatible server (Ollama, vLLM, LocalAI, llama.cpp) | Abstraction layer (`AIModelSpec.base_url`) | ✅ Abstracted |
 | Cloud STT / TTS / embeddings | AI models | Self-hosted Whisper, Seamless, MMS, Bark, E5/GTE on GPU worker | Abstraction layer (provider enums + GPU Celery worker) | ✅ Abstracted |
+| Azure Document Intelligence / Mistral OCR | Document OCR | Standard text extraction (no OCR) | Feature flag + graceful degradation (default **unset**) | ✅ Abstracted |
 | Stripe / PayPal | Payments | Not required — billing gracefully disabled when keys unset (default) | Feature flag with graceful UI fallback | ✅ Abstracted |
 | Azure Content Moderator | Image safety checker | Not required — check skipped when endpoint unset (default) | Feature flag (`AZURE_IMAGE_MODERATION_ENDPOINT`, default **unset**) | ✅ Optional |
 | Azure Key Vault | Managed secrets | Not required — pass API keys as plain environment variables to functions instead | Optional (`AZURE_KEY_VAULT_ENDPOINT` unset ⇒ disabled) | ✅ Optional |
@@ -75,6 +76,15 @@ Self-hosted **Whisper**, **Seamless M4T**, and **MMS** run on the GPU worker ([d
 
 ### Text-to-speech
 Self-hosted **Bark** runs on the GPU worker; cloud TTS providers are optional alternatives behind the `TextToSpeechProviders` enum ([daras_ai_v2/text_to_speech_settings_widgets.py](daras_ai_v2/text_to_speech_settings_widgets.py)).
+
+### Document Intelligence / OCR
+Document extraction workflows support multiple OCR providers through a unified abstraction ([recipes/DocExtract.py#L606-L631](recipes/DocExtract.py#L606)):
+
+- **Azure Document Intelligence** (proprietary) — enabled when `AZURE_FORM_RECOGNIZER_KEY` is set ([daras_ai_v2/azure_doc_extract.py](daras_ai_v2/azure_doc_extract.py))
+- **Mistral OCR** (cloud API, self-hostable models) — enabled when `MISTRAL_API_KEY` is set ([daras_ai_v2/mistral_ocr.py](daras_ai_v2/mistral_ocr.py))
+- **Fallback to standard text extraction** — when no OCR provider is configured (the default), documents use standard text extraction methods without OCR capabilities
+
+The UI gracefully degrades when OCR providers are unavailable, displaying a warning and falling back to basic text extraction. Both providers are optional; neither is required for core document processing functionality.
 
 ### Modal-hosted models
 Two models (MMS TTS, Omnilingual ASR) are deployed on [Modal](https://modal.com). These are **optional features**: TTS and ASR each have multiple self-hosted and provider alternatives, and the platform functions fully without Modal credentials.


### PR DESCRIPTION
## Summary
- Added documentation for Document Intelligence / OCR providers in PLATFORM_INDEPENDENCE.md
- Documents how Azure Document Intelligence and Mistral OCR are both optional and gated behind API keys
- Shows graceful fallback to standard text extraction when no OCR provider is configured

## Changes
- Updated summary table to include OCR providers as an abstracted dependency
- Added new "Document Intelligence / OCR" subsection under section 4 (AI models & abstraction layers)
- Referenced recent DocExtract.py changes that gate providers behind `AZURE_FORM_RECOGNIZER_KEY` and `MISTRAL_API_KEY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)