### PR TITLE
fix: prevent thinking traces in bot deployments

### DIFF
--- a/daras_ai_v2/asr.py
+++ b/daras_ai_v2/asr.py
@@ -1403,7 +1403,7 @@ def run_asr(
                 initial=2,
                 maximum=30,
                 timeout=60,
-            )
+            ),
         )  # BatchRecognizeFileResult
         # Handle the response
         return "\n\n".join(

--- a/daras_ai_v2/bots.py
+++ b/daras_ai_v2/bots.py
@@ -1,5 +1,6 @@
 import mimetypes
 import random
+import re
 import traceback
 import typing
 from datetime import datetime
@@ -63,6 +64,14 @@ DEFAULT_RESPONSE = (
 INVALID_INPUT_FORMAT = (
     "⚠️ Sorry! I don't understand {} messsages. Please try with text or audio."
 )
+
+THINKING_HIDDEN_PLATFORMS = {
+    Platform.WHATSAPP,
+    Platform.SLACK,
+    Platform.TELEGRAM,
+    Platform.TWILIO,
+}
+THINK_TAG_RE = re.compile(r"(<think\b[^>]*>|</think\s*>)", re.IGNORECASE)
 
 
 ERROR_MSG = """
@@ -545,6 +554,7 @@ def _process_and_send_msg(
     sent_msg_id = None  # this is the message id to record in the db
     last_idx = 0  # this is the last index of the text sent to the user
     prev_final_prompt = []  # this is the last final_prompt sent to the user
+    thinking_filter = ThinkingFilter(enabled=bot.platform in THINKING_HIDDEN_PLATFORMS)
     if bot.streaming_enabled:
         # subscribe to the realtime channel for updates
         channel = bot.page_cls.realtime_channel_name(sr.run_id, sr.uid)
@@ -570,6 +580,7 @@ def _process_and_send_msg(
                 prev_final_prompt = final_prompt
 
                 text = state.get("output_text") and state.get("output_text")[0]
+                text = thinking_filter.filter(text)
                 if not text:
                     # if no text, send the run status as text
                     update_msg_id = bot.send_run_status(
@@ -615,6 +626,7 @@ def _process_and_send_msg(
         return
 
     text = state.get("output_text") and state.get("output_text")[0]
+    text = thinking_filter.filter(text)
     audio = state.get("output_audio")
     video = state.get("output_video")
     documents = state.get("output_documents")
@@ -654,6 +666,35 @@ def _process_and_send_msg(
         # bot output for human
         bot_msg_display_content=state.get("output_text") and state["output_text"][0],
     )
+
+
+def remove_thinking(text: str | None) -> str | None:
+    return ThinkingFilter(enabled=True).filter(text)
+
+
+class ThinkingFilter:
+    def __init__(self, *, enabled: bool):
+        self.enabled = enabled
+        self.source_text = ""
+        self.visible_text = ""
+        self.inside_thinking = False
+
+    def filter(self, text: str | None) -> str | None:
+        if not self.enabled or text is None:
+            return text
+
+        if not text.startswith(self.source_text):
+            self.source_text = ""
+            self.visible_text = ""
+            self.inside_thinking = False
+
+        for i, chunk in enumerate(THINK_TAG_RE.split(text[len(self.source_text) :])):
+            if i % 2:
+                self.inside_thinking = not chunk.startswith("</")
+            elif not self.inside_thinking:
+                self.visible_text += chunk
+        self.source_text = text
+        return self.visible_text if self.visible_text.strip() else ""
 
 
 def compute_prompt_delta(

--- a/daras_ai_v2/bots.py
+++ b/daras_ai_v2/bots.py
@@ -1,6 +1,5 @@
 import mimetypes
 import random
-import re
 import traceback
 import typing
 from datetime import datetime
@@ -71,7 +70,6 @@ THINKING_HIDDEN_PLATFORMS = {
     Platform.TELEGRAM,
     Platform.TWILIO,
 }
-THINK_TAG_RE = re.compile(r"(<think\b[^>]*>|</think\s*>)", re.IGNORECASE)
 
 
 ERROR_MSG = """
@@ -244,6 +242,8 @@ class BotInterface:
         self,
         *,
         text: str | None = None,
+        buttons: list[ReplyButton] | None = None,
+        parsed: bool = False,
         audio: list[str] | None = None,
         video: list[str] | None = None,
         send_feedback_buttons: bool = False,
@@ -255,6 +255,9 @@ class BotInterface:
         Send a message response to the user using the bot's platform API
 
         :param text: The text to send
+        :param buttons: The buttons to send, already parsed by the caller
+        :param parsed: Whether text & buttons already went through parse_bot_html() -
+            parsing twice re-interprets escaped markup as real markup
         :param audio: The audio URL to send
         :param video: The video URL to send
         :param send_feedback_buttons: Whether to send feedback buttons with the message
@@ -267,9 +270,12 @@ class BotInterface:
         if should_translate:
             text = self.translate_response(text)
 
-        buttons, text, thinking, disable_feedback = parse_bot_html(text)
-        if disable_feedback:
-            send_feedback_buttons = False
+        if parsed:
+            buttons = buttons or []
+        else:
+            buttons, text, thinking, disable_feedback = parse_bot_html(text)
+            if disable_feedback:
+                send_feedback_buttons = False
 
         if buttons and send_feedback_buttons and self.platform != Platform.SLACK:
             update_msg_id = self._send_msg(
@@ -552,9 +558,11 @@ def _process_and_send_msg(
 
     update_msg_id = None  # this is the message id to update during streaming
     sent_msg_id = None  # this is the message id to record in the db
-    last_idx = 0  # this is the last index of the text sent to the user
+    last_idx = 0  # how much of the text the user has already been sent
+    prev_len = 0  # length of the text in the previous update
+    buttons_sent = False  # did the buttons go out with the last chunk
+    hide_thinking = bot.platform in THINKING_HIDDEN_PLATFORMS
     prev_final_prompt = []  # this is the last final_prompt sent to the user
-    thinking_filter = ThinkingFilter(enabled=bot.platform in THINKING_HIDDEN_PLATFORMS)
     if bot.streaming_enabled:
         # subscribe to the realtime channel for updates
         channel = bot.page_cls.realtime_channel_name(sr.run_id, sr.uid)
@@ -579,32 +587,66 @@ def _process_and_send_msg(
                     )
                 prev_final_prompt = final_prompt
 
-                text = state.get("output_text") and state.get("output_text")[0]
-                text = thinking_filter.filter(text)
-                if not text:
+                # strip to match the recipe's end-of-run strip - last_idx must
+                # index the same text the final send slices, or chars get eaten
+                text = ((state.get("output_text") or [None])[0] or "").strip()
+                buttons = None
+                if hide_thinking:
+                    # parse before slicing, so a delta can't start inside <think>
+                    buttons, text, _, disable_feedback = parse_bot_html(text)
+                    if disable_feedback:
+                        send_feedback_buttons = False
+                if not text.strip():
+                    # whitespace is truthy but shows as an empty message
                     # if no text, send the run status as text
                     update_msg_id = bot.send_run_status(
                         update_msg_id=update_msg_id, references=state.get("references")
                     )
                     continue  # no text, wait for the next update
                 streaming_done = state.get("finish_reason")
+                if not streaming_done:
+                    # a half-streamed <button> parses as a complete one with a
+                    # truncated title - only send them once the run is done
+                    buttons = None
                 # send the response to the user
                 if bot.can_update_message:
+                    # the whole text is re-sent each time, so the buttons the final
+                    # send adds always land on a message with a body
                     update_msg_id = bot.send_msg(
                         text=text.strip() + "...",
+                        parsed=hide_thinking,
                         update_msg_id=update_msg_id,
                         send_feedback_buttons=streaming_done and send_feedback_buttons,
                     )
-                    last_idx = len(text)
+                    # NOTE: load-bearing - the platform can downgrade to
+                    # can_update_message=False mid-run, and the delta resumes here
+                    last_idx = prev_len = len(text)
                 else:
-                    next_chunk = text[last_idx:]
-                    last_idx = len(text)
-                    if not next_chunk:
-                        continue  # no chunk, wait for the next update
+                    if streaming_done or not hide_thinking:
+                        # nothing held back once the buttons aren't either
+                        end = len(text)
+                    else:
+                        # hold the newest delta back, so the buttons have a body to
+                        # ride out with when the run finishes
+                        end = prev_len
+                    next_chunk = text[last_idx:end]
+                    if not last_idx:
+                        # starts the answer, so leading blank lines are padding
+                        next_chunk = next_chunk.lstrip()
+                    prev_len = len(text)
+                    if not (next_chunk.strip() or buttons):
+                        # last_idx stays put, so the whitespace goes out with the
+                        # next real text instead of as a message of its own
+                        continue
+                    last_idx = end
                     update_msg_id = bot.send_msg(
-                        text=next_chunk,
+                        text=next_chunk or None,
+                        buttons=buttons,
+                        parsed=hide_thinking,
                         send_feedback_buttons=streaming_done and send_feedback_buttons,
                     )
+                    if buttons is not None:
+                        buttons_sent = True
                 if streaming_done and not bot.can_update_message:
                     # if we send the buttons, this is the ID we need to record in the db for lookups later when the button is pressed
                     sent_msg_id = update_msg_id
@@ -625,22 +667,41 @@ def _process_and_send_msg(
         bot.send_msg(text=ERROR_MSG.format(err_msg))
         return
 
-    text = state.get("output_text") and state.get("output_text")[0]
-    text = thinking_filter.filter(text)
+    # same read as the streaming loop above - [] must come back as "", not as a
+    # list, and the strip has to match or last_idx indexes the wrong text
+    text = ((state.get("output_text") or [None])[0] or "").strip()
+    buttons = None
+    disable_feedback = False
+    if hide_thinking:
+        buttons, text, _, disable_feedback = parse_bot_html(text)
+        if buttons_sent:
+            # already sent with the last chunk
+            buttons = []
+    if disable_feedback:
+        send_feedback_buttons = False
     audio = state.get("output_audio")
     video = state.get("output_video")
     documents = state.get("output_documents")
     # check for empty response
-    if not (text or audio or video or documents or send_feedback_buttons):
+    if not (text or buttons or audio or video or documents or send_feedback_buttons):
         bot.send_msg(text=DEFAULT_RESPONSE)
         return
     # if in-place updates are enabled, update the message, otherwise send the remaining text
     if text and not bot.can_update_message:
         text = text[last_idx:]
+    if hide_thinking:
+        # removing the thinking leaves its blank lines behind as padding
+        text = (text or "").rstrip()
+        if bot.can_update_message or not last_idx:
+            # only when this starts the answer - otherwise it's the remainder, and
+            # its leading space joins it to what was already sent
+            text = text.lstrip()
     # send the response to the user if there is any remaining
-    if text or audio or video or documents or send_feedback_buttons:
+    if text or buttons or audio or video or documents or send_feedback_buttons:
         update_msg_id = bot.send_msg(
             text=text or None,
+            buttons=buttons,
+            parsed=hide_thinking,
             audio=audio or None,
             video=video or None,
             documents=documents or None,
@@ -666,35 +727,6 @@ def _process_and_send_msg(
         # bot output for human
         bot_msg_display_content=state.get("output_text") and state["output_text"][0],
     )
-
-
-def remove_thinking(text: str | None) -> str | None:
-    return ThinkingFilter(enabled=True).filter(text)
-
-
-class ThinkingFilter:
-    def __init__(self, *, enabled: bool):
-        self.enabled = enabled
-        self.source_text = ""
-        self.visible_text = ""
-        self.inside_thinking = False
-
-    def filter(self, text: str | None) -> str | None:
-        if not self.enabled or text is None:
-            return text
-
-        if not text.startswith(self.source_text):
-            self.source_text = ""
-            self.visible_text = ""
-            self.inside_thinking = False
-
-        for i, chunk in enumerate(THINK_TAG_RE.split(text[len(self.source_text) :])):
-            if i % 2:
-                self.inside_thinking = not chunk.startswith("</")
-            elif not self.inside_thinking:
-                self.visible_text += chunk
-        self.source_text = text
-        return self.visible_text if self.visible_text.strip() else ""
 
 
 def compute_prompt_delta(

--- a/routers/slack_api.py
+++ b/routers/slack_api.py
@@ -22,7 +22,7 @@ from daras_ai_v2.bot_integration_connect import (
     connect_bot_to_published_run,
     load_published_run_from_state,
 )
-from daras_ai_v2.bots import msg_handler, remove_thinking
+from daras_ai_v2.bots import msg_handler, parse_bot_html
 from daras_ai_v2.exceptions import raise_for_status
 from daras_ai_v2.fastapi_tricks import (
     fastapi_request_urlencoded_body,
@@ -417,4 +417,4 @@ def slack_get_response_for_msg_id(
     if not output_text:
         return {"status": "no_output"}
 
-    return {"status": "ok", "content": remove_thinking(output_text[0])}
+    return {"status": "ok", "content": parse_bot_html(output_text[0])[1]}

--- a/routers/slack_api.py
+++ b/routers/slack_api.py
@@ -22,7 +22,7 @@ from daras_ai_v2.bot_integration_connect import (
     connect_bot_to_published_run,
     load_published_run_from_state,
 )
-from daras_ai_v2.bots import msg_handler
+from daras_ai_v2.bots import msg_handler, remove_thinking
 from daras_ai_v2.exceptions import raise_for_status
 from daras_ai_v2.fastapi_tricks import (
     fastapi_request_urlencoded_body,
@@ -417,4 +417,4 @@ def slack_get_response_for_msg_id(
     if not output_text:
         return {"status": "no_output"}
 
-    return {"status": "ok", "content": output_text[0]}
+    return {"status": "ok", "content": remove_thinking(output_text[0])}


### PR DESCRIPTION
## Summary

- suppress complete and partial `<think>` blocks before calculating streamed delivery chunks for WhatsApp, Slack, Telegram, and Twilio
- retain state across cumulative updates and safely reparse translated or reformatted replacement output
- sanitize Slack's polling response without modifying `raw_output_text`, `raw_tts_text`, or web widget behavior

## Validation

- `ruff format --check daras_ai_v2/bots.py routers/slack_api.py`
- `ruff check daras_ai_v2/bots.py routers/slack_api.py`
- focused local regression suite: 8 passed
- `pytest tests/test_slack.py -q`: 1 passed, 1 skipped
- `git diff --check`