### PR TITLE
Add ComfyUI cloud gateway (comfy.gooey.ai)

### DIFF
--- a/comfy/Dockerfile
+++ b/comfy/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.12-slim
+
+WORKDIR /srv/comfy
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV PYTHONUNBUFFERED=1
+EXPOSE 8501
+
+CMD ["uvicorn", "gateway.main:app", "--host", "0.0.0.0", "--port", "8501"]

--- a/comfy/README.md
+++ b/comfy/README.md
@@ -1,0 +1,184 @@
+# Gooey ComfyUI Cloud (comfy.gooey.ai)
+
+A separate service that gives every Gooey user a cloud-hosted [ComfyUI](https://github.com/comfyanonymous/ComfyUI),
+logged in with their **Gooey account**, billed in **Gooey credits** to their
+**selected workspace**, with a **Gooey header** on top of the ComfyUI app for
+navigation, workspace switching, and live credit balance.
+
+```
+                      browser (comfy.gooey.ai)
+                               │
+                               ▼
+   ┌───────────────────────────────────────────────────────┐
+   │  ComfyUI Gateway  (this directory — FastAPI)          │
+   │  • SSO with gooey.ai (signed short-lived tokens)      │
+   │  • signed session cookie (uid + workspaces)           │
+   │  • injects the Gooey header into ComfyUI's index.html │
+   │  • reverse-proxies HTTP + WebSocket to the backend    │
+   │  • bills 1 GPU-minute of credits per minute of use    │
+   │  • idle reaper stops instances after inactivity       │
+   └──────────┬───────────────────────────┬────────────────┘
+              │ server-to-server          │ per-workspace instances
+              ▼ (COMFY_SERVICE_TOKEN)     ▼
+   ┌─────────────────────┐     ┌───────────────────────────┐
+   │ gooey-server        │     │ Modal sandboxes           │
+   │ /comfy/sso/         │     │ (comfy_modal.py)          │
+   │ /__/comfy/api/*     │     │ ComfyUI + comfy-cli, GPU, │
+   │ (verify SSO, list   │     │ persistent Volume per     │
+   │  workspaces, deduct │     │ workspace for models/     │
+   │  credits)           │     │ outputs/custom nodes      │
+   └─────────────────────┘     └───────────────────────────┘
+```
+
+## How it works
+
+### Login with the Gooey account
+
+comfy.gooey.ai and gooey.ai are different origins, and the gooey session
+cookie is host-only, so the gateway uses a redirect-based SSO handshake
+instead of sharing cookies:
+
+1. Unauthenticated navigation to `comfy.gooey.ai/*` redirects to
+   `gooey.ai/comfy/sso/?next=<path>` (`routers/comfy_api.py` on gooey-server).
+2. That endpoint runs behind gooey-server's normal auth middleware. If the
+   user isn't logged in it bounces through `/login/` first (the comfy URL is
+   in `SAFE_URLS`, so the post-login redirect is allowed).
+3. It then mints a 5-minute token signed with `SECRET_KEY`
+   (salt `gooey-comfy-sso`) and redirects to
+   `comfy.gooey.ai/auth/callback?token=…`.
+4. The gateway exchanges the token server-to-server
+   (`POST /__/comfy/api/verify-sso/`, authenticated with the shared
+   `COMFY_SERVICE_TOKEN` bearer) and receives the user's profile plus all
+   workspaces they're a member of, with balances.
+5. The gateway sets its own signed `comfy_session` cookie. Nothing secret
+   from gooey.ai ever reaches the browser or the ComfyUI upstream (the proxy
+   strips the `Cookie` header).
+
+### Workspaces & billing
+
+- The Gooey header has a **workspace switcher**; the selection is stored in
+  the gateway session (mirroring gooey-server's `selected-workspace-id`).
+- Each workspace gets its **own ComfyUI instance** and its own Modal Volume
+  (`comfyui-workspace-<id>`) — models, custom nodes, inputs and outputs are
+  shared by workspace members and persist across sessions.
+- While an instance is up, the gateway reports usage every minute to
+  `POST /__/comfy/api/usage/`. Pricing stays on gooey-server
+  (`COMFY_CREDITS_PER_GPU_MINUTE`, default 10 credits/GPU-minute); deduction
+  uses the same idempotent `Workspace.add_balance` primitive as recipe runs,
+  with deterministic invoice ids (`<sandbox_id>/<tick>`) so retries can never
+  double-charge. Transactions appear in the workspace's normal billing
+  history on gooey.ai.
+- Launch is refused below `MIN_CREDITS_TO_LAUNCH`; when a workspace runs out
+  of credits mid-session the instance is stopped and the user is pointed at
+  the gooey.ai billing page.
+- The idle reaper stops instances after `IDLE_TIMEOUT_SECONDS` (default
+  15 min) without proxy traffic; Modal sandboxes additionally have a hard
+  12-hour lifetime cap as a spend backstop.
+
+### The Gooey header
+
+`gateway/header.py` injects a `<style>+<script>` snippet into ComfyUI's
+`index.html` as it passes through the proxy. The script inserts a fixed
+44 px bar (Gooey logo → gooey.ai, workspace switcher, live credit balance
+refreshed every 30 s via `/gooey/api/me`, add-credits link, avatar, logout)
+and pushes the ComfyUI app down below it. DOM-insertion via script keeps it
+robust against changes to ComfyUI's markup.
+
+### GPU backends
+
+`COMFY_BACKEND` selects the compute backend (`gateway/backends.py`):
+
+- **`modal`** (default): boots a `modal.Sandbox` per workspace from the
+  pre-baked image in `comfy_modal.py` (comfy-cli + pinned ComfyUI, NVIDIA
+  deps), exposed through a Modal tunnel. GPU type via `MODAL_GPU`
+  (default `L4`).
+- **`static`**: one fixed upstream ComfyUI (`STATIC_COMFY_URL`) shared by
+  everyone — for local dev, or a self-managed GPU box / RunPod pod. Billed
+  only for *active* minutes since the GPU isn't dedicated.
+
+Other managed ComfyUI providers can be added as small `BaseBackend`
+subclasses (launch + terminate + url).
+
+## Deployment
+
+### 1. gooey-server side (already wired in this repo)
+
+Set env vars on the main gooey-server deployment:
+
+| var | value |
+|---|---|
+| `COMFY_BASE_URL` | `https://comfy.gooey.ai` |
+| `COMFY_SERVICE_TOKEN` | long random secret, shared with the gateway |
+| `COMFY_CREDITS_PER_GPU_MINUTE` | e.g. `10` |
+
+### 2. Bake the Modal image
+
+```bash
+cd comfy
+pip install -r requirements.txt
+modal token set  # or MODAL_TOKEN_ID / MODAL_TOKEN_SECRET
+python comfy_modal.py
+```
+
+### 3. Deploy the gateway
+
+Any container host works (Cloud Run / Fly / GKE). It's stateless except for
+in-memory instance tracking, so run **a single replica** (or add sticky
+routing by workspace if scaling out).
+
+```bash
+docker build -t gooey-comfy-gateway comfy/
+docker run -p 8501:8501 \
+  -e COMFY_BASE_URL=https://comfy.gooey.ai \
+  -e GOOEY_APP_BASE_URL=https://gooey.ai \
+  -e GOOEY_API_BASE_URL=https://api.gooey.ai \
+  -e COMFY_SERVICE_TOKEN=... \
+  -e SECRET_KEY=... \
+  -e MODAL_TOKEN_ID=... -e MODAL_TOKEN_SECRET=... \
+  -e MODAL_GPU=L4 \
+  gooey-comfy-gateway
+```
+
+Point the `comfy.gooey.ai` DNS record at the deployment (TLS required —
+the session cookie is `Secure` on https).
+
+### 4. Local development
+
+```bash
+# terminal 1: gooey-server as usual (localhost:8080 / :3000)
+# terminal 2: any local ComfyUI on :8188
+# terminal 3:
+cd comfy
+COMFY_BACKEND=static STATIC_COMFY_URL=http://localhost:8188 \
+  SECRET_KEY=dev COMFY_SERVICE_TOKEN=dev \
+  GOOEY_APP_BASE_URL=http://localhost:3000 \
+  GOOEY_API_BASE_URL=http://localhost:8080 \
+  COMFY_BASE_URL=http://localhost:8501 \
+  uvicorn gateway.main:app --port 8501 --reload
+```
+
+(set `COMFY_SERVICE_TOKEN=dev` on the gooey-server side too.)
+
+## Endpoint reference
+
+Gateway (comfy.gooey.ai):
+
+| route | purpose |
+|---|---|
+| `GET /login` | kick off SSO via gooey.ai |
+| `GET /auth/callback?token=` | finish SSO, set session cookie |
+| `GET /gooey/logout` | clear session, back to gooey.ai |
+| `GET /gooey/api/me` | fresh profile + workspace balances (header polls this) |
+| `POST /gooey/switch-workspace` | change the active workspace |
+| `WS /ws` | proxied ComfyUI websocket |
+| `* /{path}` | authenticated reverse proxy to the workspace's ComfyUI |
+
+gooey-server (`routers/comfy_api.py`):
+
+| route | auth | purpose |
+|---|---|---|
+| `GET /comfy/sso/` | browser session | mint SSO token, redirect to gateway |
+| `POST /__/comfy/api/verify-sso/` | service token | token → user + workspaces |
+| `GET /__/comfy/api/users/{uid}/` | service token | refresh profile/balances |
+| `POST /__/comfy/api/usage/` | service token | bill gpu_ms to a workspace (idempotent) |
+| `GET /__/comfy/api/workspaces/{id}/balance/` | service token | pre-flight balance check |

--- a/comfy/README.md
+++ b/comfy/README.md
@@ -92,9 +92,18 @@ robust against changes to ComfyUI's markup.
   pre-baked image in `comfy_modal.py` (comfy-cli + pinned ComfyUI, NVIDIA
   deps), exposed through a Modal tunnel. GPU type via `MODAL_GPU`
   (default `L4`).
+- **`local`**: same per-workspace isolation, but each instance is a local
+  `comfy launch` subprocess instead of a Modal sandbox — for local installs
+  that want to use their own machine (and GPU, if `nvidia-smi` finds one;
+  otherwise ComfyUI runs with `--cpu`). Per-workspace data lives under
+  `COMFY_LOCAL_DATA_DIR` (default `~/.gooey-comfy`), ports are allocated
+  from `COMFY_LOCAL_PORT_START` (default 8190). Credits are **not**
+  deducted unless `COMFY_LOCAL_BILLING=1`, since it's your own hardware.
+  Requires comfy-cli: `pip install comfy-cli && comfy --skip-prompt install`.
 - **`static`**: one fixed upstream ComfyUI (`STATIC_COMFY_URL`) shared by
-  everyone — for local dev, or a self-managed GPU box / RunPod pod. Billed
-  only for *active* minutes since the GPU isn't dedicated.
+  everyone — for pointing at an already-running ComfyUI or a self-managed
+  GPU box / RunPod pod. Billed only for *active* minutes since the GPU
+  isn't dedicated.
 
 Other managed ComfyUI providers can be added as small `BaseBackend`
 subclasses (launch + terminate + url).
@@ -146,10 +155,11 @@ the session cookie is `Secure` on https).
 
 ```bash
 # terminal 1: gooey-server as usual (localhost:8080 / :3000)
-# terminal 2: any local ComfyUI on :8188
-# terminal 3:
+# terminal 2:
 cd comfy
-COMFY_BACKEND=static STATIC_COMFY_URL=http://localhost:8188 \
+pip install -r requirements.txt comfy-cli
+comfy --skip-prompt install   # one-time; picks up your GPU if you have one
+COMFY_BACKEND=local \
   SECRET_KEY=dev COMFY_SERVICE_TOKEN=dev \
   GOOEY_APP_BASE_URL=http://localhost:3000 \
   GOOEY_API_BASE_URL=http://localhost:8080 \
@@ -158,6 +168,11 @@ COMFY_BACKEND=static STATIC_COMFY_URL=http://localhost:8188 \
 ```
 
 (set `COMFY_SERVICE_TOKEN=dev` on the gooey-server side too.)
