### PR TITLE
fix: handle null choice.message in run_openai_chat

### DIFF
--- a/daras_ai_v2/language_model.py
+++ b/daras_ai_v2/language_model.py
@@ -890,7 +890,10 @@ def run_openai_chat(
     if anthropic_json_workaround:
         ret = _extract_anthropic_json_responses(completion)
     else:
-        ret = [choice.message.dict() for choice in completion.choices]
+        # some providers may return choices with a null message
+        ret = [choice.message.dict() for choice in completion.choices if choice.message]
+    if not ret:
+        return [format_chat_entry(role=CHATML_ROLE_ASSISTANT, content_text="")]
     record_openai_llm_usage(used_model, completion, messages, ret)
     return ret
 


### PR DESCRIPTION
## Problem

Sentry issue [GOOEY-668](https://dara-network.sentry.io/issues/7700249800/): `AttributeError: 'NoneType' object has no attribute 'dict'` at `daras_ai_v2/language_model.py` in `run_openai_chat`. Some OpenAI-compatible providers can return a completion choice whose `message` is null, and `choice.message.dict()` crashes.

## Fix

Skip choices with a null `message` when building the response list, and fall back to an empty assistant entry (same fallback already used for an empty `completion.choices`) if nothing remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)