### PR TITLE
fix: honor OpenAI ASR output formats

### DIFF
--- a/daras_ai_v2/asr.py
+++ b/daras_ai_v2/asr.py
@@ -1483,6 +1483,11 @@ def run_asr(
         AsrModels.gpt_4_o_audio,
         AsrModels.gpt_4_o_mini_audio,
     }:
+        if output_format in {AsrOutputFormat.srt, AsrOutputFormat.vtt}:
+            raise UserError(
+                f"{selected_model.value} can't generate {output_format.value}"
+            )
+
         from daras_ai_v2.language_model import get_openai_client
 
         audio_r = requests.get(audio_url)
@@ -1491,12 +1496,13 @@ def run_asr(
         model_id = asr_model_ids[selected_model]
 
         client = get_openai_client(model_id)
-        return client.audio.transcriptions.create(
+        transcription = client.audio.transcriptions.create(
             model=model_id,
             file=(audio_url, audio_r.content),
             prompt=input_prompt,
-            response_format="text",
+            response_format="json",
         )
+        data = {"text": transcription.text}
     elif selected_model in {AsrModels.voxtral_mini}:
         from daras_ai_v2.language_model import get_openai_client
 

--- a/tests/test_asr.py
+++ b/tests/test_asr.py
@@ -1,0 +1,76 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from daras_ai_v2.asr import asr_model_ids, AsrModels, run_asr
+from daras_ai_v2.exceptions import UserError
+
+
+AUDIO_URL = "https://example.com/audio.wav"
+TRANSCRIPT = "Test transcription"
+OPENAI_ASR_MODELS = (
+    AsrModels.gpt_transcribe,
+    AsrModels.gpt_4_o_audio,
+    AsrModels.gpt_4_o_mini_audio,
+)
+
+
+@pytest.mark.parametrize("selected_model", OPENAI_ASR_MODELS)
+@pytest.mark.parametrize(
+    ("output_format", "expected"),
+    [("text", TRANSCRIPT), ("json", {"text": TRANSCRIPT})],
+)
+def test_openai_asr_output_format(selected_model, output_format, expected):
+    audio_response = Mock(
+        status_code=200,
+        reason="OK",
+        url=AUDIO_URL,
+        content=b"audio",
+    )
+    client = Mock()
+    client.audio.transcriptions.create.return_value = Mock(text=TRANSCRIPT)
+
+    with (
+        patch(
+            "daras_ai_v2.asr.audio_url_to_wav_url",
+            return_value=(AUDIO_URL, 1),
+        ),
+        patch("daras_ai_v2.asr.requests.get", return_value=audio_response),
+        patch(
+            "daras_ai_v2.language_model.get_openai_client",
+            return_value=client,
+        ),
+    ):
+        result = run_asr(
+            audio_url=AUDIO_URL,
+            selected_model=selected_model.name,
+            output_format=output_format,
+        )
+
+    assert result == expected
+    client.audio.transcriptions.create.assert_called_once_with(
+        model=asr_model_ids[selected_model],
+        file=(AUDIO_URL, b"audio"),
+        prompt=None,
+        response_format="json",
+    )
+
+
+@pytest.mark.parametrize("selected_model", OPENAI_ASR_MODELS)
+@pytest.mark.parametrize("output_format", ["srt", "vtt"])
+def test_openai_asr_rejects_timestamp_formats(selected_model, output_format):
+    with (
+        patch(
+            "daras_ai_v2.asr.audio_url_to_wav_url",
+            return_value=(AUDIO_URL, 1),
+        ),
+        patch("daras_ai_v2.asr.requests.get") as requests_get,
+        pytest.raises(UserError, match=f"can't generate {output_format.upper()}"),
+    ):
+        run_asr(
+            audio_url=AUDIO_URL,
+            selected_model=selected_model.name,
+            output_format=output_format,
+        )
+
+    requests_get.assert_not_called()


### PR DESCRIPTION
## Stack\n\n- Stacked on #1069.\n- Review and merge #1069 before this PR.\n\n## Summary\n\n- Request JSON from OpenAI transcription models and convert it through Gooey's existing text/JSON output handling.\n- Reject SRT and VTT for OpenAI transcription models because their responses do not include timestamp chunks.\n- Cover GPT Transcribe, GPT-4o Transcribe, and GPT-4o mini Transcribe with regression tests.\n\n## Testing\n\n- ruff check daras_ai_v2/asr.py tests/test_asr.py\n- pytest tests/test_asr.py -q (12 passed)