### PR TITLE
Add SraVaani 1.0 ASR (ARTPARK, IISc) deployed on Modal

### DIFF
--- a/PLATFORM_INDEPENDENCE.md
+++ b/PLATFORM_INDEPENDENCE.md
@@ -24,7 +24,7 @@ Gooey Server itself is licensed under [Apache License 2.0](LICENSE).
 | Stripe / PayPal | Payments | Not required — billing gracefully disabled when keys unset (default) | Feature flag with graceful UI fallback | ✅ Abstracted |
 | Azure Content Moderator | Image safety checker | Not required — check skipped when endpoint unset (default) | Feature flag (`AZURE_IMAGE_MODERATION_ENDPOINT`, default **unset**) | ✅ Optional |
 | Azure Key Vault | Managed secrets | Not required — pass API keys as plain environment variables to functions instead | Optional (`AZURE_KEY_VAULT_ENDPOINT` unset ⇒ disabled) | ✅ Optional |
-| Modal (MMS TTS, Omnilingual ASR) | AI model hosting | Optional feature; core TTS/ASR works via GPU worker or other providers | Optional integration | ✅ Optional |
+| Modal (MMS TTS, Omnilingual ASR, SraVaani ASR) | AI model hosting | Optional feature; core TTS/ASR works via GPU worker or other providers | Optional integration | ✅ Optional |
 | Font Awesome Pro | UI icons | Font Awesome Free (self-hosted) | Asset swap for self-hosted builds | 🔧 In progress |
 | Google Tag Manager | Analytics | Not required for operation | Env-gated script (unset ⇒ not rendered) | 🔧 In progress |
 | WhatsApp / Slack / Facebook / Twilio integrations | Messaging connectors | Optional integrations; core product functions without them | Optional (keys unset ⇒ disabled) | ✅ Optional |
@@ -103,7 +103,7 @@ Document extraction workflows support multiple OCR providers through a unified a
 The UI gracefully degrades when OCR providers are unavailable, displaying a warning and falling back to basic text extraction. Both providers are optional; neither is required for core document processing functionality.
 
 ### Modal-hosted models
