### PR TITLE
Mobile/sidebar polish and four bug fixes.

### DIFF
--- a/gooey-gui/app/components/AskGooeyNew.css
+++ b/gooey-gui/app/components/AskGooeyNew.css
@@ -1,11 +1,308 @@
+.ask-gooey-page {
+  width: 100%;
+  min-height: 100dvh;
+  padding: 48px 24px;
+  background: #fbfaf8;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+}
+
+.ask-gooey-column {
+  max-width: 840px;
+  width: 100%;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 28px;
+}
+
+.ask-gooey-header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  color: #1f1f1f;
+}
+
 .ask-gooey-title {
+  margin: 0;
+  text-align: center;
   font-size: 2rem;
+  font-weight: 400;
+  font-family: Georgia, serif;
+  color: #111;
+  letter-spacing: -0.02em;
+}
+
+.ask-gooey-title-highlight {
+  background-color: #a5ffee;
+  padding: 0 4px;
+  border-radius: 4px;
 }
 
 .ask-gooey-logo {
   width: 44px;
   height: 44px;
   flex-shrink: 0;
+}
+
+.ask-gooey-composer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 28px;
+  width: 100%;
+}
+
+.ask-gooey-error {
+  text-align: center;
+  font-size: 0.9rem;
+}
+
+/* Desktop: input first, chips below (DOM is chips then input). */
+.ask-gooey-suggestions {
+  order: 2;
+  position: relative;
+  width: 100%;
+}
+
+.ask-gooey-input-bar {
+  order: 1;
+  width: 100%;
+  border-radius: 16px;
+  padding: 1px;
+  background: linear-gradient(135deg, #5ee6d0 0%, #b7c8fe 50%, #e3e0f9 100%);
+  box-shadow: 0 0 6px rgba(94, 230, 208, 0.3);
+  transition: box-shadow 0.15s ease;
+  display: flex;
+  flex-direction: column;
+}
+
+.ask-gooey-input-bar--focused {
+  box-shadow: 0 0 10px rgba(94, 230, 208, 0.5);
+}
+
+.ask-gooey-input-bar-inner {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  background: rgba(255, 255, 255, 0.99);
+  border-radius: 15.5px;
+  padding: 16px 8px 8px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ask-gooey-input-bar.gooey-orbit-border::before {
+  padding: 4px;
+}
+
+.ask-gooey-attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.ask-gooey-attachment {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: #f4f5f7;
+  border: 1px solid #eaeaea;
+  border-radius: 10px;
+  padding: 4px 8px;
+  font-size: 12px;
+  color: #333;
+  max-width: 260px;
+}
+
+.ask-gooey-attachment i {
+  font-size: 12px;
+}
+
+.ask-gooey-attachment-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ask-gooey-attachment-remove {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: #888;
+  display: flex;
+  align-items: center;
+}
+
+.ask-gooey-textarea {
+  width: 100%;
+  min-height: 24px;
+  max-height: 240px;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: #4b587a;
+  font-size: 14px;
+  line-height: 20px;
+  resize: none;
+  padding: 0;
+  font-family: Inter, sans-serif;
+  overflow: hidden;
+}
+
+.ask-gooey-textarea:not(:placeholder-shown) {
+  color: #000;
+}
+
+.ask-gooey-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 36px;
+}
+
+.ask-gooey-file-input {
+  display: none;
+}
+
+.ask-gooey-toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ask-gooey-attach-btn,
+.ask-gooey-mic-btn,
+.ask-gooey-send-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  cursor: pointer;
+}
+
+.ask-gooey-attach-btn {
+  background: none;
+  padding: 5px;
+  color: #000;
+  width: 24px;
+  height: 24px;
+  border-radius: 8px;
+}
+
+.ask-gooey-attach-btn i {
+  font-size: 14px;
+}
+
+.ask-gooey-mic-btn {
+  background: none;
+  padding: 0;
+  color: #0a1021;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.ask-gooey-mic-btn i,
+.ask-gooey-send-btn i {
+  font-size: 16px;
+}
+
+.ask-gooey-mic-btn--recording {
+  background: #fdecec;
+  color: #dc3545;
+}
+
+.ask-gooey-mic-btn--connecting {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.ask-gooey-send-btn {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: none;
+  color: #8994b1;
+  cursor: not-allowed;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.ask-gooey-send-btn--active {
+  background: #000;
+  color: #fff;
+  cursor: pointer;
+}
+
+.ask-gooey-suggestions-scroll {
+  display: flex;
+  gap: 12px;
+  width: 100%;
+  overflow-x: auto;
+  padding-bottom: 4px;
+  align-items: center;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.ask-gooey-suggestions-scroll::-webkit-scrollbar {
+  display: none;
+}
+
+.ask-gooey-suggestion-chip {
+  background: #fff;
+  border: 1px solid #eaeaea;
+  border-radius: 16px;
+  padding: 6px 12px;
+  font-size: 13px;
+  color: #000;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.ask-gooey-suggestion-chip:hover {
+  background: #f9f9f9;
+}
+
+.ask-gooey-suggestions-fade {
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 4px;
+  width: 80px;
+  background: linear-gradient(
+    to right,
+    rgba(251, 250, 248, 0) 0%,
+    rgba(251, 250, 248, 1) 60%
+  );
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  pointer-events: none;
+}
+
+.ask-gooey-suggestions-arrow {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 8px 4px 8px 16px;
+  color: #000;
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ask-gooey-suggestions-arrow i {
+  font-size: 14px;
 }
 
 @media (min-width: 768px) {
@@ -16,5 +313,103 @@
   .ask-gooey-logo {
     width: 64px;
     height: 64px;
+  }
+}
+
+/* Matches the nav rail → drawer breakpoint (56px mobile top bar).
+   Bootstrap's `.min-vh-100` is `min-height: 100vh !important`, so a
+   full viewport was stacking under the top bar and creating the extra
+   scroll. Override that and size this page to the leftover column. */
+@media (max-width: 991.98px) {
+  .min-vh-100:has(.ask-gooey-page) {
+    min-height: 0 !important;
+  }
+
+  .d-flex.flex-column.flex-lg-row.min-vh-100.w-100:has(.ask-gooey-page) {
+    height: 100dvh;
+    min-height: 100dvh !important;
+  }
+
+  .d-flex.flex-column.flex-lg-row.min-vh-100.w-100:has(.ask-gooey-page)
+    > :first-child {
+    flex-shrink: 0;
+  }
+
+  .d-flex.flex-column.flex-grow-1.min-w-0:has(.ask-gooey-page) {
+    min-height: 0 !important;
+    flex: 1 1 auto;
+  }
+
+  .d-flex.flex-column.min-vh-100.w-100:has(.ask-gooey-page):not(.flex-lg-row) {
+    min-height: 0 !important;
+    height: 100%;
+  }
+
+  .d-flex.flex-column.min-vh-100.w-100:has(#main-content .ask-gooey-page):not(
+      .flex-lg-row
+    )
+    > :has(#main-content) {
+    flex: 1 1 auto;
+    min-height: 0;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+
+  #main-content:has(.ask-gooey-page) {
+    flex: 1 1 auto;
+    min-height: 0;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .ask-gooey-page {
+    flex: 1 1 auto;
+    height: 100%;
+    min-height: 0;
+    padding: 16px 16px 12px;
+    align-items: stretch;
+    justify-content: flex-start;
+  }
+
+  .ask-gooey-column {
+    flex: 1 1 auto;
+    min-height: 0;
+    height: 100%;
+    gap: 16px;
+    justify-content: space-between;
+  }
+
+  .ask-gooey-header {
+    flex: 1 1 auto;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    min-height: 0;
+    width: 100%;
+    text-align: center;
+  }
+
+  .ask-gooey-title {
+    flex: 0 1 auto;
+    width: auto;
+    max-width: 100%;
+  }
+
+  .ask-gooey-composer {
+    flex: 0 0 auto;
+    margin-top: auto;
+    gap: 12px;
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+    background: #fbfaf8;
+  }
+
+  .ask-gooey-suggestions {
+    order: 1;
+  }
+
+  .ask-gooey-input-bar {
+    order: 2;
   }
 }

--- a/gooey-gui/app/components/AskGooeyNew.tsx
+++ b/gooey-gui/app/components/AskGooeyNew.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "@remix-run/react";
 import { fetchServerAPI } from "~/fetchServerAPI";
 import { useLiveTranscription } from "~/useLiveTranscription";
 import type { CustomComponentProps } from "~/components";
+import "~/styles/gooey-orbit-border.css";
 import "./AskGooeyNew.css";
 
 type AskGooeyNewProps = CustomComponentProps & {
@@ -149,6 +150,13 @@ export function AskGooeyNew({
 
   const canSubmit = value.trim().length > 0 && !isSubmitting && !isUploading;
   const titleParts = renderTitleWithHighlight(title, highlight);
+  const inputBarClass = isFocused
+    ? "ask-gooey-input-bar ask-gooey-input-bar--focused gooey-orbit-border gooey-orbit-border--strong"
+    : "ask-gooey-input-bar gooey-orbit-border gooey-orbit-border--strong";
+  const sendBtnClass = canSubmit
+    ? "ask-gooey-send-btn ask-gooey-send-btn--active"
+    : "ask-gooey-send-btn";
+  const micBtnClass = micButtonClass(micState);
 
   const suggestions = [
     "Swahili WhatsApp bot for community health workers",
@@ -157,360 +165,164 @@ export function AskGooeyNew({
   ];
 
   return (
-    <div
-      style={{
-        width: "100%",
-        minHeight: "100dvh",
-        padding: "48px 24px",
-        background: "#FFFFFF",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-      }}
-    >
-      <div
-        style={{
-          maxWidth: "840px",
-          width: "100%",
-          margin: "0 auto",
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          gap: "28px",
-        }}
-      >
-        <div
-          className="d-flex align-items-center justify-content-center"
-          style={{ gap: "16px", color: "#1f1f1f", marginBottom: "8px" }}
-        >
+    <div className="ask-gooey-page">
+      <div className="ask-gooey-column">
+        <div className="ask-gooey-header">
           <img
             className="ask-gooey-logo"
             src="https://storage.googleapis.com/dara-c1b52.appspot.com/daras_ai/media/47e069e2-5b65-11f1-80ef-02420a00016f/gooey-builder-logo-fit.gif"
             alt="Gooey Logo"
           />
-          <h1
-            className="ask-gooey-title"
-            style={{
-              margin: 0,
-              textAlign: "center",
-              fontWeight: 400,
-              fontFamily: "Georgia, serif",
-              color: "#111",
-              letterSpacing: "-0.02em",
-            }}
-          >
-            {titleParts}
-          </h1>
+          <h1 className="ask-gooey-title">{titleParts}</h1>
         </div>
 
-        <div
-          style={{
-            position: "relative",
-            width: "100%",
-            borderRadius: "16px",
-            padding: "1px", // For the gradient border
-            background: "linear-gradient(135deg, #5EE6D0 0%, #B7C8FE 50%, #E3E0F9 100%)",
-            boxShadow: isFocused
-              ? "0 0 10px rgba(94, 230, 208, 0.5)"
-              : "0 0 6px rgba(94, 230, 208, 0.3)",
-            transition: "box-shadow 0.15s ease",
-            display: "flex",
-            flexDirection: "column",
-          }}
-        >
-          <div
-            style={{
-              width: "100%",
-              background: "rgba(255, 255, 255, 0.99)",
-              borderRadius: "15.5px",
-              padding: "16px 8px 8px 16px",
-              display: "flex",
-              flexDirection: "column",
-              gap: "8px",
-            }}
-          >
-            {attachments.length > 0 && (
-              <div style={{ display: "flex", flexWrap: "wrap", gap: "8px" }}>
-                {attachments.map((a) => (
-                  <div
-                    key={a.id}
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: "6px",
-                      background: "#F4F5F7",
-                      border: "1px solid #eaeaea",
-                      borderRadius: "10px",
-                      padding: "4px 8px",
-                      fontSize: "12px",
-                      color: "#333",
-                      maxWidth: "260px",
-                    }}
+        <div className="ask-gooey-composer">
+          {error && (
+            <div role="alert" className="ask-gooey-error text-danger">
+              {error}
+            </div>
+          )}
+          <div className="ask-gooey-suggestions">
+            <div
+              id="suggestions-container"
+              ref={scrollContainerRef}
+              onScroll={checkScroll}
+              className="ask-gooey-suggestions-scroll"
+            >
+              {suggestions.map((chip, i) => (
+                <button
+                  key={i}
+                  type="button"
+                  onClick={() => setValue(chip)}
+                  className="ask-gooey-suggestion-chip"
+                >
+                  {chip}
+                </button>
+              ))}
+            </div>
+            {showScrollArrow && (
+              <div className="ask-gooey-suggestions-fade">
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (scrollContainerRef.current) {
+                      scrollContainerRef.current.scrollBy({
+                        left: 250,
+                        behavior: "smooth",
+                      });
+                    }
+                  }}
+                  className="ask-gooey-suggestions-arrow"
+                >
+                  <i className="fa-solid fa-chevron-right" />
+                </button>
+              </div>
+            )}
+          </div>
+          <div className={inputBarClass}>
+            <div className="ask-gooey-input-bar-inner">
+              {attachments.length > 0 && (
+                <div className="ask-gooey-attachments">
+                  {attachments.map((a) => (
+                    <div key={a.id} className="ask-gooey-attachment">
+                      {a.uploading ? (
+                        <i className="fa-regular fa-spinner-third fa-spin" />
+                      ) : (
+                        <i
+                          className={
+                            a.contentType.startsWith("image/")
+                              ? "fa-regular fa-image"
+                              : "fa-regular fa-file"
+                          }
+                        />
+                      )}
+                      <span className="ask-gooey-attachment-name">{a.name}</span>
+                      <button
+                        type="button"
+                        onClick={() => removeAttachment(a.id)}
+                        aria-label={`Remove ${a.name}`}
+                        className="ask-gooey-attachment-remove"
+                      >
+                        <i className="fa-regular fa-xmark" />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+              <textarea
+                ref={textareaRef}
+                data-submit-disabled
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+                onKeyDown={onKeyDown}
+                onFocus={() => setIsFocused(true)}
+                onBlur={() => setIsFocused(false)}
+                placeholder={placeholder}
+                rows={1}
+                disabled={isSubmitting}
+                aria-label={title}
+                className="ask-gooey-textarea"
+              />
+              <div className="ask-gooey-toolbar">
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  multiple
+                  onChange={(e) => onFilesSelected(e.target.files)}
+                  className="ask-gooey-file-input"
+                />
+                <button
+                  type="button"
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={isSubmitting}
+                  aria-label="Attach files"
+                  className="ask-gooey-attach-btn"
+                >
+                  <i className="fa-regular fa-plus" />
+                </button>
+                <div className="ask-gooey-toolbar-right">
+                  <button
+                    type="button"
+                    onClick={toggleRecording}
+                    disabled={isSubmitting || micState === "connecting"}
+                    aria-label={
+                      micState === "recording"
+                        ? "Stop dictation"
+                        : "Dictate with microphone"
+                    }
+                    className={micBtnClass}
                   >
-                    {a.uploading ? (
-                      <i
-                        className="fa-regular fa-spinner-third fa-spin"
-                        style={{ fontSize: "12px" }}
-                      />
+                    {micState === "connecting" ? (
+                      <i className="fa-regular fa-spinner-third fa-spin" />
                     ) : (
                       <i
                         className={
-                          a.contentType.startsWith("image/")
-                            ? "fa-regular fa-image"
-                            : "fa-regular fa-file"
+                          micState === "recording"
+                            ? "fa-solid fa-microphone fa-beat-fade"
+                            : "fa-regular fa-microphone"
                         }
-                        style={{ fontSize: "12px" }}
                       />
                     )}
-                    <span
-                      style={{
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                        whiteSpace: "nowrap",
-                      }}
-                    >
-                      {a.name}
-                    </span>
-                    <button
-                      type="button"
-                      onClick={() => removeAttachment(a.id)}
-                      aria-label={`Remove ${a.name}`}
-                      style={{
-                        background: "none",
-                        border: "none",
-                        padding: "0",
-                        cursor: "pointer",
-                        color: "#888",
-                        display: "flex",
-                        alignItems: "center",
-                      }}
-                    >
-                      <i className="fa-regular fa-xmark" style={{ fontSize: "12px" }} />
-                    </button>
-                  </div>
-                ))}
-              </div>
-            )}
-            <textarea
-              ref={textareaRef}
-              data-submit-disabled
-              value={value}
-              onChange={(e) => setValue(e.target.value)}
-              onKeyDown={onKeyDown}
-              onFocus={() => setIsFocused(true)}
-              onBlur={() => setIsFocused(false)}
-              placeholder={placeholder}
-              rows={1}
-              disabled={isSubmitting}
-              aria-label={title}
-              style={{
-                width: "100%",
-                minHeight: "24px",
-                maxHeight: "240px",
-                background: "transparent",
-                border: "none",
-                outline: "none",
-                color: value ? "#000" : "#4B587A",
-                fontSize: "14px",
-                lineHeight: "20px",
-                resize: "none",
-                padding: "0",
-                fontFamily: "'Inter', sans-serif",
-              }}
-            />
-            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", height: "36px" }}>
-              <input
-                ref={fileInputRef}
-                type="file"
-                multiple
-                onChange={(e) => onFilesSelected(e.target.files)}
-                style={{ display: "none" }}
-              />
-              <button
-                type="button"
-                onClick={() => fileInputRef.current?.click()}
-                disabled={isSubmitting}
-                aria-label="Attach files"
-                style={{
-                  background: "none",
-                  border: "none",
-                  padding: "5px",
-                  color: "#000",
-                  cursor: "pointer",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  width: "24px",
-                  height: "24px",
-                  borderRadius: "8px",
-                }}
-              >
-                <i className="fa-regular fa-plus" style={{ fontSize: "14px" }} />
-              </button>
-              <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-                <button
-                  type="button"
-                  onClick={toggleRecording}
-                  disabled={isSubmitting || micState === "connecting"}
-                  aria-label={
-                    micState === "recording"
-                      ? "Stop dictation"
-                      : "Dictate with microphone"
-                  }
-                  style={{
-                    background: micState === "recording" ? "#FDECEC" : "none",
-                    border: "none",
-                    padding: "0",
-                    color: micState === "recording" ? "#DC3545" : "#0A1021",
-                    cursor:
-                      micState === "connecting" ? "not-allowed" : "pointer",
-                    opacity: micState === "connecting" ? 0.6 : 1,
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    width: "32px",
-                    height: "32px",
-                    borderRadius: "8px",
-                    transition: "background 0.2s ease, color 0.2s ease",
-                  }}
-                >
-                  {micState === "connecting" ? (
-                    <i
-                      className="fa-regular fa-spinner-third fa-spin"
-                      style={{ fontSize: "16px" }}
-                    />
-                  ) : (
-                    <i
-                      className={
-                        micState === "recording"
-                          ? "fa-solid fa-microphone fa-beat-fade"
-                          : "fa-regular fa-microphone"
-                      }
-                      style={{ fontSize: "16px" }}
-                    />
-                  )}
-                </button>
-                <button
-                  type="button"
-                  data-submit-disabled
-                  onClick={submit}
-                  disabled={!canSubmit}
-                  aria-label="Send message"
-                  style={{
-                    width: "36px",
-                    height: "36px",
-                    borderRadius: "12px",
-                    background: canSubmit ? "#e0e0e0" : "#D9D9D9",
-                    border: "none",
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    color: canSubmit ? "#333" : "#8994B1",
-                    cursor: canSubmit ? "pointer" : "not-allowed",
-                    transition: "background 0.2s ease, color 0.2s ease",
-                  }}
-                >
-                  {isSubmitting ? (
-                    <i
-                      className="fa-regular fa-spinner-third fa-spin"
-                      style={{ fontSize: "16px" }}
-                    />
-                  ) : (
-                    <i
-                      className="fa-solid fa-arrow-up"
-                      style={{ fontSize: "16px" }}
-                    />
-                  )}
-                </button>
+                  </button>
+                  <button
+                    type="button"
+                    data-submit-disabled
+                    onClick={submit}
+                    disabled={!canSubmit}
+                    aria-label="Send message"
+                    className={sendBtnClass}
+                  >
+                    {isSubmitting ? (
+                      <i className="fa-regular fa-spinner-third fa-spin" />
+                    ) : (
+                      <i className="fa-solid fa-arrow-up" />
+                    )}
+                  </button>
+                </div>
               </div>
             </div>
           </div>
         </div>
-
-        <div style={{ position: "relative", width: "100%" }}>
-          <div 
-            id="suggestions-container"
-            ref={scrollContainerRef}
-            onScroll={checkScroll}
-            style={{ 
-              display: "flex", 
-              gap: "12px", 
-              width: "100%", 
-              overflowX: "auto", 
-              paddingBottom: "4px",
-              alignItems: "center",
-              scrollbarWidth: "none",
-              msOverflowStyle: "none",
-            }}
-          >
-            {suggestions.map((chip, i) => (
-              <button
-                key={i}
-                onClick={() => setValue(chip)}
-                style={{
-                  background: "#fff",
-                  border: "1px solid #eaeaea",
-                  borderRadius: "16px",
-                  padding: "6px 12px",
-                  fontSize: "13px",
-                  color: "#000",
-                  whiteSpace: "nowrap",
-                  cursor: "pointer",
-                  transition: "background 0.2s ease",
-                }}
-                onMouseEnter={(e) => (e.currentTarget.style.background = "#f9f9f9")}
-                onMouseLeave={(e) => (e.currentTarget.style.background = "#fff")}
-              >
-                {chip}
-              </button>
-            ))}
-          </div>
-          {showScrollArrow && (
-            <div
-              style={{
-                position: "absolute",
-                right: 0,
-                top: 0,
-                bottom: "4px",
-                width: "80px",
-                background: "linear-gradient(to right, rgba(255,255,255,0) 0%, rgba(255,255,255,1) 60%)",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "flex-end",
-                pointerEvents: "none",
-              }}
-            >
-              <button
-                onClick={() => {
-                  if (scrollContainerRef.current) scrollContainerRef.current.scrollBy({ left: 250, behavior: "smooth" });
-                }}
-                style={{
-                  background: "none",
-                  border: "none",
-                  cursor: "pointer",
-                  padding: "8px 4px 8px 16px",
-                  color: "#000",
-                  pointerEvents: "auto",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                }}
-              >
-                <i className="fa-solid fa-chevron-right" style={{ fontSize: "14px" }} />
-              </button>
-            </div>
-          )}
-        </div>
-
-        {error && (
-          <div
-            role="alert"
-            className="text-danger"
-            style={{ textAlign: "center", fontSize: "0.9rem" }}
-          >
-            {error}
-          </div>
-        )}
       </div>
     </div>
   );
@@ -542,18 +354,20 @@ function renderTitleWithHighlight(title: string, highlight: string) {
   return (
     <>
       {before}
-      <span
-        style={{
-          backgroundColor: "#A5FFEE",
-          padding: "0 4px",
-          borderRadius: "4px",
-        }}
-      >
-        {match}
-      </span>
+      <span className="ask-gooey-title-highlight">{match}</span>
       {after}
     </>
   );
+}
+
+function micButtonClass(micState: string) {
+  if (micState === "recording") {
+    return "ask-gooey-mic-btn ask-gooey-mic-btn--recording";
+  }
+  if (micState === "connecting") {
+    return "ask-gooey-mic-btn ask-gooey-mic-btn--connecting";
+  }
+  return "ask-gooey-mic-btn";
 }
 
 function autoResize(el: HTMLTextAreaElement | null) {

--- a/gooey-gui/app/components/AskGooeyNew.tsx
+++ b/gooey-gui/app/components/AskGooeyNew.tsx
@@ -24,7 +24,7 @@ type Attachment = {
 export function AskGooeyNew({
   title = "What will you build today?",
   highlight = "",
-  placeholder = "Ask Gooey to build an agent for farmers in Kenya",
+  placeholder = "Build an agent for farmers in Kenya",
 }: AskGooeyNewProps) {
   const navigate = useNavigate();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -82,7 +82,8 @@ export function AskGooeyNew({
 
   const checkScroll = () => {
     if (scrollContainerRef.current) {
-      const { scrollLeft, scrollWidth, clientWidth } = scrollContainerRef.current;
+      const { scrollLeft, scrollWidth, clientWidth } =
+        scrollContainerRef.current;
       setShowScrollArrow(scrollLeft + clientWidth < scrollWidth - 1);
     }
   };
@@ -236,7 +237,9 @@ export function AskGooeyNew({
                           }
                         />
                       )}
-                      <span className="ask-gooey-attachment-name">{a.name}</span>
+                      <span className="ask-gooey-attachment-name">
+                        {a.name}
+                      </span>
                       <button
                         type="button"
                         onClick={() => removeAttachment(a.id)}

--- a/gooey-gui/app/components/CodeEditor.css
+++ b/gooey-gui/app/components/CodeEditor.css
@@ -1,0 +1,11 @@
+/* Mobile: the global `input, select, textarea` bump in custom.css can't reach
+   CodeMirror -- its editable surface is a contenteditable div -- so the editor
+   would still trip Safari's zoom-on-focus at the theme's 14px. Size the whole
+   editor (content and gutters together, so line numbers stay in proportion)
+   instead of just the content. The extra class beats the theme's own
+   `.cm-editor` rule whichever order the stylesheets land in. */
+@media (max-width: 991.98px) {
+  .gui-input.code-editor-wrapper .cm-editor {
+    font-size: 16px;
+  }
+}

--- a/gooey-gui/app/components/CodeEditor.tsx
+++ b/gooey-gui/app/components/CodeEditor.tsx
@@ -1,3 +1,5 @@
+import "./CodeEditor.css";
+
 import CodeMirror, {
   type Extension,
   type ReactCodeMirrorRef,

--- a/gooey-gui/app/components/NavigationSidebar/GooeyBuilderButton.tsx
+++ b/gooey-gui/app/components/NavigationSidebar/GooeyBuilderButton.tsx
@@ -14,7 +14,7 @@ export function GooeyBuilderButton({
     <button
       type="button"
       className={clsx(
-        "gooey-builder-btn btn bg-hover-light d-flex align-items-center position-relative p-2",
+        "gooey-builder-btn gooey-orbit-border btn bg-hover-light d-flex align-items-center position-relative p-2",
         compact ? "justify-content-center" : "gap-2",
         mobile ? "border-0" : "border border-1"
       )}

--- a/gooey-gui/app/components/NavigationSidebar/NavigationSidebar.css
+++ b/gooey-gui/app/components/NavigationSidebar/NavigationSidebar.css
@@ -261,12 +261,20 @@ a.nav-brand {
   z-index: 1030;
 }
 
-/* Scrim behind the open drawer. */
+/* Scrim behind the open drawer, split in two on purpose.
+
+   This half is colourless -- it exists only to catch the tap that closes the
+   drawer. Safari on iOS tints the strips it draws outside the page (status bar,
+   bottom toolbar) from whatever is composited into a `position: fixed` layer
+   touching that edge, and it does not re-sample when the layer disappears. A
+   grey fixed layer spanning the viewport therefore stained both strips and left
+   them stained after the drawer closed. Keeping every colour out of this layer
+   is what avoids that; the dimming is done by .gooey-app-shell::after below,
+   which lives in the document instead. */
 .nav-scrim {
   position: fixed;
   inset: 0;
-  background-color: rgba(0, 0, 0, 0.4);
-  z-index: 1044;
+  z-index: 1045;
 }
 
 @media (max-width: 991.98px) {
@@ -296,5 +304,23 @@ a.nav-brand {
   html:has(.nav-sidebar--drawer-open) body {
     overflow: hidden;
     overscroll-behavior: none;
+  }
+
+  /* The other half of the scrim: the dimming. It hangs off the in-flow app
+     shell, so it spans the whole document and covers the viewport at any scroll
+     offset without being `position: fixed` -- which is what keeps Safari from
+     tinting its strips (see .nav-scrim). The shell is only made a containing
+     block while the drawer is open, to keep that off everything else. The
+     drawer itself (z-index 9999) stays above this. */
+  html:has(.nav-sidebar--drawer-open) .gooey-app-shell {
+    position: relative;
+  }
+
+  html:has(.nav-sidebar--drawer-open) .gooey-app-shell::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-color: rgba(0, 0, 0, 0.4);
+    z-index: 1044;
   }
 }

--- a/gooey-gui/app/components/NavigationSidebar/NavigationSidebar.css
+++ b/gooey-gui/app/components/NavigationSidebar/NavigationSidebar.css
@@ -93,6 +93,15 @@ a.nav-brand {
   scrollbar-color: rgba(0, 0, 0, 0.15) transparent;
 }
 
+/* Keyboard focus: the browser paints its focus ring *outside* an element's box
+   (outline-offset: 1px), but rows here stretch to the full width of this
+   scroll region -- which clips overflow -- so the ring's right edge (and both
+   edges for un-indented rows) got sliced off. Pull the ring inside the row
+   instead of loosening the clipping, which the sticky rail depends on. */
+.nav-scroll-region :focus-visible {
+  outline-offset: -3px;
+}
+
 .nav-scroll-region::-webkit-scrollbar {
   width: 4px;
 }
@@ -194,7 +203,8 @@ a.nav-brand {
 .nav-item-link {
   transition: background-color 100ms ease;
   text-decoration: none;
-  min-height: 40px;
+  min-height: 36px;
+  font-size: 14px;
 }
 
 .nav-item-link.dense {
@@ -251,11 +261,12 @@ a.nav-brand {
 }
 
 .account-menu-panel {
-  min-width: 300px;
+  min-width: 250px;
   max-width: 300px;
   max-height: 70vh;
   overflow-y: auto;
   overscroll-behavior: contain;
+  font-size: 14px;
 }
 
 /* Circular workspace icon slot; sizes the FontAwesome fallback glyph. */

--- a/gooey-gui/app/components/NavigationSidebar/NavigationSidebar.css
+++ b/gooey-gui/app/components/NavigationSidebar/NavigationSidebar.css
@@ -125,76 +125,10 @@ a.nav-brand {
   object-fit: cover;
 }
 
-/* Gooey Builder button: a cyan brand-color light that travels around the
-   border. A conic-gradient "comet" rotates and is masked down to just the
-   border ring, so the bright arc sweeps left→right and around the perimeter.
-   #03dac5 is the Gooey brand cyan (see the spinner accent in custom.css). */
-@property --gooey-builder-angle {
-  syntax: "<angle>";
-  initial-value: 0deg;
-  inherits: false;
-}
-.gooey-builder-btn::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  padding: 1.5px; /* ring thickness */
-  background: conic-gradient(
-    from var(--gooey-builder-angle),
-    rgba(3, 218, 197, 0.35) 0deg,
-    rgba(3, 218, 197, 0.35) 70deg,
-    rgba(3, 218, 197, 0.9) 130deg,
-    #a5ffee 160deg,
-    rgba(3, 218, 197, 0.9) 190deg,
-    rgba(3, 218, 197, 0.35) 250deg,
-    rgba(3, 218, 197, 0.35) 360deg
-  );
-  /* Mask out the center, leaving only the padding-width border ring. */
-  -webkit-mask:
-    linear-gradient(#fff 0 0) content-box,
-    linear-gradient(#fff 0 0);
-  -webkit-mask-composite: xor;
-  mask:
-    linear-gradient(#fff 0 0) content-box,
-    linear-gradient(#fff 0 0);
-  mask-composite: exclude;
-  pointer-events: none;
-  /* Two sweeps, then fade the entire ring out and keep it hidden (forwards),
-     so the border disappears after the animation. */
-  animation:
-    gooey-builder-orbit 2.8s linear 2,
-    gooey-builder-fade 5.6s ease-out forwards;
-}
-
-@keyframes gooey-builder-orbit {
-  to {
-    --gooey-builder-angle: 360deg;
-  }
-}
-
-@keyframes gooey-builder-fade {
-  0%,
-  85% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0;
-  }
-}
-
-/* Respect reduced-motion: park the light as a static cyan rim (no sweep, no
-   fade-out). */
-@media (prefers-reduced-motion: reduce) {
-  .gooey-builder-btn::before {
-    animation: none;
-  }
-}
-
-/* On mobile the button lives in the top bar: disable the sweep entirely and
-   drop the ring so no border is left behind. */
+/* On mobile the button lives in the top bar: disable the shared orbit ring
+   so no border is left behind. */
 @media (max-width: 991.98px) {
-  .gooey-builder-btn::before {
+  .gooey-builder-btn.gooey-orbit-border::before {
     display: none;
   }
 }

--- a/gooey-gui/app/components/NavigationSidebar/PrimaryNavItems.tsx
+++ b/gooey-gui/app/components/NavigationSidebar/PrimaryNavItems.tsx
@@ -110,7 +110,7 @@ function NavItem({
         )}
       >
         <span
-          className={clsx("nav-item-icon")}
+          className="nav-item-icon"
           dangerouslySetInnerHTML={{ __html: item.icon }}
         />
         {!collapsed && <span>{item.label}</span>}

--- a/gooey-gui/app/components/NavigationSidebar/PrimaryNavItems.tsx
+++ b/gooey-gui/app/components/NavigationSidebar/PrimaryNavItems.tsx
@@ -98,24 +98,19 @@ function NavItem({
     collapsed && "position-relative",
     children && "nav-section-toggle",
     !!item.href && "bg-hover-light",
-    item.dense ? "dense px-2 py-1 small" : "px-2 py-2"
+    item.dense ? "dense px-2 py-1 small" : "px-2 py-1"
   );
   const content = (
     <Fragment>
       <span
         className={clsx(
-          "d-flex align-items-center flex-grow-1",
+          "d-flex align-items-center flex-grow-1 gap-1",
           collapsed && "justify-content-center",
-          collapsed && !item.href && "d-none", // hide when no href and collapsed
-          item.dense ? "gap-1" : "gap-2"
+          collapsed && !item.href && "d-none" // hide when no href and collapsed
         )}
       >
         <span
-          className={clsx(
-            "nav-item-icon",
-            !isActive && "text-muted",
-            item.dense && !collapsed && "small"
-          )}
+          className={clsx("nav-item-icon")}
           dangerouslySetInnerHTML={{ __html: item.icon }}
         />
         {!collapsed && <span>{item.label}</span>}
@@ -200,7 +195,7 @@ function NavItemChildren({
         )}
       </NavItem>
       {showItems && (
-        <div className={clsx(!item.dense && "saved-tree")}>
+        <div className={clsx(!item.dense && "saved-tree mb-2")}>
           {showSkeleton ? (
             <WorkflowListSkeleton rows={3} indent={!item.dense} />
           ) : (

--- a/gooey-gui/app/components/NavigationSidebar/WorkspaceAccountMenu.tsx
+++ b/gooey-gui/app/components/NavigationSidebar/WorkspaceAccountMenu.tsx
@@ -33,7 +33,7 @@ const WORKSPACE_SWITCHER_POPPER_OPTIONS = {
 const MENU_PANEL_CLASS =
   "account-menu-panel bg-body border shadow p-1 rounded-3";
 const MENU_ROW_BASE_CLASS =
-  "d-flex align-items-center gap-2 w-100 px-3 py-2 text-body text-decoration-none text-start border-0 rounded bg-hover-light";
+  "d-flex align-items-center gap-1 w-100 px-2 py-2 text-body text-decoration-none text-start border-0 rounded bg-hover-light";
 const MENU_ROW_ACTION_CLASS = clsx(
   MENU_ROW_BASE_CLASS,
   "bg-transparent bg-hover-light"
@@ -98,7 +98,7 @@ export function WorkspaceAccountMenu({
               <i className="fa-regular fa-chevron-right text-body-secondary flex-shrink-0 small" />
             </button>
           </Tippy>
-          <hr className="my-1" />
+          <hr className="my-1 text-muted" />
         </>
       )}
 
@@ -115,7 +115,7 @@ export function WorkspaceAccountMenu({
 
       {account.logout_href && (
         <>
-          <hr className="my-1" />
+          <hr className="my-1 text-muted" />
           <a href={account.logout_href} className={MENU_ROW_ACTION_CLASS}>
             <MenuIcon icon="fa-regular fa-arrow-right-from-bracket" />
             <span className="flex-grow-1 text-truncate min-w-0">Log out</span>
@@ -164,7 +164,7 @@ export function WorkspaceAccountMenu({
         )}
         {!compact && (
           <>
-            <span className="flex-grow-1 text-start overflow-hidden min-w-0">
+            <span className="flex-grow-1 text-start overflow-hidden min-w-0 small">
               <span className="d-block text-truncate fw-semibold">
                 {account.user.name}
               </span>
@@ -208,7 +208,7 @@ function WorkspaceSwitcher({
       ))}
       {account.add_workspace_url && (
         <>
-          <hr className="my-1" />
+          <hr className="my-1 text-muted" />
           <AccountMenuItem
             icon="fa-regular fa-plus"
             href={account.add_workspace_url}

--- a/gooey-gui/app/components/NavigationSidebar/index.tsx
+++ b/gooey-gui/app/components/NavigationSidebar/index.tsx
@@ -1,3 +1,4 @@
+import "~/styles/gooey-orbit-border.css";
 import "./NavigationSidebar.css";
 
 import clsx from "clsx";

--- a/gooey-gui/app/components/NavigationSidebar/index.tsx
+++ b/gooey-gui/app/components/NavigationSidebar/index.tsx
@@ -71,6 +71,14 @@ export function NavigationSidebar({
     return () => mq.removeEventListener("change", update);
   }, []);
 
+  // The mobile drawer covers the page, so navigating out of it has to close it:
+  // a nav item, a history row, a link in the account menu. Taps that navigate
+  // nowhere -- opening the account menu, switching workspace, toggling a section
+  // open -- leave the drawer where it is.
+  useEffect(() => {
+    if (isMobile) setCollapsed(true);
+  }, [isMobile, location.key]);
+
   useEffect(() => {
     if (!builderEventKey) return;
     const onOpen = () => {

--- a/gooey-gui/app/styles/custom.css
+++ b/gooey-gui/app/styles/custom.css
@@ -959,3 +959,22 @@ button {
 .object-fit-none {
   object-fit: none;
 }
+
+/* Mobile: Safari on iOS zooms the whole page in whenever a focused field's
+   font-size is under 16px, and most of the app renders its inputs inside
+   0.9rem wrappers (e.g. widgets/workflow_search.py), so they inherit 14.4px.
+   Level the fields themselves up to 16px here rather than pinning the viewport
+   with maximum-scale, which would stop the focus zoom but also take pinch-zoom
+   away on browsers that honour it.
+
+   !important because the fields we need to reach are styled by whatever owns
+   them -- react-select's generated emotion classes, per-component rules like
+   .ask-gooey-textarea -- and every one of those outranks a bare element
+   selector. Scoped to form controls below the mobile breakpoint. */
+@media (max-width: 991.98px) {
+  input,
+  select,
+  textarea {
+    font-size: 16px !important;
+  }
+}

--- a/gooey-gui/app/styles/gooey-orbit-border.css
+++ b/gooey-gui/app/styles/gooey-orbit-border.css
@@ -1,0 +1,90 @@
+/* Shared cyan brand-color light that travels around a border. A conic-gradient
+   "comet" rotates and is masked down to just the border ring, so the bright
+   arc sweeps left→right and around the perimeter.
+   #03dac5 is the Gooey brand cyan (see the spinner accent in custom.css). */
+@property --gooey-orbit-angle {
+  syntax: "<angle>";
+  initial-value: 0deg;
+  inherits: false;
+}
+
+.gooey-orbit-border {
+  position: relative;
+}
+
+.gooey-orbit-border::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1.5px; /* ring thickness */
+  background: conic-gradient(
+    from var(--gooey-orbit-angle),
+    rgba(3, 218, 197, 0.35) 0deg,
+    rgba(3, 218, 197, 0.35) 70deg,
+    rgba(3, 218, 197, 0.9) 130deg,
+    #a5ffee 160deg,
+    rgba(3, 218, 197, 0.9) 190deg,
+    rgba(3, 218, 197, 0.35) 250deg,
+    rgba(3, 218, 197, 0.35) 360deg
+  );
+  /* Mask out the center, leaving only the padding-width border ring. */
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  mask-composite: exclude;
+  pointer-events: none;
+  /* Two sweeps, then fade the entire ring out and keep it hidden (forwards). */
+  animation:
+    gooey-orbit-spin 2.8s linear 2,
+    gooey-orbit-fade 5.6s ease-out forwards;
+}
+
+/* Larger surfaces (e.g. the Ask Gooey input): a tighter, brighter comet with
+   a transparent trail so the traveling light reads against a pastel border. */
+.gooey-orbit-border--strong::before {
+  padding: 2.5px;
+  background: conic-gradient(
+    from var(--gooey-orbit-angle),
+    transparent 0deg,
+    transparent 105deg,
+    rgba(3, 218, 197, 0.55) 135deg,
+    #03dac5 150deg,
+    #ffffff 160deg,
+    #03dac5 170deg,
+    rgba(3, 218, 197, 0.55) 185deg,
+    transparent 215deg,
+    transparent 360deg
+  );
+  filter:
+    drop-shadow(0 0 4px #03dac5)
+    drop-shadow(0 0 10px rgba(3, 218, 197, 0.9));
+}
+
+@keyframes gooey-orbit-spin {
+  to {
+    --gooey-orbit-angle: 360deg;
+  }
+}
+
+@keyframes gooey-orbit-fade {
+  0%,
+  85% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+/* Respect reduced-motion: park the light as a static cyan rim (no sweep, no
+   fade-out). */
+@media (prefers-reduced-motion: reduce) {
+  .gooey-orbit-border::before {
+    animation: none;
+  }
+}

--- a/gooey_gui/components/modal.py
+++ b/gooey_gui/components/modal.py
@@ -180,5 +180,5 @@ def modal_scaffold(
             return (
                 gui.div(className="modal-header border-0"),
                 gui.div(className="modal-body"),
-                gui.div(className="modal-footer border-0 py-0"),
+                gui.div(className="modal-footer border-0 pt-0 pb-3"),
             )

--- a/routers/ask_gooey_new.py
+++ b/routers/ask_gooey_new.py
@@ -106,7 +106,7 @@ def render_ask_gooey_new(
     workspace: Workspace | None,
     title: str = "What will you build today?",
     highlight: str = "",
-    placeholder: str = "Ask Gooey to build an agent for farmers in Kenya",
+    placeholder: str = "Build an agent for farmers in Kenya",
 ):
     """Centered "What can I help with?" hero prompt for /explore.
 

--- a/routers/root.py
+++ b/routers/root.py
@@ -767,7 +767,9 @@ def sidebar_page_wrapper(
 
     # Column on mobile (rail collapses to an off-canvas drawer + top bar),
     # row on desktop (rail beside content).
-    with gui.div(className="d-flex flex-column flex-lg-row min-vh-100 w-100"):
+    with gui.div(
+        className="gooey-app-shell d-flex flex-column flex-lg-row min-vh-100 w-100"
+    ):
         navigation_sidebar.render(
             request, default_collapsed=default_collapsed, page=page
         )

--- a/widgets/navigation_sidebar.py
+++ b/widgets/navigation_sidebar.py
@@ -261,7 +261,7 @@ def _load_workspaces(
         WorkspaceData(
             id=ws.id,
             name=ws.display_name(user),
-            icon_html=ws.html_icon(),
+            icon_html=ws.html_icon(size="30px"),
             subtitle=_workspace_subtitle(ws, member_counts.get(ws.id, 0)),
             is_current=current_workspace is not None and ws.id == current_workspace.id,
             is_personal=ws.is_personal,


### PR DESCRIPTION
Mobile/sidebar polish and four bug fixes.

**Bugs**
- Focus rings in the sidebar were clipped — rows fill `.nav-scroll-region`, which clips overflow, and the browser paints its ring outside the box. Ring now drawn inside (`outline-offset: -3px`).
- Mobile drawer stayed open after tapping a nav item, hiding the page you just navigated to. Now closes on location change; opening the account menu / toggling a section still leaves it open.
- iOS zoomed the page on input focus — most fields inherit 14.4px from `0.9rem` wrappers. Bumped to 16px on mobile (plus CodeMirror, whose editable surface is a contenteditable div).
- Drawer scrim stained Safari's status bar and bottom toolbar, and the stain persisted after closing. Scrim is now a colourless fixed tap-catcher; dimming moved to `.gooey-app-shell::after` in the document flow.

**Polish**
- Sidebar density: rows 40px → 36px, 14px type, tighter account menu.
- Ask Gooey hero: orbit border extracted to shared `gooey-orbit-border.css`, ~340 lines of inline styles moved to CSS, composer pinned on mobile.

## Testing
- Sidebar behavior verified in-browser at desktop and drawer widths (focus rings, drawer open/close cases, field sizes at both breakpoints).
- Safari edge-tinting verified on an iPhone simulator with a harness reproducing the scrim shape — `theme-color`, z-index, and 1px insets all fail; only removing colour from the fixed layer works.
- `tsc` clean (5 pre-existing errors unrelated), `prettier` clean.

## Notes for reviewers
- `input, select, textarea { font-size: 16px !important }` — `!important` needed to beat react-select's emotion classes and per-component rules.
- Ask Gooey mobile CSS matches Bootstrap utility chains via `:has()` — works, but brittle if the shell's classes change.
- Not verified end-to-end on a physical iPhone; the scrim fix was validated by harness, not by driving the real drawer.