+
+`COMFY_BACKEND=local` gives you the full production behavior — per-workspace
+instances, launch/idle lifecycle, header — but everything runs on your own
+machine and no credits are deducted. If you already have a ComfyUI running,
+use `COMFY_BACKEND=static STATIC_COMFY_URL=http://localhost:8188` instead.
 
 ## Endpoint reference
 

--- a/comfy/comfy_modal.py
+++ b/comfy/comfy_modal.py
@@ -1,0 +1,74 @@
+"""
+Modal deployment for ComfyUI cloud (comfy.gooey.ai).
+
+Each Gooey workspace gets its own ComfyUI sandbox with a persistent
+`modal.Volume` mounted at /data (models, custom nodes, inputs, outputs), so
+users build up their own model library per workspace.
+
+Pre-bake the image (recommended before first launch, and after bumping
+versions):
+
+```bash
+python comfy_modal.py  # runs a throwaway sandbox once to build+cache the image
+```
+
+The gateway (gateway/backends.py) imports `launch_sandbox()` to boot instances
+on demand. Requires MODAL_TOKEN_ID / MODAL_TOKEN_SECRET in the environment.
+"""
+
+import modal
+
+APP_NAME = "gooey-comfyui"
+COMFY_PORT = 8188
+COMFY_VERSION = "0.3.44"
+
+# GPU-seconds cap per sandbox — a hard backstop on runaway spend; the gateway's
+# idle reaper normally stops sandboxes long before this
+MAX_SANDBOX_LIFETIME = 12 * 60 * 60
+
+image = (
+    modal.Image.debian_slim(python_version="3.11")
+    .apt_install("git", "wget", "libgl1", "libglib2.0-0")
+    .pip_install("comfy-cli~=1.4")
+    .run_commands(
+        f"comfy --skip-prompt install --fast-deps --nvidia --version {COMFY_VERSION}"
+    )
+)
+
+
+def launch_sandbox(
+    workspace_id: int | str,
+    gpu: str = "L4",
+    timeout: int = MAX_SANDBOX_LIFETIME,
+) -> modal.Sandbox:
+    app = modal.App.lookup(APP_NAME, create_if_missing=True)
+    volume = modal.Volume.from_name(
+        f"comfyui-workspace-{workspace_id}", create_if_missing=True
+    )
+    return modal.Sandbox.create(
+        "bash",
+        "-c",
+        # --base-directory keeps models/custom_nodes/input/output on the
+        # workspace volume so they survive sandbox restarts
+        f"mkdir -p /data/comfy && "
+        f"comfy launch -- --listen 0.0.0.0 --port {COMFY_PORT} "
+        f"--base-directory /data/comfy",
+        app=app,
+        image=image,
+        gpu=gpu,
+        timeout=timeout,
+        encrypted_ports=[COMFY_PORT],
+        volumes={"/data": volume},
+    )
+
+
+def sandbox_url(sandbox: modal.Sandbox) -> str:
+    return sandbox.tunnels()[COMFY_PORT].url
+
+
+if __name__ == "__main__":
+    print("Building image by launching a throwaway sandbox ...")
+    sb = launch_sandbox("image-build-test", timeout=5 * 60)
+    print("Sandbox:", sb.object_id, "->", sandbox_url(sb))
+    sb.terminate()
+    print("Image built & cached. Done.")

--- a/comfy/gateway/backends.py
+++ b/comfy/gateway/backends.py
@@ -48,9 +48,7 @@ class BaseBackend:
             if instance and not instance.stopped:
                 return instance
 
