### PR TITLE
fix: use a plain logout link

### DIFF
--- a/gooey-gui/app/components/NavigationSidebar/WorkspaceAccountMenu.tsx
+++ b/gooey-gui/app/components/NavigationSidebar/WorkspaceAccountMenu.tsx
@@ -116,13 +116,10 @@ export function WorkspaceAccountMenu({
       {account.logout_href && (
         <>
           <hr className="my-1" />
-          <AccountMenuItem
-            href={account.logout_href}
-            icon="fa-regular fa-arrow-right-from-bracket"
-            onClick={closeMenu}
-          >
-            Log out
-          </AccountMenuItem>
+          <a href={account.logout_href} className={MENU_ROW_ACTION_CLASS}>
+            <MenuIcon icon="fa-regular fa-arrow-right-from-bracket" />
+            <span className="flex-grow-1 text-truncate min-w-0">Log out</span>
+          </a>
         </>
       )}
     </div>


### PR DESCRIPTION
Log out is now a simple <a href> to /logout/ so the browser does a full page request instead of a client-side route.

### Q/A checklist

- [x] I have tested my UI changes on mobile and they look acceptable
- [x] I have tested changes to the workflows in both the API and the UI
- [x] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [x] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
