### PR TITLE
Fixes GOOEY-UI-2XB: stop sidebar removeChild crash

### DIFF
--- a/gooey-gui/app/components/NavigationSidebar/PrimaryNavItems.tsx
+++ b/gooey-gui/app/components/NavigationSidebar/PrimaryNavItems.tsx
@@ -156,10 +156,25 @@ function NavItemChildren({
     );
   }
 
-  // React 17 throws NotFoundError ("removeChild") when a component root
-  // switches between null, a single host node, and a Fragment. History
-  // fetching and rail collapse used to do exactly that (GOOEY-UI-2XB).
-  return <div className="d-flex flex-column gap-1">{body}</div>;
+  // React 17 throws NotFoundError ("removeChild") when it tries to detach a
+  // node that a translator/extension has reparented. History fetching and
+  // rail collapse used to switch this component's root between null, a
+  // single node, and a Fragment (GOOEY-UI-2XB). Keep a stable outer host,
+  // and remount the inner host when the phase changes so React drops the
+  // whole subtree instead of surgically removing mutated children.
+  let phase = "empty";
+  if (collapsed) {
+    phase = "collapsed";
+  } else if (hasRows) {
+    phase = "rows";
+  }
+  return (
+    <div>
+      <div key={phase} className="d-flex flex-column gap-1">
+        {body}
+      </div>
+    </div>
+  );
 }
 
 function NavItem({

--- a/gooey-gui/app/components/NavigationSidebar/PrimaryNavItems.tsx
+++ b/gooey-gui/app/components/NavigationSidebar/PrimaryNavItems.tsx
@@ -27,12 +27,13 @@ export function PrimaryNavItems({
       <div className="nav-scroll-region d-flex flex-column gap-1 mt-1">
         {nav_items.map((item) => {
           const hasChildren = item.items.length > 0 || !!item.items_url;
-          if (hasChildren && !railCollapsed) {
+          if (hasChildren) {
             return (
               <NavItemChildren
                 key={item.key}
                 item={item}
                 isActive={item.key === active_key}
+                collapsed={railCollapsed}
               />
             );
           }
@@ -79,6 +80,88 @@ export function PrimaryNavItems({
   );
 }
 
+function NavItemChildren({
+  item,
+  isActive,
+  collapsed,
+}: {
+  item: NavItemData;
+  isActive: boolean;
+  collapsed: boolean;
+}) {
+  const [open, setOpen] = useState(true);
+  const { items, isFetching } = useNavItemChildren(item);
+  const showSkeleton = isFetching && items.length === 0;
+  const hasRows = items.length > 0 || showSkeleton;
+
+  let body: ReactNode = null;
+  if (collapsed) {
+    body = (
+      <NavItem item={item} isActive={isActive} collapsed dense={item.dense} />
+    );
+  } else if (!hasRows) {
+    // A fetched section has no href of its own, so an empty result means
+    // there's nothing to link to — drop the label instead of a dead row.
+    if (!item.items_url) {
+      body = (
+        <NavItem
+          item={item}
+          isActive={isActive}
+          collapsed={false}
+          dense={item.dense}
+        />
+      );
+    }
+  } else {
+    // Non-collapsible sections (e.g. History) drop the chevron and stay expanded.
+    const showItems = !item.collapsible || open;
+    let rows: ReactNode = null;
+    if (showItems) {
+      if (showSkeleton) {
+        rows = <WorkflowListSkeleton rows={3} indent={!item.dense} />;
+      } else {
+        rows = <WorkflowList items={items} indent={!item.dense} />;
+      }
+    }
+    body = (
+      <Fragment>
+        <NavItem
+          item={item}
+          isActive={isActive}
+          collapsed={false}
+          dense={item.dense}
+        >
+          {/* the chevron after the label toggles the nested items open/closed */}
+          {item.collapsible && (
+            <span
+              className="flex-grow-1 d-flex align-items-center justify-content-end flex-grow-1"
+              onClick={(e) => {
+                e.preventDefault();
+                setOpen((isOpen) => !isOpen);
+              }}
+            >
+              <i
+                className={clsx(
+                  "nav-chevron-icon fa-regular",
+                  open ? "fa-chevron-down" : "fa-chevron-right"
+                )}
+              />
+            </span>
+          )}
+        </NavItem>
+        {showItems && (
+          <div className={clsx(!item.dense && "saved-tree")}>{rows}</div>
+        )}
+      </Fragment>
+    );
+  }
+
+  // React 17 throws NotFoundError ("removeChild") when a component root
+  // switches between null, a single host node, and a Fragment. History
+  // fetching and rail collapse used to do exactly that (GOOEY-UI-2XB).
+  return <div className="d-flex flex-column gap-1">{body}</div>;
+}
+
 function NavItem({
   item,
   isActive,
@@ -116,7 +199,7 @@ function NavItem({
             !isActive && "text-muted",
             item.dense && !collapsed && "small"
           )}
-          dangerouslySetInnerHTML={{ __html: item.icon }}
+          dangerouslySetInnerHTML={{ __html: item.icon || "" }}
         />
         {!collapsed && <span>{item.label}</span>}
       </span>
@@ -141,74 +224,6 @@ function NavItem({
     >
       {content}
     </Link>
-  );
-}
-
-function NavItemChildren({
-  item,
-  isActive,
-}: {
-  item: NavItemData;
-  isActive: boolean;
-}) {
-  const [open, setOpen] = useState(true);
-  const { items, isFetching } = useNavItemChildren(item);
-  const showSkeleton = isFetching && items.length === 0;
-
-  if (items.length === 0 && !showSkeleton) {
-    // A fetched section has no href of its own, so an empty result means there's
-    // nothing to link to — drop the whole section instead of a dead label.
-    if (item.items_url) return null;
-    // No children → behaves like a plain nav item (label links to href).
-    return (
-      <NavItem
-        item={item}
-        isActive={isActive}
-        collapsed={false}
-        dense={item.dense}
-      />
-    );
-  }
-
-  // Non-collapsible sections (e.g. History) drop the chevron and stay expanded.
-  const showItems = !item.collapsible || open;
-
-  return (
-    <Fragment>
-      <NavItem
-        item={item}
-        isActive={isActive}
-        collapsed={false}
-        dense={item.dense}
-      >
-        {/* the chevron after the label toggles the nested items open/closed */}
-        {item.collapsible && (
-          <span
-            className="flex-grow-1 d-flex align-items-center justify-content-end flex-grow-1"
-            onClick={(e) => {
-              e.preventDefault();
-              setOpen((isOpen) => !isOpen);
-            }}
-          >
-            <i
-              className={clsx(
-                "nav-chevron-icon fa-regular",
-                open ? "fa-chevron-down" : "fa-chevron-right"
-              )}
-            />
-          </span>
-        )}
-      </NavItem>
-      {showItems && (
-        <div className={clsx(!item.dense && "saved-tree")}>
-          {showSkeleton ? (
-            <WorkflowListSkeleton rows={3} indent={!item.dense} />
-          ) : (
-            <WorkflowList items={items} indent={!item.dense} />
-          )}
-        </div>
-      )}
-    </Fragment>
   );
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [GOOEY-UI-2XB](https://dara-network.sentry.io/issues/GOOEY-UI-2XB/).

### What happened

Sentry reported `NotFoundError: Failed to execute 'removeChild' on 'Node'` on `/Lipsync/` (Edge 151, release `8d932c51`). The component stack pointed at `PrimaryNavItems`.

This app is on **React 17**. React 17 throws that DOMException when it tries to detach a node that is no longer a child of the parent it recorded — typically after a translator/extension reparents a node, and especially when a component root switches between `null`, a single host node, and a `Fragment`.

`NavItemChildren` was doing all three:

1. History (`items_url`) first rendered `null`, then a `Fragment` (header + skeleton/list) after fetch.
2. A section with no nested rows rendered a bare `NavItem`.
3. Collapsing the rail swapped `NavItemChildren` ↔ `NavItem` for the same `key`.

### Fix

- Always mount `NavItemChildren` for sections that can have children, including the collapsed rail.
- Always wrap that component in a stable outer host `div`.
- Key an inner host by phase (`collapsed` / `rows` / `empty`) so React remounts the subtree instead of surgically removing children that may have been reparented.
- Empty fetched sections still hide their label; the wrapper stays mounted.

A jsdom + React 17 harness confirmed the old Fragment/`null` root throws the same `NotFoundError` after a node is reparented, and the keyed host does not.

### Q/A checklist

- [ ] I have tested my UI changes on mobile and they look acceptable
- [ ] I have tested changes to the workflows in both the API and the UI
- [ ] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [ ] My changes have not increased the import time of the server

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00616-a65d-72c7-af1e-2431ee3b4ac4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00616-a65d-72c7-af1e-2431ee3b4ac4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