-Two models (MMS TTS, Omnilingual ASR) are deployed on [Modal](https://modal.com). These are **optional features**: TTS and ASR each have multiple self-hosted and provider alternatives, and the platform functions fully without Modal credentials.
+Three models (MMS TTS, Omnilingual ASR, SraVaani ASR) are deployed on [Modal](https://modal.com). These are **optional features**: TTS and ASR each have multiple self-hosted and provider alternatives, and the platform functions fully without Modal credentials.
 
 ## 5. Payments — feature flag with graceful degradation (Path 2)
 

--- a/daras_ai_v2/asr.py
+++ b/daras_ai_v2/asr.py
@@ -1446,8 +1446,10 @@ def run_asr(
 
         SraVaani = modal.Cls.from_name(modal_app.name, "SraVaani")
         with modal.enable_output():
-            transcription = SraVaani().run.remote(audio_url=audio_url)
-        return transcription
+            data = SraVaani().run.remote(
+                audio_url=audio_url,
+                return_timestamps=output_format != AsrOutputFormat.text,
+            )
     elif selected_model in {AsrModels.gpt_4_o_audio, AsrModels.gpt_4_o_mini_audio}:
         from daras_ai_v2.language_model import get_openai_client
 

--- a/daras_ai_v2/asr.py
+++ b/daras_ai_v2/asr.py
@@ -296,6 +296,19 @@ SAARAS_V3_SUPPORTED = {
     "ml-IN", "mni-IN", "mr-IN", "ne-IN", "od-IN", "pa-IN", "sa-IN", "sat-IN", "sd-IN", "ta-IN", "te-IN", "ur-IN",
 }  # fmt: skip
 
+# SraVaani 1.0 (ARTPARK, IISc) - 65 Indian languages & dialects (ISO 639-3), auto language identification
+# https://huggingface.co/ARTPARK-IISc/SraVaani-1.0
+# (a few supported dialects have no ISO 639-3 code and are omitted here: Bearybashe, Chakhesang, Khariboli, Khortha, Malvani)
+SRAVAANI_SUPPORTED = {
+    # scheduled languages
+    "asm", "ben", "brx", "doi", "guj", "hin", "kan", "kok", "mai", "mal", "mni", "mar", "nep", "ori", "pan", "san",
+    "sat", "snd", "tam", "tel",
+    # non-scheduled languages & dialects
+    "eng", "njm", "njo", "awa", "vjk", "bgw", "bhb", "bho", "bns", "ccp", "hne", "gbm", "grt", "hlb", "bgc", "clk",
+    "dhd", "mjw", "khn", "trp", "kfy", "kyw", "lmn", "mag", "mwr", "lus", "nag", "sck", "pwr", "raj", "nre", "spv",
+    "swv", "nsm", "sgj", "sjp", "tcy", "nnp",
+}  # fmt: skip
+
 
 class AsrModels(Enum):
     whisper_large_v2 = "Whisper Large v2 (openai)"
@@ -312,6 +325,7 @@ class AsrModels(Enum):
     seamless_m4t_v2 = "Seamless M4T v2 (Facebook Research)"
     mms_1b_all = "Massively Multilingual Speech (MMS) (Facebook Research)"
     meta_omnilingual_asr_llm_7b = "Omnilingual ASR LLM (Meta)"
+    sravaani_v1 = "SraVaani 1.0 (ARTPARK, IISc)"
     voxtral_mini = "Voxtral Mini Transcribe 2"
 
     ghana_nlp_asr_v2 = "Ghana NLP ASR v2"
@@ -387,6 +401,7 @@ asr_model_ids = {
     AsrModels.seamless_m4t_v2: "facebook/seamless-m4t-v2-large",
     AsrModels.mms_1b_all: "facebook/mms-1b-all",
     AsrModels.meta_omnilingual_asr_llm_7b: "omniASR_LLM_7B",
+    AsrModels.sravaani_v1: "ARTPARK-IISc/SraVaani-1.0",
     AsrModels.voxtral_mini: "voxtral-mini-2602",
     AsrModels.lelapa: "lelapa-vulavula",
     AsrModels.elevenlabs: "elevenlabs-scribe-v1",
@@ -426,6 +441,7 @@ asr_supported_languages = {
     AsrModels.azure: AZURE_SUPPORTED,
     AsrModels.mms_1b_all: MMS_SUPPORTED,
     AsrModels.meta_omnilingual_asr_llm_7b: OMNILINGUAL_ASR_SUPPORTED,
+    AsrModels.sravaani_v1: SRAVAANI_SUPPORTED,
     AsrModels.voxtral_mini: VOXTRAL_SUPPORTED,
     AsrModels.ghana_nlp_asr_v2: GHANA_NLP_ASR_V2_SUPPORTED,
     AsrModels.lelapa: LELAPA_ASR_SUPPORTED,
@@ -1418,6 +1434,19 @@ def run_asr(
             transcription = Omnilingual().run.remote(
                 audio_url=audio_url, language=language
             )
+        return transcription
+    elif selected_model == AsrModels.sravaani_v1:
+        import modal
+        from modal_functions.sravaani_asr import app as modal_app
+
+        # SraVaani identifies the spoken language automatically, so the
+        # selected language is only validated, not passed to the model
+        if language:
+            normalised_lang_in_collection(language, SRAVAANI_SUPPORTED)
+
+        SraVaani = modal.Cls.from_name(modal_app.name, "SraVaani")
+        with modal.enable_output():
+            transcription = SraVaani().run.remote(audio_url=audio_url)
         return transcription
     elif selected_model in {AsrModels.gpt_4_o_audio, AsrModels.gpt_4_o_mini_audio}:
         from daras_ai_v2.language_model import get_openai_client

--- a/modal_functions/sravaani_asr.py
+++ b/modal_functions/sravaani_asr.py
@@ -1,0 +1,137 @@
+"""
+To deploy changes to remote functions, run this file directly as a script:
+
+```bash
+poetry run python modal_functions/sravaani_asr.py
+```
+
+Or use the modal CLI:
+
+```bash
+poetry run modal deploy modal_functions/sravaani_asr.py
+```
+
+Note: the HuggingFace repo is gated, so a valid HF_TOKEN (with access granted to
+ARTPARK-IISc/SraVaani-1.0) must be set in the environment when deploying.
+"""
+
+import modal
+from decouple import config
+
+app = modal.App("gooey-sravaani-asr")
+
+MODEL_ID = "ARTPARK-IISc/SraVaani-1.0"
+
+cache_dir = "/cache"
+model_cache = modal.Volume.from_name("hf-model-cache", create_if_missing=True)
+
+image = (
+    modal.Image.debian_slim()
+    .apt_install("libsndfile1", "ffmpeg")  # Required for audio processing
+    .pip_install(
+        "transformers~=4.44",
+        "huggingface_hub[hf_transfer]~=0.34.4",
+        "torch~=2.5.1",
+        "soundfile~=0.12",
+        "librosa~=0.10",
+        "requests~=2.31",
+    )
+    .env(
+        {
+            "HF_HUB_CACHE": cache_dir,
+            "HF_TOKEN": config("HF_TOKEN", ""),
+            "HF_XET_HIGH_PERFORMANCE": "1",
+        }
+    )
+)
+
+
+def load_model(model_id: str):
+    """Load the SraVaani ASR model via transformers remote code."""
+    import torch
+    from transformers import AutoModel
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    print(f"Loading model: {model_id} on {device}")
+    model = (
+        AutoModel.from_pretrained(model_id, trust_remote_code=True).to(device).eval()
+    )
+    print("Model loaded successfully")
+
+    return model
+
+
+@app.cls(
+    image=image,
+    gpu="a10g",
+    volumes={cache_dir: model_cache},
+    timeout=30 * 60,
+    scaledown_window=60 * 60,  # 1 hour
+    max_containers=2,
+    enable_memory_snapshot=True,
+    experimental_options={"enable_gpu_snapshot": True},
+)
+class SraVaani:
+    @modal.enter(snap=True)
+    def load(self):
+        self.model = load_model(MODEL_ID)
+
+    @modal.method()
+    def run(self, audio_url: str) -> str:
+        """Run transcription on the given audio file.
+
+        SraVaani identifies the spoken language automatically, so no language
+        tag is needed at inference.
+        """
+        import os
+
+        # Download audio file
+        print(f"Downloading audio from: {audio_url}")
+        audio_path = download_audio(audio_url)
+
+        try:
+            # Run transcription (language is auto-detected by the model)
+            hyps = self.model.transcribe([audio_path], return_hypotheses=True)
+            # hybrid TDT-CTC models may return (best_hyps, all_hyps)
+            if isinstance(hyps, tuple):
+                hyps = hyps[0]
+            hyp = hyps[0]
+            transcription = getattr(hyp, "text", hyp)
+            print(f"Transcription: {transcription}")
+
+            return transcription
+
+        finally:
+            # Clean up temporary file
+            if os.path.exists(audio_path):
+                os.remove(audio_path)
+
+
+def download_audio(url: str) -> str:
+    """Download WAV audio file from URL to a temporary file."""
+    import requests
+    import tempfile
+    import os
+
+    response = requests.get(url, stream=True)
+    response.raise_for_status()
+
+    # Create temporary file with .wav extension
+    fd, path = tempfile.mkstemp(suffix=".wav")
+
+    try:
+        with os.fdopen(fd, "wb") as f:
+            for chunk in response.iter_content(chunk_size=8192):
+                f.write(chunk)
+    except Exception:
+        # Clean up on error
+        if os.path.exists(path):
+            os.remove(path)
+        raise
+
+    return path
+
+
+if __name__ == "__main__":
+    with modal.enable_output():
+        app.deploy()

--- a/modal_functions/sravaani_asr.py
+++ b/modal_functions/sravaani_asr.py
@@ -20,10 +20,12 @@ from decouple import config
 
 app = modal.App("gooey-sravaani-asr")
 
-MODEL_ID = "ARTPARK-IISc/SraVaani-1.0"
+SRAVAANI_MODEL_ID = "ARTPARK-IISc/SraVaani-1.0"
+SRAVAANI_MODEL_REVISION = "39c6add757f46af212d583ed765894ae78b2ebad"
 
 cache_dir = "/cache"
 model_cache = modal.Volume.from_name("hf-model-cache", create_if_missing=True)
+hf_secret = modal.Secret.from_dict({"HF_TOKEN": config("HF_TOKEN", "")})
 
 image = (
     modal.Image.debian_slim()
@@ -35,27 +37,40 @@ image = (
         "soundfile~=0.12",
         "sentencepiece~=0.2",
         "requests~=2.31",
+        "python-decouple",
     )
     .env(
         {
             "HF_HUB_CACHE": cache_dir,
-            "HF_TOKEN": config("HF_TOKEN", ""),
             "HF_XET_HIGH_PERFORMANCE": "1",
         }
     )
 )
 
 
-def load_model(model_id: str):
-    """Load the SraVaani ASR model via transformers remote code."""
+def load_model(model_id: str, revision: str):
+    """Download and eagerly load a pinned SraVaani model snapshot."""
     import torch
+    from huggingface_hub import snapshot_download
     from transformers import AutoModel
 
     device = "cuda" if torch.cuda.is_available() else "cpu"
-    print(f"Loading model: {model_id} on {device}")
-    model = (
-        AutoModel.from_pretrained(model_id, trust_remote_code=True).to(device).eval()
+    print(f"Loading model: {model_id}@{revision} on {device}")
+    model_path = snapshot_download(
+        repo_id=model_id,
+        revision=revision,
+        cache_dir=cache_dir,
     )
+    model = (
+        AutoModel.from_pretrained(
+            model_path,
+            trust_remote_code=True,
+            local_files_only=True,
+        )
+        .to(device)
+        .eval()
+    )
+    model._ensure_loaded()
     print("Model loaded successfully")
 
     return model
@@ -64,6 +79,7 @@ def load_model(model_id: str):
 @app.cls(
     image=image,
     gpu="a10g",
+    secrets=[hf_secret],
     volumes={cache_dir: model_cache},
     timeout=30 * 60,
     scaledown_window=60 * 60,  # 1 hour
@@ -74,10 +90,10 @@ def load_model(model_id: str):
 class SraVaani:
     @modal.enter(snap=True)
     def load(self):
-        self.model = load_model(MODEL_ID)
+        self.model = load_model(SRAVAANI_MODEL_ID, SRAVAANI_MODEL_REVISION)
 
     @modal.method()
-    def run(self, audio_url: str) -> str:
+    def run(self, audio_url: str, return_timestamps: bool = False) -> dict:
         """Run transcription on the given audio file.
 
         SraVaani identifies the spoken language automatically, so no language
@@ -91,9 +107,13 @@ class SraVaani:
 
         try:
             # Run transcription (language is auto-detected by the model)
-            transcriptions = self.model.transcribe([audio_path])
-            transcription = transcriptions[0]
-            print(f"Transcription: {transcription}")
+            transcriptions = self.model.transcribe(
+                [audio_path], timestamps=return_timestamps
+            )
+            transcription = _sravaani_transcription_to_output(
+                transcriptions[0], return_timestamps=return_timestamps
+            )
+            print(f"Transcription: {transcription['text']}")
 
             return transcription
 
@@ -101,6 +121,25 @@ class SraVaani:
             # Clean up temporary file
             if os.path.exists(audio_path):
                 os.remove(audio_path)
+
+
+def _sravaani_transcription_to_output(
+    transcription, *, return_timestamps: bool
+) -> dict:
+    if not return_timestamps:
+        return {"text": transcription}
+
+    return {
+        "text": transcription.text,
+        "chunks": [
+            {
+                "timestamp": (word["start"], word["end"]),
+                "text": word["word"],
+                "speaker": None,
+            }
+            for word in transcription.timestamp["word"]
+        ],
+    }
 
 
 def download_audio(url: str) -> str:

--- a/modal_functions/sravaani_asr.py
+++ b/modal_functions/sravaani_asr.py
@@ -27,13 +27,13 @@ model_cache = modal.Volume.from_name("hf-model-cache", create_if_missing=True)
 
 image = (
     modal.Image.debian_slim()
-    .apt_install("libsndfile1", "ffmpeg")  # Required for audio processing
+    .apt_install("libsndfile1")  # Required for audio processing
     .pip_install(
-        "transformers~=4.44",
-        "huggingface_hub[hf_transfer]~=0.34.4",
-        "torch~=2.5.1",
+        "transformers~=5.15",
+        "huggingface_hub[hf_transfer]",
+        "torch~=2.13",
         "soundfile~=0.12",
-        "librosa~=0.10",
+        "sentencepiece~=0.2",
         "requests~=2.31",
     )
     .env(
@@ -91,12 +91,8 @@ class SraVaani:
 
         try:
             # Run transcription (language is auto-detected by the model)
-            hyps = self.model.transcribe([audio_path], return_hypotheses=True)
-            # hybrid TDT-CTC models may return (best_hyps, all_hyps)
-            if isinstance(hyps, tuple):
-                hyps = hyps[0]
-            hyp = hyps[0]
-            transcription = getattr(hyp, "text", hyp)
+            transcriptions = self.model.transcribe([audio_path])
+            transcription = transcriptions[0]
             print(f"Transcription: {transcription}")
 
             return transcription


### PR DESCRIPTION
Adds [SraVaani 1.0](https://huggingface.co/ARTPARK-IISc/SraVaani-1.0) — the open (MIT-licensed) ~430M-parameter FastConformer ASR model from IISc's SPIRE Lab + ARTPARK — as a new speech-recognition provider, deployed on Modal alongside the existing Omnilingual ASR and MMS TTS apps.

**What's included**

- `modal_functions/sravaani_asr.py` — Modal deployment script (`gooey-sravaani-asr` app) mirroring the `meta_omnilingual_asr.py` setup: A10G GPU, shared `hf-model-cache` volume, memory + GPU snapshots, 1-hour scaledown. The model is loaded via `transformers.AutoModel` with `trust_remote_code=True` per the model card. The repo's remote code was reviewed: it is a pure-torch TorchScript wrapper (no `nemo_toolkit` needed), and the image deps (`transformers`, `torch`, `soundfile`, `sentencepiece`) match what it actually imports.
- `daras_ai_v2/asr.py` — new `AsrModels.sravaani_v1` entry ("SraVaani 1.0 (ARTPARK, IISc)") with its HF model id, a 58-code ISO 639-3 supported-language set covering the model's 65 Indian languages/dialects (a few dialects — Bearybashe, Chakhesang, Khariboli, Khortha, Malvani — have no ISO 639-3 code and are noted in a comment), and a `run_asr` dispatch branch calling the Modal class. SraVaani identifies the spoken language automatically, so auto-detect is enabled and a selected language is only validated, never forwarded.
- `PLATFORM_INDEPENDENCE.md` — lists SraVaani among the optional Modal-hosted models.

**Verified end-to-end (CPU, local)**

Inference was exercised for real with the exact loading code used in the Modal function:

- LibriSpeech English sample → transcribed correctly.
- A Hindi utterance synthesized with `facebook/mms-tts-hin` → transcribed **word-for-word** ("भारत एक विशाल देश है और यहाँ अनेक भाषाएँ बोली जाती हैं"), with no language tag passed — auto language ID working as advertised.

**Deployment notes**

- Deploy with `HF_TOKEN=... poetry run modal deploy modal_functions/sravaani_asr.py`. The HF repo is gated (auto-approval); the deploying HF account must have accepted access to `ARTPARK-IISc/SraVaani-1.0`. This session's egress proxy does not support gRPC, so the Modal deploy itself must be run by a maintainer from a normal environment.
- Per the [technical report](https://arxiv.org/pdf/2608.08235), audio is resampled to 16 kHz internally; `run_asr` already converts input to WAV before dispatch.

### Q/A checklist

- [ ] I have tested my UI changes on mobile and they look acceptable
- [ ] I have tested changes to the workflows in both the API and the UI
- [x] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [x] My changes have not increased the import time of the server

(Modal and `transformers` imports are function-local; verified `AsrModels`, the language set, `lang_format_func` display, language normalization, and the Modal module import cleanly. Ruff lint + format pass.)

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvkuvuS3L344qik4E5vKWy