### PR TITLE
fix: retry transient Chirp operation polling failures

### DIFF
--- a/daras_ai_v2/asr.py
+++ b/daras_ai_v2/asr.py
@@ -1213,6 +1213,8 @@ def run_asr(
         str: Transcribed text.
     """
     import google.cloud.speech_v2 as cloud_speech
+    from google.api_core import exceptions as google_exceptions
+    from google.api_core import retry as google_retry
     from google.api_core.client_options import ClientOptions
     from google.cloud.texttospeech_v1 import AudioEncoding
     import langcodes
@@ -1382,7 +1384,20 @@ def run_asr(
         # Make the request
         operation = client.batch_recognize(request=request)
         # Wait for operation to complete
-        response = operation.result()  # BatchRecognizeFileResult
+        response = operation.result(
+            timeout=600,
+            retry=google_retry.Retry(
+                predicate=google_retry.if_exception_type(
+                    google_exceptions.ResourceExhausted,
+                    google_exceptions.TooManyRequests,
+                    google_exceptions.InternalServerError,
+                    google_exceptions.ServiceUnavailable,
+                ),
+                initial=2,
+                maximum=30,
+                timeout=60,
+            )
+        )  # BatchRecognizeFileResult
         # Handle the response
         return "\n\n".join(
             result.alternatives[0].transcript


### PR DESCRIPTION
## Summary

- Retry transient Google API failures while polling Chirp 3 long-running operations.
- Explicitly handle `ResourceExhausted` alongside standard transient 429, 500, and 503 errors.
- Use bounded exponential backoff without resubmitting the transcription job.

## Problem

Google can accept a Chirp 3 `BatchRecognize` request and return an operation ID, then temporarily reject a subsequent `Operations.GetOperation` status check with `429 ResourceExhausted`.

The transcription job may still be valid, but the polling exception currently escapes and causes the API request to fail. Retrying `BatchRecognize` would be unsafe because it could create duplicate jobs.

## Implementation

Pass an explicit `google.api_core.retry.Retry` policy to `operation.result()`:

- Overall operation timeout: 10 minutes
- Per-poll retry timeout: 60 seconds
- Initial retry delay: 2 seconds
- Maximum retry delay: 30 seconds
- Retryable errors: `ResourceExhausted`, `TooManyRequests`, `InternalServerError`, and `ServiceUnavailable`

Only the read-only operation status request is retried. The original `BatchRecognize` request is submitted once.

## Verification

- `ruff check daras_ai_v2/asr.py`
- `python -m py_compile daras_ai_v2/asr.py`
- `git diff --check origin/master...HEAD`
- Local baseline request returned HTTP 200 in 15.47 seconds.
- Initial local stress test ran 10 API requests at concurrency 3, with two documents per request. All 10 requests returned HTTP 200.
- Increased sustained-load test ran 30 API requests at concurrency 3, covering 60 documents. 29 requests returned HTTP 200; one returned HTTP 500 after exhausting its operation deadline while delayed by queue saturation. Median latency was 97.91 seconds, p95 was 207.22 seconds, and total wall time was 17m59s. No Google `ResourceExhausted` 429 was exposed to the client.
- A burst test at concurrency 10 confirmed the separate application-level paid-user concurrency limit of 4: excess requests were rejected by Gooey's own rate limiter before reaching Google.