### PR TITLE
fix: avoid freezing admin on large JSON fields

### DIFF
--- a/bots/templates/django/forms/widgets/textarea.html
+++ b/bots/templates/django/forms/widgets/textarea.html
@@ -17,18 +17,25 @@
     <textarea name="{{ widget.name }}" {% include "django/forms/widgets/attrs.html" %}
     >{% if widget.value %}{{ widget.value | pretty_json }}{% endif %}</textarea>
     <script>
-        CodeMirror.fromTextArea(document.getElementById("{{ widget.attrs.id }}"), {
-            lineNumbers: true,
-            matchBrackets: true,
-            mode: "application/json",
-            gutters: ["CodeMirror-lint-markers"],
-            theme: "monokai",
-            lint: true,
-            extraKeys: {
-                "Ctrl-F": "findPersistent",
-                "Cmd-F": "findPersistent"
-            }
-        });
+        (() => {
+            const textarea = document.getElementById("{{ widget.attrs.id }}");
+            // CodeMirror's synchronous JSON linting can lock up the admin page for
+            // large SavedRun states. Keep those values in the native textarea.
+            if (textarea.value.length > 100_000) return;
+
+            CodeMirror.fromTextArea(textarea, {
+                lineNumbers: true,
+                matchBrackets: true,
+                mode: "application/json",
+                gutters: ["CodeMirror-lint-markers"],
+                theme: "monokai",
+                lint: true,
+                extraKeys: {
+                    "Ctrl-F": "findPersistent",
+                    "Cmd-F": "findPersistent"
+                }
+            });
+        })();
     </script>
 {% else %}
     <textarea rows="1" name="{{ widget.name }}" {% include "django/forms/widgets/attrs.html" %}


### PR DESCRIPTION
## Summary

- skip CodeMirror initialization for JSON fields larger than 100,000 characters
- retain the native editable textarea for oversized SavedRun state
- preserve CodeMirror syntax highlighting and linting for normal-sized JSON fields

## Context

Large SavedRun state causes CodeMirror and its synchronous JSON linter to block the browser main thread, leaving the Django admin page slow or unresponsive.

## Verification

- `git diff --check`
- reproduced the affected production page becoming unresponsive during read-only inspection
- no production admin records were changed