### PR TITLE
fix: strip thinking traces for non WEB deployments

### DIFF
--- a/daras_ai_v2/asr.py
+++ b/daras_ai_v2/asr.py
@@ -1403,7 +1403,7 @@ def run_asr(
                 initial=2,
                 maximum=30,
                 timeout=60,
-            )
+            ),
         )  # BatchRecognizeFileResult
         # Handle the response
         return "\n\n".join(

--- a/daras_ai_v2/bots.py
+++ b/daras_ai_v2/bots.py
@@ -1,39 +1,40 @@
 import mimetypes
 import random
+import re
 import traceback
 import typing
 from datetime import datetime
 
-from bots.models.message_thread import MessageThread
-import gooey_gui as gui
 import requests
-from django.db import transaction, IntegrityError
+from django.db import IntegrityError, transaction
 from django.utils import timezone
 from fastapi import HTTPException
 from pydantic import BaseModel, Field
 from sentry_sdk import capture_exception
 
+import gooey_gui as gui
 from app_users.models import AppUser
 from bots.models import (
-    Platform,
-    Message,
+    BotIntegration,
     Conversation,
     Feedback,
+    Message,
+    MessageAttachment,
+    Platform,
     SavedRun,
     Workflow,
-    MessageAttachment,
-    BotIntegration,
     db_msgs_to_entries,
 )
 from bots.models.convo_msg import ConvoBlockedStatus
+from bots.models.message_thread import MessageThread
 from daras_ai_v2 import settings
 from daras_ai_v2.asr import run_google_translate, should_translate_lang
 from daras_ai_v2.base import BasePage, RecipeRunState, StateKeys
-from daras_ai_v2.csv_lines import csv_encode_row, csv_decode_row
+from daras_ai_v2.csv_lines import csv_decode_row, csv_encode_row
 from daras_ai_v2.exceptions import UserError, raise_for_status
 from daras_ai_v2.language_model import (
-    CHATML_ROLE_USER,
     CHATML_ROLE_ASSISTANT,
+    CHATML_ROLE_USER,
     ConversationEntry,
 )
 from daras_ai_v2.ratelimits import RateLimitExceeded, ensure_bot_rate_limits
@@ -540,6 +541,7 @@ def _process_and_send_msg(
         capture_exception(e)
 
     send_feedback_buttons = bot.show_feedback_buttons
+    should_strip_thinking = bot.platform != Platform.WEB
 
     update_msg_id = None  # this is the message id to update during streaming
     sent_msg_id = None  # this is the message id to record in the db
@@ -570,6 +572,8 @@ def _process_and_send_msg(
                 prev_final_prompt = final_prompt
 
                 text = state.get("output_text") and state.get("output_text")[0]
+                if should_strip_thinking:
+                    text = strip_thinking(text)
                 if not text:
                     # if no text, send the run status as text
                     update_msg_id = bot.send_run_status(
@@ -615,6 +619,8 @@ def _process_and_send_msg(
         return
 
     text = state.get("output_text") and state.get("output_text")[0]
+    if should_strip_thinking:
+        text = strip_thinking(text)
     audio = state.get("output_audio")
     video = state.get("output_video")
     documents = state.get("output_documents")
@@ -654,6 +660,23 @@ def _process_and_send_msg(
         # bot output for human
         bot_msg_display_content=state.get("output_text") and state["output_text"][0],
     )
+
+
+def strip_thinking(text: str | None) -> str:
+    """
+    Remove `<think>...</think>` blocks from the text, leaving everything else -
+    including `<button>` and any other markup - byte-for-byte in its original order.
+    """
+    if not text:
+        return ""
+    return THINKING_TAG_RE.sub("", text).strip()
+
+
+# an unterminated block is matched till the end of the text, so that thinking
+# isn't leaked to the user while the response is still streaming in
+THINKING_TAG_RE = re.compile(
+    r"<think\b[^>]*>.*?(?:</think\s*>|\Z)", flags=re.IGNORECASE | re.DOTALL
+)
 
 
 def compute_prompt_delta(

--- a/tests/test_strip_thinking.py
+++ b/tests/test_strip_thinking.py
@@ -1,0 +1,109 @@
+import pytest
+
+from daras_ai_v2.bots import strip_thinking
+
+
+@pytest.mark.parametrize("text", [None, "", "   \n  "])
+def test_strip_thinking_empty(text):
+    assert strip_thinking(text) == ""
+
+
+def test_strip_thinking_no_thinking():
+    text = "Hello **world**, visit https://gooey.ai/?a=1&b=2 <3"
+    assert strip_thinking(text) == text
+
+
+def test_strip_thinking_removes_block():
+    assert (
+        strip_thinking("<think>let me reason about this</think>\n\nThe answer is 42.")
+        == "The answer is 42."
+    )
+    assert (
+        strip_thinking("The answer is 42.\n\n<think>was that right?</think>")
+        == "The answer is 42."
+    )
+
+
+def test_strip_thinking_multiline_and_multiple_blocks():
+    text = """
+<think>
+first thought
+second thought
+</think>
+Step one.
+<think>more reasoning</think>
+Step two.
+""".strip()
+    assert strip_thinking(text) == "Step one.\n\nStep two."
+
+
+def test_strip_thinking_unterminated_block():
+    # while streaming, the closing tag hasn't arrived yet
+    assert strip_thinking("Thinking...\n<think>partial reason") == "Thinking..."
+    assert strip_thinking("<think>partial reason") == ""
+
+
+def test_strip_thinking_preserves_buttons():
+    text = (
+        '<button gui-target="input_prompt">Yes</button>'
+        "<think>should i ask?</think>"
+        '<button gui-action="disable_feedback">No</button>'
+    )
+    assert strip_thinking(text) == (
+        '<button gui-target="input_prompt">Yes</button>'
+        '<button gui-action="disable_feedback">No</button>'
+    )
+
+
+def test_strip_thinking_preserves_tag_order_with_text():
+    text = (
+        "<think>reasoning</think>"
+        "Here are your options:\n"
+        '<button gui-target="input_prompt">Alpha</button>\n'
+        "or maybe\n"
+        '<button gui-target="input_prompt">Beta</button>\n'
+        "<b>Pick one</b> and <i>tell me</i> — <video src='x.mp4'/>"
+    )
+    assert strip_thinking(text) == (
+        "Here are your options:\n"
+        '<button gui-target="input_prompt">Alpha</button>\n'
+        "or maybe\n"
+        '<button gui-target="input_prompt">Beta</button>\n'
+        "<b>Pick one</b> and <i>tell me</i> — <video src='x.mp4'/>"
+    )
+
+
+def test_strip_thinking_preserves_nested_markup_inside_kept_tags():
+    text = "<p>outer <span>inner <think>hmm</think>text</span> tail</p>"
+    assert strip_thinking(text) == "<p>outer <span>inner text</span> tail</p>"
+
+
+def test_strip_thinking_tag_variants():
+    assert strip_thinking('<think type="reasoning">x</think>y') == "y"
+    assert strip_thinking("<THINK>x</THINK>y") == "y"
+    assert strip_thinking("<think>x</think >y") == "y"
+    # not a thinking tag
+    assert strip_thinking("<thinking>x</thinking>") == "<thinking>x</thinking>"
+    assert strip_thinking("I think that's right") == "I think that's right"
+
+
+def test_strip_thinking_streaming_prefix_stays_stable():
+    """
+    Platforms that can't edit messages send `text[last_idx:]` deltas, so the
+    stripped prefix must never change as more of the response streams in.
+    """
+    chunks = [
+        "Hi there. ",
+        "Hi there. <think>",
+        "Hi there. <think>hmm",
+        "Hi there. <think>hmm, let me check</think>",
+        "Hi there. <think>hmm, let me check</think> The answer",
+        "Hi there. <think>hmm, let me check</think> The answer is 42.",
+    ]
+    sent = ""
+    for chunk in chunks:
+        stripped = strip_thinking(chunk)
+        assert stripped.startswith(sent), f"{stripped!r} does not extend {sent!r}"
+        sent = stripped
+    # the whitespace on either side of the removed block is left alone
+    assert sent == "Hi there.  The answer is 42."


### PR DESCRIPTION
### Q/A checklist

- [ ] I have tested my UI changes on mobile and they look acceptable
- [ ] I have tested changes to the workflows in both the API and the UI
- [ ] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [ ] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