-            balance = await gooey_client.get_balance(
-                uid=uid, workspace_id=workspace_id
-            )
+            balance = await gooey_client.get_balance(uid=uid, workspace_id=workspace_id)
             if balance < settings.MIN_CREDITS_TO_LAUNCH:
                 raise gooey_client.InsufficientCredits(
                     f"This workspace needs at least "
@@ -288,8 +286,7 @@ class StaticBackend(BaseBackend):
 
     def _is_billable(self, instance: ComfyInstance) -> bool:
         return (
-            instance.ready
-            and time.time() - instance.last_active < BILLING_INTERVAL * 2
+            instance.ready and time.time() - instance.last_active < BILLING_INTERVAL * 2
         )
 
 

--- a/comfy/gateway/backends.py
+++ b/comfy/gateway/backends.py
@@ -184,6 +184,94 @@ class ModalBackend(BaseBackend):
                 logger.exception("failed to terminate modal sandbox")
 
 
+class LocalBackend(BaseBackend):
+    """
+    Runs the same ComfyUI-per-workspace setup as ModalBackend, but as local
+    subprocesses instead of Modal sandboxes (COMFY_BACKEND=local). Uses the
+    local GPU when one is visible, else falls back to CPU. Needs comfy-cli
+    with ComfyUI installed (`pip install comfy-cli && comfy install`).
+
+    Billing is off by default (it's the operator's own hardware); flip
+    COMFY_LOCAL_BILLING=1 to meter it like the static backend.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._procs: dict[int, asyncio.subprocess.Process] = {}
+        self._next_port = settings.COMFY_LOCAL_PORT_START
+
+    async def _launch(self, instance: ComfyInstance):
+        import shutil
+        from pathlib import Path
+
+        if not shutil.which("comfy"):
+            raise RuntimeError(
+                "COMFY_BACKEND=local needs comfy-cli on PATH: "
+                "`pip install comfy-cli && comfy --skip-prompt install`"
+            )
+
+        port = self._next_port
+        self._next_port += 1
+        base_dir = (
+            Path(settings.COMFY_LOCAL_DATA_DIR).expanduser()
+            / f"workspace-{instance.workspace_id}"
+        )
+        base_dir.mkdir(parents=True, exist_ok=True)
+
+        cmd = [
+            "comfy",
+            "launch",
+            "--",
+            "--listen",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--base-directory",
+            str(base_dir),
+        ]
+        if not await _has_local_gpu():
+            cmd.append("--cpu")
+
+        proc = await asyncio.create_subprocess_exec(*cmd)
+        self._procs[instance.workspace_id] = proc
+        instance.instance_id = f"local-{instance.workspace_id}-{int(time.time())}"
+        instance.url = f"http://127.0.0.1:{port}"
+        logger.info(
+            f"launched local comfy for workspace {instance.workspace_id} "
+            f"on port {port} (pid {proc.pid}): {' '.join(cmd)}"
+        )
+
+    async def _terminate(self, instance: ComfyInstance):
+        proc = self._procs.pop(instance.workspace_id, None)
+        if not proc or proc.returncode is not None:
+            return
+        proc.terminate()
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=15)
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+
+    def _is_billable(self, instance: ComfyInstance) -> bool:
+        return (
+            settings.COMFY_LOCAL_BILLING
+            and instance.ready
+            and time.time() - instance.last_active < BILLING_INTERVAL * 2
+        )
+
+
+async def _has_local_gpu() -> bool:
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "nvidia-smi",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        return await proc.wait() == 0
+    except FileNotFoundError:
+        return False
+
+
 class StaticBackend(BaseBackend):
     """
     A single fixed upstream ComfyUI shared by all workspaces (local dev, or a
@@ -206,6 +294,11 @@ class StaticBackend(BaseBackend):
 
 
 def make_backend() -> BaseBackend:
-    if settings.COMFY_BACKEND == "modal":
-        return ModalBackend()
-    return StaticBackend()
+    match settings.COMFY_BACKEND:
+        case "modal":
+            return ModalBackend()
+        case "local":
+            return LocalBackend()
+        case "static":
+            return StaticBackend()
+    raise ValueError(f"unknown COMFY_BACKEND: {settings.COMFY_BACKEND!r}")

--- a/comfy/gateway/backends.py
+++ b/comfy/gateway/backends.py
@@ -1,0 +1,211 @@
+"""
+Manages one ComfyUI instance per Gooey workspace: launch on demand, meter GPU
+time into Gooey credits every minute, and stop after a period of no traffic.
+"""
+
+import asyncio
+import logging
+import time
+
+import httpx
+
+from gateway import gooey_client, settings
+
+logger = logging.getLogger("comfy.backends")
+
+BILLING_INTERVAL = 60  # seconds; one billing tick = one GPU-minute
+
+
+class ComfyInstance:
+    def __init__(self, workspace_id: int, uid: str):
+        self.workspace_id = workspace_id
+        # the user who caused the launch; usage is billed to the workspace
+        self.uid = uid
+        self.instance_id: str = ""
+        self.url: str = ""
+        self.ready = False
+        self.stopped = False
+        self.stop_reason = ""
+        self.started_at = time.time()
+        self.last_active = time.time()
+        self._tasks: list[asyncio.Task] = []
+
+    def touch(self):
+        self.last_active = time.time()
+
+
+class BaseBackend:
+    """One instance per workspace, lazily launched."""
+
+    def __init__(self):
+        self._instances: dict[int, ComfyInstance] = {}
+        self._locks: dict[int, asyncio.Lock] = {}
+
+    async def get_or_launch(self, workspace_id: int, uid: str) -> ComfyInstance:
+        lock = self._locks.setdefault(workspace_id, asyncio.Lock())
+        async with lock:
+            instance = self._instances.get(workspace_id)
+            if instance and not instance.stopped:
+                return instance
+
+            balance = await gooey_client.get_balance(
+                uid=uid, workspace_id=workspace_id
+            )
+            if balance < settings.MIN_CREDITS_TO_LAUNCH:
+                raise gooey_client.InsufficientCredits(
+                    f"This workspace needs at least "
+                    f"{settings.MIN_CREDITS_TO_LAUNCH} credits to start ComfyUI."
+                )
+
+            instance = ComfyInstance(workspace_id, uid)
+            self._instances[workspace_id] = instance
+            await self._launch(instance)
+            instance._tasks.append(asyncio.create_task(self._wait_ready(instance)))
+            instance._tasks.append(asyncio.create_task(self._billing_loop(instance)))
+            instance._tasks.append(asyncio.create_task(self._idle_reaper(instance)))
+            return instance
+
+    def get(self, workspace_id: int) -> ComfyInstance | None:
+        instance = self._instances.get(workspace_id)
+        if instance and not instance.stopped:
+            return instance
+        return None
+
+    async def stop(self, workspace_id: int, reason: str = ""):
+        instance = self._instances.pop(workspace_id, None)
+        if not instance or instance.stopped:
+            return
+        instance.stopped = True
+        instance.stop_reason = reason
+        logger.info(f"stopping comfy instance for workspace {workspace_id}: {reason}")
+        for task in instance._tasks:
+            if task is not asyncio.current_task():
+                task.cancel()
+        await self._terminate(instance)
+
+    async def shutdown(self):
+        for workspace_id in list(self._instances):
+            await self.stop(workspace_id, reason="gateway shutdown")
+
+    async def _wait_ready(self, instance: ComfyInstance):
+        async with httpx.AsyncClient(timeout=5) as client:
+            for _ in range(120):
+                if instance.stopped:
+                    return
+                try:
+                    r = await client.get(instance.url + "/system_stats")
+                    if r.status_code == 200:
+                        instance.ready = True
+                        logger.info(
+                            f"comfy ready for workspace {instance.workspace_id}: "
+                            f"{instance.url}"
+                        )
+                        return
+                except httpx.HTTPError:
+                    pass
+                await asyncio.sleep(5)
+        await self.stop(instance.workspace_id, reason="ComfyUI failed to start")
+
+    async def _billing_loop(self, instance: ComfyInstance):
+        """Charge one GPU-minute per tick while the instance is up."""
+        tick = 0
+        while not instance.stopped:
+            await asyncio.sleep(BILLING_INTERVAL)
+            if instance.stopped or not self._is_billable(instance):
+                continue
+            tick += 1
+            try:
+                await gooey_client.record_usage(
+                    uid=instance.uid,
+                    workspace_id=instance.workspace_id,
+                    gpu_ms=BILLING_INTERVAL * 1000,
+                    # deterministic per tick: retries can never double-charge
+                    invoice_id=f"{instance.instance_id}/{tick}",
+                    note=f"ComfyUI GPU time ({settings.COMFY_BACKEND})",
+                )
+            except gooey_client.InsufficientCredits:
+                await self.stop(
+                    instance.workspace_id,
+                    reason="Workspace ran out of credits. "
+                    "Add credits on gooey.ai to continue.",
+                )
+                return
+            except Exception as e:
+                # transient billing-API failure: retry next tick with the same
+                # invoice sequence rather than killing the user's session
+                logger.exception(f"usage recording failed (tick {tick}): {e}")
+
+    async def _idle_reaper(self, instance: ComfyInstance):
+        while not instance.stopped:
+            await asyncio.sleep(30)
+            idle = time.time() - instance.last_active
+            if idle > settings.IDLE_TIMEOUT_SECONDS:
+                await self.stop(
+                    instance.workspace_id,
+                    reason=f"stopped after {int(idle / 60)} minutes of inactivity",
+                )
+                return
+
+    def _is_billable(self, instance: ComfyInstance) -> bool:
+        return instance.ready
+
+    async def _launch(self, instance: ComfyInstance):
+        raise NotImplementedError
+
+    async def _terminate(self, instance: ComfyInstance):
+        raise NotImplementedError
+
+
+class ModalBackend(BaseBackend):
+    """A dedicated Modal sandbox per workspace (see comfy_modal.py)."""
+
+    def __init__(self):
+        super().__init__()
+        self._sandboxes = {}
+
+    async def _launch(self, instance: ComfyInstance):
+        import comfy_modal
+
+        sandbox = await asyncio.to_thread(
+            comfy_modal.launch_sandbox,
+            instance.workspace_id,
+            gpu=settings.MODAL_GPU,
+        )
+        self._sandboxes[instance.workspace_id] = sandbox
+        instance.instance_id = sandbox.object_id
+        instance.url = await asyncio.to_thread(comfy_modal.sandbox_url, sandbox)
+
+    async def _terminate(self, instance: ComfyInstance):
+        sandbox = self._sandboxes.pop(instance.workspace_id, None)
+        if sandbox:
+            try:
+                await asyncio.to_thread(sandbox.terminate)
+            except Exception:
+                logger.exception("failed to terminate modal sandbox")
+
+
+class StaticBackend(BaseBackend):
+    """
+    A single fixed upstream ComfyUI shared by all workspaces (local dev, or a
+    self-managed GPU box). Billed per *active* minute since the GPU isn't
+    dedicated per workspace.
+    """
+
+    async def _launch(self, instance: ComfyInstance):
+        instance.instance_id = f"static-{instance.workspace_id}-{int(time.time())}"
+        instance.url = settings.STATIC_COMFY_URL.rstrip("/")
+
+    async def _terminate(self, instance: ComfyInstance):
+        pass  # nothing to tear down; the upstream keeps running
+
+    def _is_billable(self, instance: ComfyInstance) -> bool:
+        return (
+            instance.ready
+            and time.time() - instance.last_active < BILLING_INTERVAL * 2
+        )
+
+
+def make_backend() -> BaseBackend:
+    if settings.COMFY_BACKEND == "modal":
+        return ModalBackend()
+    return StaticBackend()

--- a/comfy/gateway/gooey_client.py
+++ b/comfy/gateway/gooey_client.py
@@ -1,0 +1,74 @@
+"""Server-to-server client for gooey-server's internal comfy API."""
+
+import httpx
+
+from gateway import settings
+
+
+class InsufficientCredits(Exception):
+    pass
+
+
+class GooeyAuthError(Exception):
+    pass
+
+
+_client = httpx.AsyncClient(
+    base_url=settings.GOOEY_API_BASE_URL,
+    headers={"Authorization": f"Bearer {settings.COMFY_SERVICE_TOKEN}"},
+    timeout=30,
+)
+
+
+async def verify_sso(token: str) -> dict:
+    r = await _client.post("/__/comfy/api/verify-sso/", json={"token": token})
+    if r.status_code == 401:
+        raise GooeyAuthError(_error_msg(r))
+    r.raise_for_status()
+    return r.json()
+
+
+async def get_user(uid: str) -> dict:
+    r = await _client.get(f"/__/comfy/api/users/{uid}/")
+    if r.status_code == 401:
+        raise GooeyAuthError(_error_msg(r))
+    r.raise_for_status()
+    return r.json()
+
+
+async def record_usage(
+    *, uid: str, workspace_id: int, gpu_ms: int, invoice_id: str, note: str = ""
+) -> dict:
+    r = await _client.post(
+        "/__/comfy/api/usage/",
+        json={
+            "uid": uid,
+            "workspace_id": workspace_id,
+            "gpu_ms": gpu_ms,
+            "invoice_id": invoice_id,
+            "note": note,
+        },
+    )
+    if r.status_code == 402:
+        raise InsufficientCredits(_error_msg(r))
+    if r.status_code == 401:
+        raise GooeyAuthError(_error_msg(r))
+    r.raise_for_status()
+    return r.json()
+
+
+async def get_balance(*, uid: str, workspace_id: int) -> int:
+    r = await _client.get(
+        f"/__/comfy/api/workspaces/{workspace_id}/balance/", params={"uid": uid}
+    )
+    if r.status_code == 401:
+        raise GooeyAuthError(_error_msg(r))
+    r.raise_for_status()
+    return r.json()["balance"]
+
+
+def _error_msg(r: httpx.Response) -> str:
+    try:
+        return r.json()["detail"]["error"]
+    except Exception:
+        return r.text

--- a/comfy/gateway/header.py
+++ b/comfy/gateway/header.py
@@ -1,0 +1,148 @@
+"""
+The Gooey header bar injected on top of the ComfyUI web app.
+
+Injected as a <style> + <script> block into ComfyUI's index.html by the proxy
+(script-based DOM insertion survives any changes to ComfyUI's markup). The bar
+shows the Gooey logo, a workspace switcher, live credit balance, and the
+logged-in user, and pushes the ComfyUI app down below itself.
+"""
+
+import json
+
+from gateway import settings
+
+HEADER_HEIGHT = 44
+
+
+def render_snippet(session: dict) -> str:
+    boot = json.dumps(
+        {
+            "displayName": session["display_name"],
+            "photoUrl": session["photo_url"],
+            "workspaces": session["workspaces"],
+            "selectedWorkspaceId": session["selected_workspace_id"],
+            "appBaseUrl": settings.GOOEY_APP_BASE_URL,
+            "logoUrl": settings.GOOEY_LOGO_IMG_WHITE,
+            "headerHeight": HEADER_HEIGHT,
+        }
+    )
+    return STYLE + f"<script>window.__GOOEY__ = {boot};</script>" + SCRIPT
+
+
+STYLE = f"""
+<style id="gooey-header-style">
+  html {{ --gooey-header-h: {HEADER_HEIGHT}px; }}
+  body {{
+    margin-top: {HEADER_HEIGHT}px !important;
+    height: calc(100% - {HEADER_HEIGHT}px) !important;
+  }}
+  #vue-app, #app {{ height: calc(100vh - {HEADER_HEIGHT}px) !important; }}
+  #gooey-header {{
+    position: fixed; top: 0; left: 0; right: 0; height: {HEADER_HEIGHT}px;
+    z-index: 99999; display: flex; align-items: center; gap: 12px;
+    padding: 0 12px; box-sizing: border-box;
+    background: #02023e; color: #fff;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    font-size: 13px; border-bottom: 1px solid rgba(255,255,255,.15);
+  }}
+  #gooey-header a {{ color: #fff; text-decoration: none; opacity: .9; }}
+  #gooey-header a:hover {{ opacity: 1; text-decoration: underline; }}
+  #gooey-header img.gooey-logo {{ height: 22px; }}
+  #gooey-header .gooey-tag {{
+    background: rgba(255,255,255,.15); border-radius: 4px; padding: 2px 6px;
+    font-weight: 600; letter-spacing: .3px;
+  }}
+  #gooey-header .gooey-spacer {{ flex: 1; }}
+  #gooey-header select {{
+    background: rgba(255,255,255,.1); color: #fff; border: 1px solid
+    rgba(255,255,255,.25); border-radius: 6px; padding: 3px 6px; font-size: 13px;
+    max-width: 220px;
+  }}
+  #gooey-header select option {{ color: #000; }}
+  #gooey-header .gooey-credits {{ white-space: nowrap; }}
+  #gooey-header img.gooey-avatar {{
+    height: 26px; width: 26px; border-radius: 50%; object-fit: cover;
+  }}
+</style>
+"""
+
+SCRIPT = """
+<script id="gooey-header-script">
+(function () {
+  var G = window.__GOOEY__;
+  function fmt(n) { return n.toLocaleString(); }
+
+  function build() {
+    if (document.getElementById("gooey-header")) return;
+    var bar = document.createElement("div");
+    bar.id = "gooey-header";
+
+    var options = G.workspaces.map(function (w) {
+      var sel = w.id === G.selectedWorkspaceId ? " selected" : "";
+      return "<option value='" + w.id + "'" + sel + "></option>";
+    }).join("");
+
+    bar.innerHTML =
+      "<a href='" + G.appBaseUrl + "' title='Back to Gooey.AI'>" +
+        "<img class='gooey-logo' alt='Gooey.AI' src='" + G.logoUrl + "'/></a>" +
+      "<span class='gooey-tag'>ComfyUI</span>" +
+      "<span class='gooey-spacer'></span>" +
+      "<label>Workspace <select id='gooey-workspace-select'>" + options +
+        "</select></label>" +
+      "<span class='gooey-credits' id='gooey-credits'></span>" +
+      "<a href='" + G.appBaseUrl + "/account/' target='_blank'>Add credits</a>" +
+      "<img class='gooey-avatar' id='gooey-avatar' alt=''/>" +
+      "<span id='gooey-username'></span>" +
+      "<a href='/gooey/logout'>Logout</a>";
+    document.body.appendChild(bar);
+
+    // set user-controlled strings via textContent/attributes, never innerHTML
+    var select = document.getElementById("gooey-workspace-select");
+    G.workspaces.forEach(function (w, i) {
+      select.options[i].textContent = w.name;
+    });
+    document.getElementById("gooey-username").textContent = G.displayName;
+    document.getElementById("gooey-avatar").src = G.photoUrl;
+    renderCredits();
+
+    select.addEventListener("change", function () {
+      fetch("/gooey/switch-workspace", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ workspace_id: parseInt(select.value, 10) }),
+      }).then(function () { window.location.reload(); });
+    });
+
+    setInterval(refresh, 30000);
+  }
+
+  function renderCredits() {
+    var w = G.workspaces.find(function (w) {
+      return w.id === G.selectedWorkspaceId;
+    });
+    if (w) {
+      document.getElementById("gooey-credits").textContent =
+        fmt(w.balance) + " credits";
+    }
+  }
+
+  function refresh() {
+    fetch("/gooey/api/me").then(function (r) {
+      if (r.status === 401) { window.location.href = "/login"; return; }
+      return r.json();
+    }).then(function (me) {
+      if (!me) return;
+      G.workspaces = me.workspaces;
+      G.selectedWorkspaceId = me.selected_workspace_id;
+      renderCredits();
+    }).catch(function () {});
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", build);
+  } else {
+    build();
+  }
+})();
+</script>
+"""

--- a/comfy/gateway/main.py
+++ b/comfy/gateway/main.py
@@ -21,7 +21,7 @@ from urllib.parse import quote
 
 from fastapi import FastAPI, Request, WebSocket
 from pydantic import BaseModel
-from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
+from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse
 
 from gateway import backends, gooey_client, header, proxy, sessions, settings
 
@@ -36,7 +36,9 @@ async def lifespan(app: FastAPI):
     await backend.shutdown()
 
 
-app = FastAPI(title="Gooey ComfyUI Gateway", docs_url=None, redoc_url=None, lifespan=lifespan)
+app = FastAPI(
+    title="Gooey ComfyUI Gateway", docs_url=None, redoc_url=None, lifespan=lifespan
+)
 
 
 def sso_redirect(next_path: str = "/") -> RedirectResponse:

--- a/comfy/gateway/main.py
+++ b/comfy/gateway/main.py
@@ -1,0 +1,209 @@
+"""
+The comfy.gooey.ai gateway.
+
+Run locally:
+
+```bash
+cd comfy
+pip install -r requirements.txt
+COMFY_BACKEND=static STATIC_COMFY_URL=http://localhost:8188 \\
+    SECRET_KEY=dev COMFY_SERVICE_TOKEN=dev \\
+    GOOEY_APP_BASE_URL=http://localhost:3000 \\
+    GOOEY_API_BASE_URL=http://localhost:8080 \\
+    uvicorn gateway.main:app --port 8501 --reload
+```
+"""
+
+import html
+import logging
+from contextlib import asynccontextmanager
+from urllib.parse import quote
+
+from fastapi import FastAPI, Request, WebSocket
+from pydantic import BaseModel
+from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
+
+from gateway import backends, gooey_client, header, proxy, sessions, settings
+
+logging.basicConfig(level=logging.INFO)
+
+backend = backends.make_backend()
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    yield
+    await backend.shutdown()
+
+
+app = FastAPI(title="Gooey ComfyUI Gateway", docs_url=None, redoc_url=None, lifespan=lifespan)
+
+
+def sso_redirect(next_path: str = "/") -> RedirectResponse:
+    return RedirectResponse(
+        f"{settings.GOOEY_APP_BASE_URL}/comfy/sso/?next={quote(next_path)}"
+    )
+
+
+@app.get("/healthz")
+async def healthz():
+    return {"status": "ok"}
+
+
+@app.get("/login")
+async def login(request: Request):
+    return sso_redirect(request.query_params.get("next") or "/")
+
+
+@app.get("/auth/callback")
+async def auth_callback(token: str, next: str = "/"):
+    try:
+        user_info = await gooey_client.verify_sso(token)
+    except gooey_client.GooeyAuthError as e:
+        return _error_page("Login failed", str(e), status_code=401)
+    if not next.startswith("/") or next.startswith("//"):
+        next = "/"
+    response = RedirectResponse(next)
+    sessions.set_session(response, sessions.session_from_user_info(user_info))
+    return response
+
+
+@app.get("/gooey/logout")
+async def logout():
+    response = RedirectResponse(settings.GOOEY_APP_BASE_URL)
+    sessions.clear_session(response)
+    return response
+
+
+@app.get("/gooey/api/me")
+async def me(request: Request):
+    session = sessions.get_session(request)
+    if not session:
+        return JSONResponse({"error": "not logged in"}, status_code=401)
+    try:
+        user_info = await gooey_client.get_user(session["uid"])
+    except gooey_client.GooeyAuthError as e:
+        response = JSONResponse({"error": str(e)}, status_code=401)
+        sessions.clear_session(response)
+        return response
+    session = sessions.session_from_user_info(
+        user_info, session["selected_workspace_id"]
+    )
+    response = JSONResponse(dict(session))
+    sessions.set_session(response, session)
+    return response
+
+
+class SwitchWorkspaceRequest(BaseModel):
+    workspace_id: int
+
+
+@app.post("/gooey/switch-workspace")
+async def switch_workspace(request: Request, payload: SwitchWorkspaceRequest):
+    session = sessions.get_session(request)
+    if not session:
+        return JSONResponse({"error": "not logged in"}, status_code=401)
+    if payload.workspace_id not in [w["id"] for w in session["workspaces"]]:
+        return JSONResponse({"error": "not a member of this workspace"}, 403)
+    session["selected_workspace_id"] = payload.workspace_id
+    response = JSONResponse({"ok": True})
+    sessions.set_session(response, session)
+    return response
+
+
+@app.websocket("/ws")
+async def websocket_proxy(ws: WebSocket):
+    session = sessions.get_session(ws)
+    if not session:
+        await ws.close(code=4401)
+        return
+    instance = backend.get(session["selected_workspace_id"])
+    if not instance or not instance.ready:
+        await ws.close(code=4404)
+        return
+    instance.touch()
+    await proxy.proxy_websocket(ws, instance.url)
+
+
+@app.api_route(
+    "/{path:path}",
+    methods=["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"],
+)
+async def comfy_proxy(request: Request, path: str):
+    session = sessions.get_session(request)
+    if not session:
+        if request.method == "GET" and _is_navigation(request):
+            return sso_redirect("/" + path)
+        return JSONResponse({"error": "not logged in"}, status_code=401)
+
+    workspace_id = session["selected_workspace_id"]
+    try:
+        instance = await backend.get_or_launch(workspace_id, session["uid"])
+    except gooey_client.InsufficientCredits as e:
+        return _error_page(
+            "Insufficient credits",
+            f"{html.escape(str(e))} <br/><br/>"
+            f"<a style='color:#fff' href='{settings.GOOEY_APP_BASE_URL}/account/'>"
+            "Add credits on Gooey.AI</a>",
+            status_code=402,
+            escape=False,
+        )
+    except gooey_client.GooeyAuthError as e:
+        response = _error_page("Session expired", str(e), status_code=401)
+        sessions.clear_session(response)
+        return response
+
+    if not instance.ready:
+        return _starting_page()
+
+    instance.touch()
+    inject = None
+    if request.method == "GET" and _is_navigation(request):
+        inject = header.render_snippet(session)
+    return await proxy.proxy_http(request, instance.url, inject_html=inject)
+
+
+def _is_navigation(request: Request) -> bool:
+    return "text/html" in request.headers.get("accept", "")
+
+
+def _starting_page() -> HTMLResponse:
+    return HTMLResponse(
+        """
+        <html><head><meta http-equiv="refresh" content="3">
+        <title>Starting ComfyUI — Gooey.AI</title></head>
+        <body style="font-family:sans-serif;background:#02023e;color:#fff;
+                     display:flex;align-items:center;justify-content:center;
+                     height:100vh;margin:0;text-align:center">
+          <div>
+            <img src="{logo}" style="height:40px"/><br/><br/>
+            <h2>Starting your ComfyUI workspace &hellip;</h2>
+            <p>Provisioning a GPU &mdash; this usually takes under a minute.<br/>
+               This page refreshes automatically.</p>
+          </div>
+        </body></html>
+        """.format(logo=settings.GOOEY_LOGO_IMG_WHITE),
+        status_code=503,
+    )
+
+
+def _error_page(
+    title: str, message: str, status_code: int, escape: bool = True
+) -> HTMLResponse:
+    if escape:
+        message = html.escape(message)
+    return HTMLResponse(
+        f"""
+        <html><head><title>{html.escape(title)} — Gooey.AI</title></head>
+        <body style="font-family:sans-serif;background:#02023e;color:#fff;
+                     display:flex;align-items:center;justify-content:center;
+                     height:100vh;margin:0;text-align:center">
+          <div>
+            <h2>{html.escape(title)}</h2>
+            <p>{message}</p>
+            <p><a style="color:#fff" href="/">Try again</a></p>
+          </div>
+        </body></html>
+        """,
+        status_code=status_code,
+    )

--- a/comfy/gateway/proxy.py
+++ b/comfy/gateway/proxy.py
@@ -32,9 +32,7 @@ _client = httpx.AsyncClient(timeout=httpx.Timeout(60, read=600), follow_redirect
 
 
 def _clean_headers(headers) -> dict:
-    return {
-        k: v for k, v in headers.items() if k.lower() not in HOP_BY_HOP_HEADERS
-    }
+    return {k: v for k, v in headers.items() if k.lower() not in HOP_BY_HOP_HEADERS}
 
 
 async def proxy_http(

--- a/comfy/gateway/proxy.py
+++ b/comfy/gateway/proxy.py
@@ -1,0 +1,127 @@
+"""Reverse proxy (HTTP + WebSocket) from the gateway to a ComfyUI instance."""
+
+import asyncio
+import logging
+
+import httpx
+import websockets
+from fastapi import Request, WebSocket, WebSocketDisconnect
+from starlette.background import BackgroundTask
+from starlette.responses import Response, StreamingResponse
+
+logger = logging.getLogger("comfy.proxy")
+
+HOP_BY_HOP_HEADERS = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+    "host",
+    # our session cookie must never leave the gateway
+    "cookie",
+    # recomputed when we rewrite HTML
+    "content-length",
+    "content-encoding",
+}
+
+_client = httpx.AsyncClient(timeout=httpx.Timeout(60, read=600), follow_redirects=False)
+
+
+def _clean_headers(headers) -> dict:
+    return {
+        k: v for k, v in headers.items() if k.lower() not in HOP_BY_HOP_HEADERS
+    }
+
+
+async def proxy_http(
+    request: Request, upstream_base: str, inject_html: str | None = None
+) -> Response:
+    url = upstream_base + request.url.path
+    if request.url.query:
+        url += "?" + request.url.query
+
+    upstream_request = _client.build_request(
+        method=request.method,
+        url=url,
+        headers=_clean_headers(request.headers),
+        content=request.stream(),
+    )
+    upstream = await _client.send(upstream_request, stream=True)
+
+    content_type = upstream.headers.get("content-type", "")
+    if inject_html and "text/html" in content_type:
+        body = await upstream.aread()
+        await upstream.aclose()
+        html = body.decode("utf-8", errors="replace")
+        idx = html.lower().find("</head>")
+        if idx == -1:
+            html = inject_html + html
+        else:
+            html = html[:idx] + inject_html + html[idx:]
+        return Response(
+            content=html,
+            status_code=upstream.status_code,
+            headers=_clean_headers(upstream.headers),
+            media_type=content_type,
+        )
+
+    return StreamingResponse(
+        upstream.aiter_raw(),
+        status_code=upstream.status_code,
+        headers=_clean_headers(upstream.headers),
+        background=BackgroundTask(upstream.aclose),
+    )
+
+
+async def proxy_websocket(ws: WebSocket, upstream_base: str):
+    """Bridge the browser's /ws connection to the upstream ComfyUI websocket."""
+    upstream_url = upstream_base.replace("http", "ws", 1) + ws.url.path
+    if ws.url.query:
+        upstream_url += "?" + ws.url.query
+
+    await ws.accept()
+    try:
+        async with websockets.connect(
+            upstream_url, max_size=64 * 1024 * 1024
+        ) as upstream:
+            client_to_upstream = asyncio.create_task(_pump_client(ws, upstream))
+            upstream_to_client = asyncio.create_task(_pump_upstream(ws, upstream))
+            done, pending = await asyncio.wait(
+                [client_to_upstream, upstream_to_client],
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for task in pending:
+                task.cancel()
+    except Exception as e:
+        logger.debug(f"websocket bridge closed: {e!r}")
+    finally:
+        try:
+            await ws.close()
+        except RuntimeError:
+            pass
+
+
+async def _pump_client(ws: WebSocket, upstream):
+    while True:
+        message = await ws.receive()
+        if message["type"] == "websocket.disconnect":
+            return
+        if message.get("text") is not None:
+            await upstream.send(message["text"])
+        elif message.get("bytes") is not None:
+            await upstream.send(message["bytes"])
+
+
+async def _pump_upstream(ws: WebSocket, upstream):
+    try:
+        async for message in upstream:
+            if isinstance(message, bytes):
+                await ws.send_bytes(message)
+            else:
+                await ws.send_text(message)
+    except WebSocketDisconnect:
+        pass

--- a/comfy/gateway/sessions.py
+++ b/comfy/gateway/sessions.py
@@ -1,0 +1,59 @@
+"""Signed-cookie sessions for the gateway (mirrors gooey-server's approach)."""
+
+import typing
+
+from fastapi import Request, Response
+from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
+
+from gateway import settings
+
+_signer = URLSafeTimedSerializer(settings.SECRET_KEY, salt="comfy-gateway-session")
+
+
+class Session(typing.TypedDict):
+    uid: str
+    display_name: str
+    photo_url: str
+    workspaces: list[dict]  # [{id, name, balance, is_personal, photo_url}]
+    selected_workspace_id: int
+
+
+def get_session(request: Request) -> Session | None:
+    cookie = request.cookies.get(settings.SESSION_COOKIE)
+    if not cookie:
+        return None
+    try:
+        return _signer.loads(cookie, max_age=settings.SESSION_MAX_AGE)
+    except (BadSignature, SignatureExpired):
+        return None
+
+
+def set_session(response: Response, session: Session):
+    response.set_cookie(
+        settings.SESSION_COOKIE,
+        _signer.dumps(session),
+        max_age=settings.SESSION_MAX_AGE,
+        httponly=True,
+        samesite="lax",
+        secure=settings.COMFY_BASE_URL.startswith("https"),
+    )
+
+
+def clear_session(response: Response):
+    response.delete_cookie(settings.SESSION_COOKIE)
+
+
+def session_from_user_info(
+    user_info: dict, selected_workspace_id: int | None = None
+) -> Session:
+    workspaces = user_info["workspaces"]
+    workspace_ids = [w["id"] for w in workspaces]
+    if selected_workspace_id not in workspace_ids:
+        selected_workspace_id = workspace_ids[0]
+    return Session(
+        uid=user_info["uid"],
+        display_name=user_info["display_name"],
+        photo_url=user_info["photo_url"],
+        workspaces=workspaces,
+        selected_workspace_id=selected_workspace_id,
+    )

--- a/comfy/gateway/settings.py
+++ b/comfy/gateway/settings.py
@@ -1,0 +1,29 @@
+from decouple import config
+
+# where this gateway is served from (used in absolute redirects)
+COMFY_BASE_URL = config("COMFY_BASE_URL", "http://localhost:8501")
+
+# the main gooey.ai app (browser-facing; hosts /comfy/sso/)
+GOOEY_APP_BASE_URL = config("GOOEY_APP_BASE_URL", "https://gooey.ai")
+# the gooey-server API host (server-to-server; hosts /__/comfy/api/*)
+GOOEY_API_BASE_URL = config("GOOEY_API_BASE_URL", "https://api.gooey.ai")
+# shared bearer token — must match COMFY_SERVICE_TOKEN on gooey-server
+COMFY_SERVICE_TOKEN = config("COMFY_SERVICE_TOKEN")
+
+# signs the gateway's own session cookie
+SECRET_KEY = config("SECRET_KEY")
+SESSION_COOKIE = "comfy_session"
+SESSION_MAX_AGE = 14 * 24 * 60 * 60
+
+# "modal" (per-workspace Modal sandboxes) or "static" (one fixed upstream,
+# e.g. a RunPod/self-hosted ComfyUI — useful for local dev)
+COMFY_BACKEND = config("COMFY_BACKEND", "modal")
+STATIC_COMFY_URL = config("STATIC_COMFY_URL", "http://localhost:8188")
+MODAL_GPU = config("MODAL_GPU", "L4")
+
+# stop a workspace's instance after this much time with no proxy traffic
+IDLE_TIMEOUT_SECONDS = config("IDLE_TIMEOUT_SECONDS", 15 * 60, cast=int)
+# refuse to launch an instance if the workspace balance is below this
+MIN_CREDITS_TO_LAUNCH = config("MIN_CREDITS_TO_LAUNCH", 10, cast=int)
+
+GOOEY_LOGO_IMG_WHITE = "https://storage.googleapis.com/dara-c1b52.appspot.com/daras_ai/media/ea26bc06-7eda-11ef-89fa-02420a0001f6/gooey-white-logo.png"

--- a/comfy/gateway/settings.py
+++ b/comfy/gateway/settings.py
@@ -15,11 +15,19 @@ SECRET_KEY = config("SECRET_KEY")
 SESSION_COOKIE = "comfy_session"
 SESSION_MAX_AGE = 14 * 24 * 60 * 60
 
-# "modal" (per-workspace Modal sandboxes) or "static" (one fixed upstream,
-# e.g. a RunPod/self-hosted ComfyUI — useful for local dev)
+# "modal"  — per-workspace Modal sandboxes (production)
+# "local"  — per-workspace local ComfyUI subprocesses via comfy-cli, using the
+#            local GPU if present (local installs that don't want Modal)
+# "static" — one fixed upstream ComfyUI shared by everyone
 COMFY_BACKEND = config("COMFY_BACKEND", "modal")
 STATIC_COMFY_URL = config("STATIC_COMFY_URL", "http://localhost:8188")
 MODAL_GPU = config("MODAL_GPU", "L4")
+
+# local backend: where per-workspace models/outputs live, first port to
+# allocate, and whether to meter credits (off by default — own hardware)
+COMFY_LOCAL_DATA_DIR = config("COMFY_LOCAL_DATA_DIR", "~/.gooey-comfy")
+COMFY_LOCAL_PORT_START = config("COMFY_LOCAL_PORT_START", 8190, cast=int)
+COMFY_LOCAL_BILLING = config("COMFY_LOCAL_BILLING", False, cast=bool)
 
 # stop a workspace's instance after this much time with no proxy traffic
 IDLE_TIMEOUT_SECONDS = config("IDLE_TIMEOUT_SECONDS", 15 * 60, cast=int)

--- a/comfy/gateway/settings.py
+++ b/comfy/gateway/settings.py
@@ -19,7 +19,11 @@ SESSION_MAX_AGE = 14 * 24 * 60 * 60
 # "local"  — per-workspace local ComfyUI subprocesses via comfy-cli, using the
 #            local GPU if present (local installs that don't want Modal)
 # "static" — one fixed upstream ComfyUI shared by everyone
-COMFY_BACKEND = config("COMFY_BACKEND", "modal")
+# gooey-server's global MODAL_RUN_LOCALLY flag flips the default to "local"
+COMFY_BACKEND = config(
+    "COMFY_BACKEND",
+    "local" if config("MODAL_RUN_LOCALLY", False, cast=bool) else "modal",
+)
 STATIC_COMFY_URL = config("STATIC_COMFY_URL", "http://localhost:8188")
 MODAL_GPU = config("MODAL_GPU", "L4")
 

--- a/comfy/requirements.txt
+++ b/comfy/requirements.txt
@@ -1,0 +1,8 @@
+fastapi~=0.115
+uvicorn[standard]~=0.30
+httpx~=0.27
+websockets~=13.1
+itsdangerous~=2.2
+python-decouple~=3.8
+pydantic~=2.8
+modal~=1.0

--- a/configuration.md
+++ b/configuration.md
@@ -231,11 +231,21 @@ See [README.md § Functions runtime](README.md#%EF%B8%8F-functions-runtime-cloud
 
 ## Modal (serverless GPU)
 
-| Variable             | Description                   |
-| -------------------- | ----------------------------- |
-| `MODAL_TOKEN_ID`     | Modal token ID                |
-| `MODAL_TOKEN_SECRET` | Modal token secret            |
-| `MODAL_VLLM_API_KEY` | API key for Modal-hosted vLLM |
+| Variable                | Description                                                                                                                                                                                             |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MODAL_TOKEN_ID`        | Modal token ID                                                                                                                                                                                           |
+| `MODAL_TOKEN_SECRET`    | Modal token secret                                                                                                                                                                                       |
+| `MODAL_VLLM_API_KEY`    | API key for Modal-hosted vLLM                                                                                                                                                                            |
+| `MODAL_RUN_LOCALLY`     | Set to `1` to run every Modal workload (`modal_functions/*`) in-process on this machine instead of on Modal's cloud, using the local GPU if available. No Modal account needed. See `daras_ai_v2/modal_utils.py` |
+| `MODAL_LOCAL_WEB_URL`   | With `MODAL_RUN_LOCALLY` on, Modal web endpoints (the agri_llm vLLM server) resolve to this URL (default `http://localhost:8000`) — run the equivalent server yourself, e.g. `vllm serve ... --port 8000` |
+| `MODAL_LOCAL_CACHE_DIR` | With `MODAL_RUN_LOCALLY` on, where locally-run model weights are cached (default `/cache`, the Modal volume path — point it at e.g. `~/.cache/gooey-models` on a dev machine)                             |
+
+Notes on `MODAL_RUN_LOCALLY`: model weights are downloaded to this machine on
+first use, and models that hard-require CUDA (e.g. Omnilingual ASR) need a
+local NVIDIA GPU. `modal.Sandbox` usage (functions code-execution, ComfyUI
+cloud) is intentionally *not* switched — sandboxes isolate untrusted code and
+must not silently run on the host. The ComfyUI gateway instead defaults to its
+own `COMFY_BACKEND=local` mode when this flag is set (see `comfy/README.md`).
 
 ---
 

--- a/daras_ai_v2/asr.py
+++ b/daras_ai_v2/asr.py
@@ -1423,13 +1423,14 @@ def run_asr(
         return r.json()["transcription_text"]
     elif selected_model == AsrModels.meta_omnilingual_asr_llm_7b:
         import modal
-        from modal_functions.meta_omnilingual_asr import app as modal_app
+        from modal_functions import meta_omnilingual_asr
+        from daras_ai_v2.modal_utils import get_modal_cls
 
         # Ensure language is in the correct format (e.g., "eng_Latn")
         if language and language not in OMNILINGUAL_ASR_SUPPORTED:
             raise UserError(f"Unsupported language: {language}")
 
-        Omnilingual = modal.Cls.from_name(modal_app.name, "Omnilingual")
+        Omnilingual = get_modal_cls(meta_omnilingual_asr, "Omnilingual")
         with modal.enable_output():
             transcription = Omnilingual().run.remote(
                 audio_url=audio_url, language=language
@@ -1437,14 +1438,15 @@ def run_asr(
         return transcription
     elif selected_model == AsrModels.sravaani_v1:
         import modal
-        from modal_functions.sravaani_asr import app as modal_app
+        from modal_functions import sravaani_asr
+        from daras_ai_v2.modal_utils import get_modal_cls
 
         # SraVaani identifies the spoken language automatically, so the
         # selected language is only validated, not passed to the model
         if language:
             normalised_lang_in_collection(language, SRAVAANI_SUPPORTED)
 
-        SraVaani = modal.Cls.from_name(modal_app.name, "SraVaani")
+        SraVaani = get_modal_cls(sravaani_asr, "SraVaani")
         with modal.enable_output():
             data = SraVaani().run.remote(
                 audio_url=audio_url,

--- a/daras_ai_v2/language_model.py
+++ b/daras_ai_v2/language_model.py
@@ -1370,14 +1370,13 @@ def get_openai_client(
             default_headers={"User-Agent": "gooey/openai-sdk"},
         )
     elif model.startswith("AI71ai/"):
-        import modal
-        from modal_functions.agri_llm import app
+        from modal_functions import agri_llm
+        from daras_ai_v2.modal_utils import get_modal_web_url
 
-        modal_fn = modal.Function.from_name(app.name, "serve")
         client = openai.OpenAI(
             api_key=settings.MODAL_VLLM_API_KEY,
             max_retries=0,
-            base_url=str(furl(modal_fn.get_web_url()) / "v1"),
+            base_url=str(furl(get_modal_web_url(agri_llm, "serve")) / "v1"),
         )
     elif model.startswith("mistral-"):
         client = openai.OpenAI(

--- a/daras_ai_v2/modal_utils.py
+++ b/daras_ai_v2/modal_utils.py
@@ -1,0 +1,84 @@
+"""
+Helpers for calling Modal workloads (modal_functions/*), honoring the global
+settings.MODAL_RUN_LOCALLY flag.
+
+With the flag off (default), lookups go to the deployed Modal apps and run on
+Modal's cloud. With the flag on, the same calls execute in-process on this
+machine via modal's `.local()` — using the local GPU if the model code finds
+one — so local installs can run every Modal-backed feature without a Modal
+account. Call sites keep the standard `.remote()` spelling; the proxies below
+reroute it.
+
+Not covered by the flag: `modal.Sandbox` usage (recipes/Functions.py code
+execution, the ComfyUI cloud sandboxes) — those exist to isolate untrusted
+code, so silently running them on the host would be unsafe. The ComfyUI
+gateway has its own COMFY_BACKEND=local mode (comfy/README.md), which this
+flag switches on by default.
+
+### Usage
+
+```python
+from daras_ai_v2.modal_utils import get_modal_fn, get_modal_cls
+from modal_functions import mms_tts, sravaani_asr
+
+get_modal_fn(mms_tts, "run_mms_tts").remote(language="eng", text=...)
+get_modal_cls(sravaani_asr, "SraVaani")().run.remote(audio_url=...)
+```
+"""
+
+import typing
+
+import modal
+
+from daras_ai_v2 import settings
+
+
+def get_modal_fn(app_module: typing.Any, name: str):
+    """A modal Function with `.remote()`, local or cloud per MODAL_RUN_LOCALLY."""
+    if settings.MODAL_RUN_LOCALLY:
+        return _LocalCallableProxy(getattr(app_module, name))
+    return modal.Function.from_name(app_module.app.name, name)
+
+
+def get_modal_cls(app_module: typing.Any, name: str):
+    """A modal Cls whose instance methods support `.remote()`, local or cloud."""
+    if settings.MODAL_RUN_LOCALLY:
+        return _LocalClsProxy(getattr(app_module, name))
+    return modal.Cls.from_name(app_module.app.name, name)
+
+
+def get_modal_web_url(app_module: typing.Any, name: str) -> str:
+    """
+    URL of a modal web endpoint. Web servers (e.g. the agri_llm vLLM server)
+    can't be run in-process, so in local mode this points at
+    settings.MODAL_LOCAL_WEB_URL — start the equivalent server yourself, e.g.:
+
+        vllm serve AI71ai/agri-fanar-27b-chat --port 8000
+    """
+    if settings.MODAL_RUN_LOCALLY:
+        return settings.MODAL_LOCAL_WEB_URL
+    return modal.Function.from_name(app_module.app.name, name).get_web_url()
+
+
+class _LocalCallableProxy:
+    def __init__(self, fn):
+        self._fn = fn
+
+    def remote(self, *args, **kwargs):
+        return self._fn.local(*args, **kwargs)
+
+
+class _LocalObjProxy:
+    def __init__(self, obj):
+        self._obj = obj
+
+    def __getattr__(self, name):
+        return _LocalCallableProxy(getattr(self._obj, name))
+
+
+class _LocalClsProxy:
+    def __init__(self, cls):
+        self._cls = cls
+
+    def __call__(self, *args, **kwargs):
+        return _LocalObjProxy(self._cls(*args, **kwargs))

--- a/daras_ai_v2/settings.py
+++ b/daras_ai_v2/settings.py
@@ -346,6 +346,12 @@ HEADER_ICONS = {
     DOCS_URL: "fa-regular fa-book",
 }
 
+# ComfyUI cloud (comfy.gooey.ai) — see comfy/README.md
+COMFY_BASE_URL = config("COMFY_BASE_URL", "http://localhost:8501")
+# shared bearer token that authenticates the comfy gateway to the internal comfy API
+COMFY_SERVICE_TOKEN = config("COMFY_SERVICE_TOKEN", None)
+COMFY_CREDITS_PER_GPU_MINUTE = config("COMFY_CREDITS_PER_GPU_MINUTE", 10, cast=int)
+
 SERPER_API_KEY = config("SERPER_API_KEY", None)
 GOOGLE_GEOCODING_API_KEY = config("GOOGLE_GEOCODING_API_KEY", default="")
 GOOGLE_MAPS_API_KEY = config("GOOGLE_MAPS_API_KEY", default="")

--- a/daras_ai_v2/settings.py
+++ b/daras_ai_v2/settings.py
@@ -567,6 +567,15 @@ if MODAL_TOKEN_ID and MODAL_TOKEN_SECRET:
 
 MODAL_VLLM_API_KEY = config("MODAL_VLLM_API_KEY", "")
 
+# run all Modal workloads (modal_functions/*) in-process on this machine
+# instead of on Modal's cloud, using the local GPU if available.
+# see daras_ai_v2/modal_utils.py
+MODAL_RUN_LOCALLY = config("MODAL_RUN_LOCALLY", False, cast=bool)
+# modal web endpoints (the agri_llm vLLM server) can't run in-process; when
+# MODAL_RUN_LOCALLY is on they resolve to this URL instead — run the
+# equivalent server yourself (e.g. `vllm serve ... --port 8000`)
+MODAL_LOCAL_WEB_URL = config("MODAL_LOCAL_WEB_URL", "http://localhost:8000")
+
 HF_TOKEN = config("HF_TOKEN", "")
 
 os.environ["LIVEKIT_API_KEY"] = config("LIVEKIT_API_KEY", "")

--- a/livekit_agent.py
+++ b/livekit_agent.py
@@ -487,12 +487,11 @@ async def create_stt_llm_tts_session(
                 api_key = settings.PUBLICAI_API_KEY
                 base_url = "https://api.publicai.co/v1"
             elif model_id.startswith("AI71ai/"):
-                import modal
-                from modal_functions.agri_llm import app
+                from modal_functions import agri_llm
+                from daras_ai_v2.modal_utils import get_modal_web_url
 
-                modal_fn = modal.Function.from_name(app.name, "serve")
                 api_key = settings.MODAL_VLLM_API_KEY
-                base_url = str(furl(modal_fn.get_web_url()) / "v1")
+                base_url = str(furl(get_modal_web_url(agri_llm, "serve")) / "v1")
             else:
                 api_key = settings.OPENAI_API_KEY
                 base_url = NOT_GIVEN

--- a/modal_functions/sravaani_asr.py
+++ b/modal_functions/sravaani_asr.py
@@ -15,6 +15,8 @@ Note: the HuggingFace repo is gated, so a valid HF_TOKEN (with access granted to
 ARTPARK-IISc/SraVaani-1.0) must be set in the environment when deploying.
 """
 
+import os
+
 import modal
 from decouple import config
 
@@ -23,7 +25,9 @@ app = modal.App("gooey-sravaani-asr")
 SRAVAANI_MODEL_ID = "ARTPARK-IISc/SraVaani-1.0"
 SRAVAANI_MODEL_REVISION = "39c6add757f46af212d583ed765894ae78b2ebad"
 
-cache_dir = "/cache"
+# leave MODAL_LOCAL_CACHE_DIR unset when deploying — "/cache" is the modal
+# volume mount; the override is for MODAL_RUN_LOCALLY runs on a dev machine
+cache_dir = os.path.expanduser(config("MODAL_LOCAL_CACHE_DIR", "/cache"))
 model_cache = modal.Volume.from_name("hf-model-cache", create_if_missing=True)
 hf_secret = modal.Secret.from_dict({"HF_TOKEN": config("HF_TOKEN", "")})
 

--- a/recipes/TextToSpeech.py
+++ b/recipes/TextToSpeech.py
@@ -410,13 +410,14 @@ class TextToSpeechPage(BasePage):
                 from daras_ai_v2.tts_supported_languages import (
                     MMS_TTS_SUPPORTED_LANGUAGES,
                 )
-                from modal_functions.mms_tts import app as modal_app
+                from modal_functions import mms_tts
+                from daras_ai_v2.modal_utils import get_modal_fn
 
                 language = state.get("mms_tts_language", "eng")
                 if language not in MMS_TTS_SUPPORTED_LANGUAGES:
                     raise UserError(f"Unsupported language: {language}")
 
-                run_mms_tts = modal.Function.from_name(modal_app.name, "run_mms_tts")
+                run_mms_tts = get_modal_fn(mms_tts, "run_mms_tts")
                 with (
                     modal.enable_output(),
                     generate_signed_url("mms_tts_gen.wav", "audio/wav") as (

--- a/routers/base_auth.py
+++ b/routers/base_auth.py
@@ -53,4 +53,5 @@ SAFE_URLS = (
     settings.APP_BASE_URL,
     settings.API_BASE_URL,
     settings.ADMIN_BASE_URL,
+    settings.COMFY_BASE_URL,
 )

--- a/routers/comfy_api.py
+++ b/routers/comfy_api.py
@@ -1,0 +1,253 @@
+"""
+Integration endpoints for the ComfyUI cloud gateway (comfy.gooey.ai).
+
+The gateway is a separate service (see comfy/README.md). It relies on
+gooey-server for two things:
+
+1. Browser SSO: `GET /comfy/sso/` runs on gooey.ai where the user's session
+   cookie is visible, mints a short-lived signed token and redirects back to
+   the gateway, which exchanges it via the internal API below.
+
+2. Internal service API (`/__/comfy/api/*`): authenticated with the shared
+   `COMFY_SERVICE_TOKEN` bearer token. Lets the gateway resolve the user's
+   workspaces and bill GPU usage to a workspace using the same idempotent
+   `Workspace.add_balance` primitive used by recipe runs.
+"""
+
+import uuid
+from urllib.parse import urlparse
+
+import fastapi
+from fastapi import Depends, Header
+from furl import furl
+from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
+from pydantic import BaseModel
+from starlette.responses import RedirectResponse
+from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_402_PAYMENT_REQUIRED
+
+from app_users.models import AppUser
+from daras_ai_v2 import settings
+from routers.custom_api_router import CustomAPIRouter
+from workspaces.models import Workspace
+
+app = CustomAPIRouter()
+
+COMFY_SSO_SALT = "gooey-comfy-sso"
+COMFY_SSO_TOKEN_MAX_AGE = 5 * 60  # short-lived: only exists during the redirect
+
+_sso_signer = URLSafeTimedSerializer(settings.SECRET_KEY, salt=COMFY_SSO_SALT)
+
+
+## ---------------------------------------------------------------------------
+## Browser SSO handshake
+## ---------------------------------------------------------------------------
+
+
+@app.get("/comfy/sso/")
+def comfy_sso(request: fastapi.Request):
+    """
+    Entry point for logging into comfy.gooey.ai with the Gooey account.
+    Requires an active gooey.ai session; otherwise bounces via /login/ first.
+    """
+    from routers.base_auth import get_login_url
+
+    if not request.user or request.user.is_anonymous:
+        return RedirectResponse(get_login_url(request))
+
+    token = _sso_signer.dumps({"uid": request.user.uid})
+    callback = furl(settings.COMFY_BASE_URL).add(path="auth/callback")
+    callback.query.params["token"] = token
+
+    next_url = request.query_params.get("next")
+    if next_url and _is_comfy_relative_path(next_url):
+        callback.query.params["next"] = next_url
+
+    return RedirectResponse(str(callback))
+
+
+def _is_comfy_relative_path(next_url: str) -> bool:
+    # only allow paths on the comfy origin itself, never absolute URLs
+    parsed = urlparse(next_url)
+    return not parsed.scheme and not parsed.netloc and next_url.startswith("/")
+
+
+## ---------------------------------------------------------------------------
+## Internal service API (gateway -> gooey-server)
+## ---------------------------------------------------------------------------
+
+
+def comfy_service_auth(authorization: str = Header(default="")):
+    parts = authorization.split()
+    if (
+        not settings.COMFY_SERVICE_TOKEN
+        or len(parts) != 2
+        or parts[0].lower() != "bearer"
+        or parts[1] != settings.COMFY_SERVICE_TOKEN
+    ):
+        raise fastapi.HTTPException(
+            status_code=HTTP_401_UNAUTHORIZED,
+            detail={"error": "Invalid comfy service token."},
+        )
+
+
+class WorkspaceInfo(BaseModel):
+    id: int
+    name: str
+    balance: int
+    is_personal: bool
+    photo_url: str
+
+
+class ComfyUserInfo(BaseModel):
+    uid: str
+    display_name: str
+    email: str | None
+    photo_url: str
+    is_disabled: bool
+    workspaces: list[WorkspaceInfo]
+
+
+def _workspace_info(w: Workspace, user: AppUser) -> WorkspaceInfo:
+    return WorkspaceInfo(
+        id=w.id,
+        name=w.display_name(user),
+        balance=w.balance,
+        is_personal=w.is_personal,
+        photo_url=w.get_photo(),
+    )
+
+
+def _user_info(user: AppUser) -> ComfyUserInfo:
+    return ComfyUserInfo(
+        uid=user.uid,
+        display_name=user.display_name,
+        email=user.email,
+        photo_url=user.get_photo(),
+        is_disabled=user.is_disabled,
+        workspaces=[_workspace_info(w, user) for w in user.cached_workspaces],
+    )
+
+
+class VerifySsoRequest(BaseModel):
+    token: str
+
+
+@app.post(
+    "/__/comfy/api/verify-sso/",
+    dependencies=[Depends(comfy_service_auth)],
+    include_in_schema=False,
+)
+def comfy_verify_sso(payload: VerifySsoRequest) -> ComfyUserInfo:
+    try:
+        data = _sso_signer.loads(payload.token, max_age=COMFY_SSO_TOKEN_MAX_AGE)
+    except SignatureExpired:
+        raise fastapi.HTTPException(
+            status_code=HTTP_401_UNAUTHORIZED,
+            detail={"error": "SSO token expired. Please login again."},
+        )
+    except BadSignature:
+        raise fastapi.HTTPException(
+            status_code=HTTP_401_UNAUTHORIZED,
+            detail={"error": "Invalid SSO token."},
+        )
+    user = _get_user_or_401(data.get("uid") or "")
+    return _user_info(user)
+
+
+@app.get(
+    "/__/comfy/api/users/{uid}/",
+    dependencies=[Depends(comfy_service_auth)],
+    include_in_schema=False,
+)
+def comfy_get_user(uid: str) -> ComfyUserInfo:
+    """Refresh the user's profile + workspace balances (e.g. on workspace switch)."""
+    return _user_info(_get_user_or_401(uid))
+
+
+def _get_user_or_401(uid: str) -> AppUser:
+    try:
+        user = AppUser.objects.get(uid=uid)
+    except AppUser.DoesNotExist:
+        raise fastapi.HTTPException(
+            status_code=HTTP_401_UNAUTHORIZED,
+            detail={"error": "User not found."},
+        )
+    if user.is_disabled or user.is_anonymous:
+        raise fastapi.HTTPException(
+            status_code=HTTP_401_UNAUTHORIZED,
+            detail={"error": "This account cannot use ComfyUI cloud."},
+        )
+    return user
+
+
+class ComfyUsageRequest(BaseModel):
+    uid: str
+    workspace_id: int
+    gpu_ms: int
+    # deterministic id from the gateway (e.g. f"comfy_{sandbox_id}_{minute}") so
+    # retries never double-charge — add_balance is idempotent on invoice_id
+    invoice_id: str
+    note: str = ""
+
+
+class ComfyUsageResponse(BaseModel):
+    credits_charged: int
+    balance: int
+
+
+@app.post(
+    "/__/comfy/api/usage/",
+    dependencies=[Depends(comfy_service_auth)],
+    include_in_schema=False,
+)
+def comfy_record_usage(payload: ComfyUsageRequest) -> ComfyUsageResponse:
+    """
+    Bill metered ComfyUI GPU time to a workspace. Pricing stays server-side
+    (COMFY_CREDITS_PER_GPU_MINUTE) so the gateway only reports raw gpu_ms.
+    """
+    user = _get_user_or_401(payload.uid)
+    workspace = _get_workspace_for_member_or_401(payload.workspace_id, user)
+
+    credits = max(
+        1, round(settings.COMFY_CREDITS_PER_GPU_MINUTE * payload.gpu_ms / 60_000)
+    )
+    if workspace.balance <= 0:
+        raise fastapi.HTTPException(
+            status_code=HTTP_402_PAYMENT_REQUIRED,
+            detail={"error": "Insufficient credits.", "balance": workspace.balance},
+        )
+    txn = workspace.add_balance(
+        amount=-credits,
+        invoice_id=f"gooey_in_comfy_{uuid.uuid5(uuid.NAMESPACE_URL, payload.invoice_id)}",
+        user=user,
+    )
+    return ComfyUsageResponse(credits_charged=credits, balance=txn.end_balance)
+
+
+class ComfyBalanceResponse(BaseModel):
+    balance: int
+
+
+@app.get(
+    "/__/comfy/api/workspaces/{workspace_id}/balance/",
+    dependencies=[Depends(comfy_service_auth)],
+    include_in_schema=False,
+)
+def comfy_workspace_balance(workspace_id: int, uid: str) -> ComfyBalanceResponse:
+    user = _get_user_or_401(uid)
+    workspace = _get_workspace_for_member_or_401(workspace_id, user)
+    return ComfyBalanceResponse(balance=workspace.balance)
+
+
+def _get_workspace_for_member_or_401(workspace_id: int, user: AppUser) -> Workspace:
+    try:
+        return Workspace.objects.get(
+            id=workspace_id,
+            memberships__user=user,
+            memberships__deleted__isnull=True,
+        )
+    except Workspace.DoesNotExist:
+        raise fastapi.HTTPException(
+            status_code=HTTP_401_UNAUTHORIZED,
+            detail={"error": "You are not a member of this workspace."},
+        )

--- a/server.py
+++ b/server.py
@@ -45,6 +45,7 @@ from routers import (
     static_pages,
     onedrive_api,
     workspace,
+    comfy_api,
 )
 from routers import live_transcribe_api, twilio_ws_api
 from daras_ai_v2.openapi_tricks import patch_custom_schema_fastapi
@@ -93,6 +94,7 @@ app_routers = [
     onedrive_api.app,
     slack_api.router,
     workspace.app,
+    comfy_api.app,
     url_shortener.app,
     paypal.router,
     stripe.router,

--- a/tests/test_modal_utils.py
+++ b/tests/test_modal_utils.py
@@ -1,57 +1,60 @@
-import types
+import sys
 
 import modal
 
 from daras_ai_v2 import modal_utils, settings
 
+# a stand-in for a modal_functions/* module: modal requires @app.function /
+# @app.cls at module scope, so this test module itself plays the app module
+app = modal.App("fake-app")
 
-def _fake_app_module():
-    fake = types.ModuleType("fake_modal_app")
-    fake.app = modal.App("fake-app")
 
-    @fake.app.function()
-    def run_tts(language, text):
-        return f"{language}:{text}"
+@app.function()
+def run_tts(language, text):
+    return f"{language}:{text}"
 
-    fake.run_tts = run_tts
 
-    @fake.app.cls()
-    class FakeAsr:
-        @modal.enter()
-        def load(self):
-            self.model = "loaded-model"
+@app.cls()
+class FakeAsr:
+    @modal.enter()
+    def load(self):
+        self.model = "loaded-model"
 
-        @modal.method()
-        def run(self, audio_url):
-            return {"model": self.model, "audio": audio_url}
+    @modal.method()
+    def run(self, audio_url):
+        return {"model": self.model, "audio": audio_url}
 
-    fake.FakeAsr = FakeAsr
-    return fake
+
+fake_app_module = sys.modules[__name__]
 
 
 def test_modal_run_locally(monkeypatch):
     monkeypatch.setattr(settings, "MODAL_RUN_LOCALLY", True)
-    fake = _fake_app_module()
 
     assert (
-        modal_utils.get_modal_fn(fake, "run_tts").remote(language="eng", text="hi")
+        modal_utils.get_modal_fn(fake_app_module, "run_tts").remote(
+            language="eng", text="hi"
+        )
         == "eng:hi"
     )
 
     # @modal.enter lifecycle hooks must run for local calls
-    result = modal_utils.get_modal_cls(fake, "FakeAsr")().run.remote(
+    result = modal_utils.get_modal_cls(fake_app_module, "FakeAsr")().run.remote(
         audio_url="http://x/a.wav"
     )
     assert result == {"model": "loaded-model", "audio": "http://x/a.wav"}
 
     monkeypatch.setattr(settings, "MODAL_LOCAL_WEB_URL", "http://localhost:1234")
-    assert modal_utils.get_modal_web_url(fake, "serve") == "http://localhost:1234"
+    assert modal_utils.get_modal_web_url(fake_app_module, "serve") == (
+        "http://localhost:1234"
+    )
 
 
 def test_modal_run_on_cloud(monkeypatch):
     monkeypatch.setattr(settings, "MODAL_RUN_LOCALLY", False)
-    fake = _fake_app_module()
 
     # lookups are lazy, so constructing them needs no modal credentials
-    assert isinstance(modal_utils.get_modal_fn(fake, "run_tts"), modal.Function)
-    assert isinstance(modal_utils.get_modal_cls(fake, "FakeAsr"), modal.Cls)
+    assert isinstance(
+        modal_utils.get_modal_fn(fake_app_module, "run_tts"), modal.Function
+    )
+    assert isinstance(modal_utils.get_modal_cls(fake_app_module, "FakeAsr"), modal.Cls)

--- a/tests/test_modal_utils.py
+++ b/tests/test_modal_utils.py
@@ -1,0 +1,57 @@
+import types
+
+import modal
+
+from daras_ai_v2 import modal_utils, settings
+
+
+def _fake_app_module():
+    fake = types.ModuleType("fake_modal_app")
+    fake.app = modal.App("fake-app")
+
+    @fake.app.function()
+    def run_tts(language, text):
+        return f"{language}:{text}"
+
+    fake.run_tts = run_tts
+
+    @fake.app.cls()
+    class FakeAsr:
+        @modal.enter()
+        def load(self):
+            self.model = "loaded-model"
+
+        @modal.method()
+        def run(self, audio_url):
+            return {"model": self.model, "audio": audio_url}
+
+    fake.FakeAsr = FakeAsr
+    return fake
+
+
+def test_modal_run_locally(monkeypatch):
+    monkeypatch.setattr(settings, "MODAL_RUN_LOCALLY", True)
+    fake = _fake_app_module()
+
+    assert (
+        modal_utils.get_modal_fn(fake, "run_tts").remote(language="eng", text="hi")
+        == "eng:hi"
+    )
+
+    # @modal.enter lifecycle hooks must run for local calls
+    result = modal_utils.get_modal_cls(fake, "FakeAsr")().run.remote(
+        audio_url="http://x/a.wav"
+    )
+    assert result == {"model": "loaded-model", "audio": "http://x/a.wav"}
+
+    monkeypatch.setattr(settings, "MODAL_LOCAL_WEB_URL", "http://localhost:1234")
+    assert modal_utils.get_modal_web_url(fake, "serve") == "http://localhost:1234"
+
+
+def test_modal_run_on_cloud(monkeypatch):
+    monkeypatch.setattr(settings, "MODAL_RUN_LOCALLY", False)
+    fake = _fake_app_module()
+
+    # lookups are lazy, so constructing them needs no modal credentials
+    assert isinstance(modal_utils.get_modal_fn(fake, "run_tts"), modal.Function)
+    assert isinstance(modal_utils.get_modal_cls(fake, "FakeAsr"), modal.Cls)


### PR DESCRIPTION
## Overview

This PR adds a complete ComfyUI cloud gateway service that integrates with gooey-server to provide cloud-hosted ComfyUI instances for Gooey users. The gateway handles authentication, workspace isolation, GPU billing, and reverse proxying.

## Key Changes

### New Gateway Service (`comfy/`)
- **`gateway/main.py`**: FastAPI application serving as the reverse proxy and orchestration layer
  - SSO handshake with gooey-server (signed token exchange)
  - Session management with signed cookies
  - HTTP and WebSocket proxying to ComfyUI instances
  - Workspace switching and credit balance display
  
- **`gateway/backends.py`**: Compute backend abstraction with three implementations
  - `ModalBackend`: Per-workspace Modal sandboxes (production)
  - `LocalBackend`: Per-workspace local ComfyUI subprocesses via comfy-cli
  - `StaticBackend`: Single shared upstream ComfyUI instance
  - Automatic instance lifecycle management (launch on demand, idle reaper, billing loop)
  - GPU time metering (1 credit per GPU-minute by default)

- **`gateway/gooey_client.py`**: Server-to-server client for internal comfy API
  - SSO token verification
  - User profile and workspace balance queries
  - Idempotent usage recording with deterministic invoice IDs

- **`gateway/sessions.py`**: Signed-cookie session management
  - Mirrors gooey-server's approach using `itsdangerous`
  - Stores user info and workspace selection

- **`gateway/proxy.py`**: HTTP and WebSocket reverse proxy
  - Strips hop-by-hop headers and session cookies
  - Injects Gooey header into HTML responses
  - Bridges WebSocket connections to upstream ComfyUI

- **`gateway/header.py`**: Gooey header bar injection
  - Fixed 44px bar with logo, workspace switcher, credit balance, user menu
  - Live balance refresh every 30s
  - DOM-based insertion survives ComfyUI markup changes

- **`comfy_modal.py`**: Modal deployment configuration
  - Pre-baked image with comfy-cli and pinned ComfyUI version
  - Per-workspace persistent volumes for models/custom nodes/outputs
  - 12-hour sandbox lifetime cap as spend backstop

- **`requirements.txt`**: Gateway dependencies (FastAPI, httpx, websockets, etc.)
- **`Dockerfile`**: Container image for gateway deployment
- **`README.md`**: Comprehensive documentation of architecture, SSO flow, billing, and backend options

### Integration with gooey-server (`routers/comfy_api.py`)
- **`GET /comfy/sso/`**: Browser entry point for SSO redirect
  - Requires active gooey.ai session
  - Mints 5-minute signed token and redirects to gateway
  
- **`POST /__/comfy/api/verify-sso/`**: Internal API for token exchange
  - Returns user profile and workspace list with balances
  
- **`GET /__/comfy/api/users/{uid}/`**: Refresh user profile and balances
  
- **`POST /__/comfy/api/usage/`**: Record metered GPU usage
  - Idempotent on invoice_id (prevents double-charging on retries)
  - Uses existing `Workspace.add_balance` primitive
  - Pricing stays server-side (COMFY_CREDITS_PER_GPU_MINUTE)

### Modal Utilities (`daras_ai_v2/modal_utils.py`)
- Helpers for calling Modal workloads with local/cloud switching
- `get_modal_fn()` and `get_modal_cls()` proxies that respect `MODAL_RUN_LOCALLY` flag
- Enables local development without Modal credentials

### Configuration
- New settings in `daras_ai_v2/settings.py` and `comfy/gateway/settings.py`
- `COMFY_BASE_URL`, `COMFY_SERVICE_TOKEN`, `COMFY_CREDITS_P

https://claude.ai/code/session_01EW8uheShcoWcs6gvpszqCV