### PR TITLE
fix: handle insufficient credits in builder

### DIFF
--- a/daras_ai_v2/base_v2.py
+++ b/daras_ai_v2/base_v2.py
@@ -275,34 +275,33 @@ class BasePage(BasePageV1):
         )
 
     def _render_gooey_builder(self):
-        # The panel's collapse control, positioned against `.gooey-sidebar` at every
-        # breakpoint so there is no app-header offset to hardcode.
-        gui.model_component(
-            WorkspacePaneControlProps(
-                label="Close Ask gooey",
-                icon=FontAwesomeIcon(class_name=icons.cls.cancel),
-                target=PanelControlTarget(
-                    panel_key=GOOEY_BUILDER_EVENT_KEY,
-                    open=False,
-                ),
-                className="v2-builder-close",
-            )
-        )
-        # The panel's title, and its "new conversation" control - v2 hides the widget's own
-        # header. Skipped on an empty thread, where the widget draws its own splash.
-        if not builder_thread_is_empty(self):
+        with gui.div(className="v2-builder-header"):
+            # v2 hides the widget's own header. Skip the title on an empty thread, where the
+            # widget draws its own splash.
+            if not builder_thread_is_empty(self):
+                gui.model_component(
+                    WorkspacePaneControlProps(
+                        label=GOOEY_BUILDER_TITLE,
+                        # the label names the panel; the tooltip says what clicking it does
+                        tooltip="New Chat",
+                        icon=PhotoIcon(url=get_gooey_builder_photo_url()),
+                        target=EventControlTarget(
+                            event_name=f"{GOOEY_BUILDER_EVENT_KEY}:new"
+                        ),
+                        show_label=True,
+                        # padding is owned by `.v2-pane-control-labelled`, not a utility class
+                        className="v2-builder-new",
+                    )
+                )
             gui.model_component(
                 WorkspacePaneControlProps(
-                    label=GOOEY_BUILDER_TITLE,
-                    # the label names the panel; the tooltip says what clicking it does
-                    tooltip="New Chat",
-                    icon=PhotoIcon(url=get_gooey_builder_photo_url()),
-                    target=EventControlTarget(
-                        event_name=f"{GOOEY_BUILDER_EVENT_KEY}:new"
+                    label="Close Ask gooey",
+                    icon=FontAwesomeIcon(class_name=icons.cls.cancel),
+                    target=PanelControlTarget(
+                        panel_key=GOOEY_BUILDER_EVENT_KEY,
+                        open=False,
                     ),
-                    show_label=True,
-                    # padding is owned by `.v2-pane-control-labelled`, not a utility class
-                    className="v2-builder-new",
+                    className="v2-builder-close",
                 )
             )
         render_gooey_builder(

--- a/daras_ai_v2/base_v2.py
+++ b/daras_ai_v2/base_v2.py
@@ -1052,7 +1052,7 @@ class BasePage(BasePageV1):
             if not is_deleted:
                 self.render_is_cancelled()
                 with gui.div(
-                    className="flex-grow-1 d-flex flex-column",
+                    className="flex-grow-1 d-flex flex-column v2-run-output",
                     style=dict(minHeight=0),
                 ):
                     self.render_output()

--- a/daras_ai_v2/base_v2.py
+++ b/daras_ai_v2/base_v2.py
@@ -313,6 +313,7 @@ class BasePage(BasePageV1):
             # nothing on this tab submits, and a stale key from the workspace would fire
             # against a run the reader is not looking at
             gui.session_state.pop(self.SUBMIT_INTENT_KEY, None)
+            gui.session_state.pop("-submit-workflow", None)
             return
 
         intent = self._pop_submit_intent()
@@ -350,6 +351,9 @@ class BasePage(BasePageV1):
 
     def _pop_submit_intent(self) -> RecipeSubmitIntent | None:
         raw_intent = gui.session_state.pop(self.SUBMIT_INTENT_KEY, None)
+        legacy_submit = gui.session_state.pop("-submit-workflow", None)
+        if not raw_intent and legacy_submit:
+            raw_intent = RunIntent()
         if not raw_intent:
             return None
 

--- a/daras_ai_v2/gooey_builder.py
+++ b/daras_ai_v2/gooey_builder.py
@@ -94,9 +94,7 @@ def render_standalone_gooey_builder(
 
     handle_gooey_builder_redirect(builder_sr)
     builder_run_url = builder_sr.get_app_url()
-    messages = get_chat_widget_messages(
-        builder_sr.to_dict(), web_url=builder_run_url
-    )
+    messages = get_chat_widget_messages(builder_sr.to_dict(), web_url=builder_run_url)
     if builder_sr.error_type == exceptions.InsufficientCredits.__name__:
         render_gooey_builder_insufficient_credits(
             request=request,

--- a/daras_ai_v2/gooey_builder.py
+++ b/daras_ai_v2/gooey_builder.py
@@ -297,11 +297,6 @@ def submit_gooey_builder_message(
 
     builder_run_url = body.builder_run_url or get_default_builder_pr().get_app_url()
     builder_page_cls, builder_sr, builder_pr = url_to_runs(builder_run_url)
-    if (
-        builder_sr.surface == SavedRun.Surface.builder_prompt
-        and builder_sr.uid != request.user.uid
-    ):
-        raise fastapi.HTTPException(status_code=404)
 
     workspace = get_current_workspace(request.user, request.session)
     if builder_sr.error_type == exceptions.InsufficientCredits.__name__:

--- a/daras_ai_v2/gooey_builder.py
+++ b/daras_ai_v2/gooey_builder.py
@@ -25,13 +25,15 @@ from daras_ai_v2.web_widget_embed import (
 from routers.custom_api_router import CustomAPIRouter
 
 from workspaces.models import Workspace
-from workspaces.widgets import get_current_workspace
+from workspaces.widgets import get_current_workspace, set_current_workspace
+from widgets.errors import get_insufficient_credits_rerun_workspace
 
 if typing.TYPE_CHECKING:
     from daras_ai_v2.base import BasePage
 
 DEFAULT_GOOEY_BUILDER_PHOTO_URL = "https://storage.googleapis.com/dara-c1b52.appspot.com/daras_ai/media/63bdb560-b891-11f0-b9bc-02420a00014a/generate-ai-abstract-symbol-artificial-intelligence-colorful-stars-icon-vector%201.jpg"
 GOOEY_BUILDER_EVENT_KEY = "builder-sidebar"
+GOOEY_BUILDER_RERUN_KEY = "--insufficient-credits-rerun-builder"
 
 
 def render_gooey_builder(
@@ -47,7 +49,7 @@ def render_gooey_builder(
     handle_gooey_builder_redirect(builder_sr)
     workflow_state = {
         field_name: gui.session_state[field_name]
-        for field_name in page.fields_to_save()
+        for field_name in page.RequestModel.model_fields
         if field_name in gui.session_state
     }
     if builder_thread_is_empty(page):
@@ -136,26 +138,18 @@ def render_gooey_builder_insufficient_credits(
         builder_run_url=builder_sr.get_app_url(),
         workflow_state=workflow_state or {},
     )
-
-    def on_rerun():
-        rerun_gooey_builder(request, retry_body)
+    if gui.session_state.pop(GOOEY_BUILDER_RERUN_KEY, None):
+        raise gui.RedirectException(submit_gooey_builder_message(request, retry_body))
 
     error_params = dict(builder_sr.error_params or {})
     error_params.update(
         request=request,
         sr=builder_sr,
         current_workspace=current_workspace,
-        on_rerun=on_rerun,
+        rerun_key=GOOEY_BUILDER_RERUN_KEY,
     )
     with gui.div(className="gooey-builder-insufficient-credits"):
         exceptions.InsufficientCredits.render(error_params)
-
-
-def rerun_gooey_builder(
-    request: fastapi.Request,
-    body: GooeyBuilderSendMessage,
-) -> typing.NoReturn:
-    raise gui.RedirectException(submit_gooey_builder_message(request, body))
 
 
 def render_gooey_builder_embed(
@@ -310,6 +304,17 @@ def submit_gooey_builder_message(
         raise fastapi.HTTPException(status_code=404)
 
     workspace = get_current_workspace(request.user, request.session)
+    if builder_sr.error_type == exceptions.InsufficientCredits.__name__:
+        # A Builder retry does not use the shared credit error handler.
+        # Select and save the fallback workspace before the new run starts.
+        rerun_workspace = get_insufficient_credits_rerun_workspace(
+            current_user=request.user,
+            sr=builder_sr,
+            current_workspace=workspace,
+        )
+        if rerun_workspace:
+            workspace = rerun_workspace
+            set_current_workspace(request.session, workspace.id)
     if body.workflow_url:
         # copy the workflow_url into a new run linked to
         # builder_sr so the chat widget can navigate the user to a workflow page

--- a/daras_ai_v2/gooey_builder.py
+++ b/daras_ai_v2/gooey_builder.py
@@ -15,7 +15,7 @@ from bots.models import (
     SavedRun,
     PublishedRun,
 )
-from daras_ai_v2 import settings
+from daras_ai_v2 import exceptions, settings
 from daras_ai_v2.fastapi_tricks import fastapi_login_required
 from daras_ai_v2.web_widget_embed import (
     load_chat_widget_lib,
@@ -45,7 +45,11 @@ def render_gooey_builder(
 
     builder_sr = page.current_sr.parent_builder_saved_run
     handle_gooey_builder_redirect(builder_sr)
-
+    workflow_state = {
+        field_name: gui.session_state[field_name]
+        for field_name in page.fields_to_save()
+        if field_name in gui.session_state
+    }
     if builder_thread_is_empty(page):
         builder_run_url = None
         messages = []
@@ -54,6 +58,16 @@ def render_gooey_builder(
         messages = get_chat_widget_messages(
             builder_sr.to_dict(), web_url=builder_run_url
         )
+        if builder_sr.error_type == exceptions.InsufficientCredits.__name__:
+            render_gooey_builder_insufficient_credits(
+                request=request,
+                builder_sr=builder_sr,
+                current_workspace=page.current_workspace,
+                workflow_url=page.current_sr.get_app_url(),
+                workflow_state=workflow_state,
+            )
+            if messages and messages[-1].get("web_url") == builder_run_url:
+                messages.pop()
 
     render_gooey_builder_embed(
         # forwarded so the embed can tell a v2 page from a v1 one - without it every caller
@@ -62,11 +76,7 @@ def render_gooey_builder(
         event_key=event_key,
         builder_run_url=builder_run_url,
         messages=messages,
-        workflow_state={
-            field_name: gui.session_state[field_name]
-            for field_name in page.fields_to_save()
-            if field_name in gui.session_state
-        },
+        workflow_state=workflow_state,
     )
 
 
@@ -83,6 +93,18 @@ def render_standalone_gooey_builder(
         return
 
     handle_gooey_builder_redirect(builder_sr)
+    builder_run_url = builder_sr.get_app_url()
+    messages = get_chat_widget_messages(
+        builder_sr.to_dict(), web_url=builder_run_url
+    )
+    if builder_sr.error_type == exceptions.InsufficientCredits.__name__:
+        render_gooey_builder_insufficient_credits(
+            request=request,
+            builder_sr=builder_sr,
+            current_workspace=get_current_workspace(request.user, request.session),
+        )
+        if messages and messages[-1].get("web_url") == builder_run_url:
+            messages.pop()
 
     if builder_sr.run_status:
         # subscribe to the builder run so the page re-renders while it's
@@ -93,17 +115,49 @@ def render_standalone_gooey_builder(
         )
         gui.realtime_pull([channel])
 
-    builder_run_url = builder_sr.get_app_url()
     render_gooey_builder_embed(
         page=page or None,
         event_key=event_key,
         builder_run_url=builder_run_url,
-        messages=get_chat_widget_messages(
-            builder_sr.to_dict(), web_url=builder_run_url
-        ),
+        messages=messages,
         workflow_state={},
         builder_only=True,
     )
+
+
+def render_gooey_builder_insufficient_credits(
+    *,
+    request: fastapi.Request,
+    builder_sr: SavedRun,
+    current_workspace: Workspace | None,
+    workflow_url: str | None = None,
+    workflow_state: dict | None = None,
+) -> None:
+    retry_body = GooeyBuilderSendMessage(
+        workflow_url=workflow_url,
+        builder_run_url=builder_sr.get_app_url(),
+        workflow_state=workflow_state or {},
+    )
+
+    def on_rerun():
+        rerun_gooey_builder(request, retry_body)
+
+    error_params = dict(builder_sr.error_params or {})
+    error_params.update(
+        request=request,
+        sr=builder_sr,
+        current_workspace=current_workspace,
+        on_rerun=on_rerun,
+    )
+    with gui.div(className="gooey-builder-insufficient-credits"):
+        exceptions.InsufficientCredits.render(error_params)
+
+
+def rerun_gooey_builder(
+    request: fastapi.Request,
+    body: GooeyBuilderSendMessage,
+) -> typing.NoReturn:
+    raise gui.RedirectException(submit_gooey_builder_message(request, body))
 
 
 def render_gooey_builder_embed(
@@ -237,14 +291,27 @@ class GooeyBuilderSendMessage(pydantic.BaseModel):
 
 @router.post("/__/gooey-builder/send-message", dependencies=[fastapi_login_required])
 def gooey_builder_send_message(request: fastapi.Request, body: GooeyBuilderSendMessage):
+    return submit_gooey_builder_message(request, body)
+
+
+def submit_gooey_builder_message(
+    request: fastapi.Request, body: GooeyBuilderSendMessage
+) -> str:
     from daras_ai_v2.workflow_url_input import url_to_runs
     from functions.gooey_builder_tools import insert_gooey_builder_variables
 
     # inline import to avoid a circular dependency with routers.ask_gooey_new
     from routers.ask_gooey_new import get_gooey_builder_run_url
 
-    workspace = get_current_workspace(request.user, request.session)
+    builder_run_url = body.builder_run_url or get_default_builder_pr().get_app_url()
+    builder_page_cls, builder_sr, builder_pr = url_to_runs(builder_run_url)
+    if (
+        builder_sr.surface == SavedRun.Surface.builder_prompt
+        and builder_sr.uid != request.user.uid
+    ):
+        raise fastapi.HTTPException(status_code=404)
 
+    workspace = get_current_workspace(request.user, request.session)
     if body.workflow_url:
         # copy the workflow_url into a new run linked to
         # builder_sr so the chat widget can navigate the user to a workflow page
@@ -264,8 +331,6 @@ def gooey_builder_send_message(request: fastapi.Request, body: GooeyBuilderSendM
         workflow_sr = None
         workflow_url = ""
 
-    builder_run_url = body.builder_run_url or get_default_builder_pr().get_app_url()
-    builder_page_cls, builder_sr, builder_pr = url_to_runs(builder_run_url)
     request_body, message_thread = chat_widget_input_to_request_body(
         builder_sr, builder_sr.state, body.input_data or builder_sr.state
     )

--- a/daras_ai_v2/gooey_builder.py
+++ b/daras_ai_v2/gooey_builder.py
@@ -33,7 +33,6 @@ if typing.TYPE_CHECKING:
 
 DEFAULT_GOOEY_BUILDER_PHOTO_URL = "https://storage.googleapis.com/dara-c1b52.appspot.com/daras_ai/media/63bdb560-b891-11f0-b9bc-02420a00014a/generate-ai-abstract-symbol-artificial-intelligence-colorful-stars-icon-vector%201.jpg"
 GOOEY_BUILDER_EVENT_KEY = "builder-sidebar"
-GOOEY_BUILDER_RERUN_KEY = "--insufficient-credits-rerun-builder"
 
 
 def render_gooey_builder(
@@ -62,11 +61,10 @@ def render_gooey_builder(
         )
         if builder_sr.error_type == exceptions.InsufficientCredits.__name__:
             render_gooey_builder_insufficient_credits(
+                event_key=event_key,
                 request=request,
                 builder_sr=builder_sr,
                 current_workspace=page.current_workspace,
-                workflow_url=page.current_sr.get_app_url(),
-                workflow_state=workflow_state,
             )
             if messages and messages[-1].get("web_url") == builder_run_url:
                 messages.pop()
@@ -99,6 +97,7 @@ def render_standalone_gooey_builder(
     messages = get_chat_widget_messages(builder_sr.to_dict(), web_url=builder_run_url)
     if builder_sr.error_type == exceptions.InsufficientCredits.__name__:
         render_gooey_builder_insufficient_credits(
+            event_key=event_key,
             request=request,
             builder_sr=builder_sr,
             current_workspace=get_current_workspace(request.user, request.session),
@@ -127,26 +126,17 @@ def render_standalone_gooey_builder(
 
 def render_gooey_builder_insufficient_credits(
     *,
+    event_key: str,
     request: fastapi.Request,
     builder_sr: SavedRun,
     current_workspace: Workspace | None,
-    workflow_url: str | None = None,
-    workflow_state: dict | None = None,
 ) -> None:
-    retry_body = GooeyBuilderSendMessage(
-        workflow_url=workflow_url,
-        builder_run_url=builder_sr.get_app_url(),
-        workflow_state=workflow_state or {},
-    )
-    if gui.session_state.pop(GOOEY_BUILDER_RERUN_KEY, None):
-        raise gui.RedirectException(submit_gooey_builder_message(request, retry_body))
-
     error_params = dict(builder_sr.error_params or {})
     error_params.update(
         request=request,
         sr=builder_sr,
         current_workspace=current_workspace,
-        rerun_key=GOOEY_BUILDER_RERUN_KEY,
+        rerun_event=f"{event_key}:rerun",
     )
     with gui.div(className="gooey-builder-insufficient-credits"):
         exceptions.InsufficientCredits.render(error_params)
@@ -283,12 +273,6 @@ class GooeyBuilderSendMessage(pydantic.BaseModel):
 
 @router.post("/__/gooey-builder/send-message", dependencies=[fastapi_login_required])
 def gooey_builder_send_message(request: fastapi.Request, body: GooeyBuilderSendMessage):
-    return submit_gooey_builder_message(request, body)
-
-
-def submit_gooey_builder_message(
-    request: fastapi.Request, body: GooeyBuilderSendMessage
-) -> str:
     from daras_ai_v2.workflow_url_input import url_to_runs
     from functions.gooey_builder_tools import insert_gooey_builder_variables
 
@@ -300,8 +284,7 @@ def submit_gooey_builder_message(
 
     workspace = get_current_workspace(request.user, request.session)
     if builder_sr.error_type == exceptions.InsufficientCredits.__name__:
-        # A Builder retry does not use the shared credit error handler.
-        # Select and save the fallback workspace before the new run starts.
+        # Builder retries bypass the shared credit error handler.
         rerun_workspace = get_insufficient_credits_rerun_workspace(
             current_user=request.user,
             sr=builder_sr,

--- a/daras_ai_v2/gooey_builder.py
+++ b/daras_ai_v2/gooey_builder.py
@@ -281,6 +281,12 @@ def gooey_builder_send_message(request: fastapi.Request, body: GooeyBuilderSendM
 
     builder_run_url = body.builder_run_url or get_default_builder_pr().get_app_url()
     builder_page_cls, builder_sr, builder_pr = url_to_runs(builder_run_url)
+    if (
+        builder_sr.uid != request.user.uid
+        and not request.user.is_admin()
+        and builder_sr != get_default_builder_pr().saved_run
+    ):
+        raise fastapi.HTTPException(status_code=404)
 
     workspace = get_current_workspace(request.user, request.session)
     if builder_sr.error_type == exceptions.InsufficientCredits.__name__:

--- a/daras_ai_v2/web_widget_embed.py
+++ b/daras_ai_v2/web_widget_embed.py
@@ -32,6 +32,9 @@ def chat_widget_input_to_request_body(
         "input_images": input_data.get("input_images") or None,
         "input_documents": input_data.get("input_documents") or None,
     }
+    messages = (state.get("messages") or []).copy()
+    if messages:
+        ret["messages"] = messages
 
     button_pressed: list[str] | None = input_data.get("button_pressed")
     if button_pressed:
@@ -82,7 +85,7 @@ def chat_widget_input_to_request_body(
             assistant_entry["extra_content"] = extra_content
 
         # append previous input to the history
-        ret["messages"] = state.get("messages", []) + [user_entry, assistant_entry]
+        ret["messages"] = messages + [user_entry, assistant_entry]
 
     any_prev_input = prev_chat_input or state.get("input_prompt")
     if any_prev_input and sr.message_thread and sr.message_thread.last_run_id == sr.id:

--- a/gooey-gui/app/components/GooeyBuilderInlineEmbed.tsx
+++ b/gooey-gui/app/components/GooeyBuilderInlineEmbed.tsx
@@ -113,7 +113,5 @@ export function GooeyBuilderInlineEmbed(
     controllerRef.current?.setMessages?.(messages);
   }, [messages]);
 
-  // No `w-100`: Bootstrap's width utilities are `!important` and would beat the settled-width
-  // rule in app.css. Width is owned there.
-  return <div className="h-100" id="gooey-builder-embed" />;
+  return <div id="gooey-builder-embed" />;
 }

--- a/gooey-gui/app/components/GooeyBuilderInlineEmbed.tsx
+++ b/gooey-gui/app/components/GooeyBuilderInlineEmbed.tsx
@@ -101,11 +101,16 @@ export function GooeyBuilderInlineEmbed(
     const newConversationEvent = `${propsRef.current.event_key}:new`;
     const onNewConversation = () =>
       controllerRef.current?.onNewConversation?.();
+    const rerunEvent = `${propsRef.current.event_key}:rerun`;
+    const onRerun = () =>
+      controllerRef.current?.rerun?.(propsRef.current.builder_run_url);
     window.addEventListener(newConversationEvent, onNewConversation);
+    window.addEventListener(rerunEvent, onRerun);
 
     return () => {
       script?.removeEventListener("load", loadEmbed);
       window.removeEventListener(newConversationEvent, onNewConversation);
+      window.removeEventListener(rerunEvent, onRerun);
     };
   }, []);
 

--- a/gooey-gui/app/components/InsufficientCredits.css
+++ b/gooey-gui/app/components/InsufficientCredits.css
@@ -7,6 +7,11 @@
   padding: 16px 18px;
 }
 
+.gooey-builder-insufficient-credits > .insufficient-credits {
+  max-width: none;
+  width: 100%;
+}
+
 .insufficient-credits__title {
   align-items: center;
   color: #2a2a2a;

--- a/gooey-gui/app/components/InsufficientCredits.css
+++ b/gooey-gui/app/components/InsufficientCredits.css
@@ -7,9 +7,30 @@
   padding: 16px 18px;
 }
 
-.gooey-builder-insufficient-credits > .insufficient-credits {
+/* The card fills its wrapper's column in the v2 run pane and the Builder panel, and never
+   shrinks or scrolls: it is a short, fixed-shape notice with its own buttons, not a dump of
+   arbitrary error text. (The v2 error wrapper is otherwise a capped scroller.) */
+.gooey-builder-insufficient-credits,
+.v2-run-error:has(.insufficient-credits) {
+  flex-shrink: 0;
+  max-height: none;
+  overflow: visible;
+}
+
+.gooey-builder-insufficient-credits > .insufficient-credits,
+.v2-run-error > .insufficient-credits {
   max-width: none;
   width: 100%;
+}
+
+/* The content carrying on underneath the card fades in from its top edge, rather than the
+   card painting a translucent band over it. Fading the content itself (a mask) instead of
+   overlaying it keeps the effect invisible against whatever is below - a white message, a
+   dark code block - where a white veil would read as a grey bar over the dark one. */
+:has(> .gooey-builder-insufficient-credits) #gooey-builder-embed,
+.v2-run-error:has(.insufficient-credits) ~ .v2-run-output {
+  mask-image: linear-gradient(to bottom, transparent, #000 2.5rem);
+  -webkit-mask-image: linear-gradient(to bottom, transparent, #000 2.5rem);
 }
 
 .insufficient-credits__title {

--- a/gooey-gui/app/components/InsufficientCredits.css
+++ b/gooey-gui/app/components/InsufficientCredits.css
@@ -7,9 +7,7 @@
   padding: 16px 18px;
 }
 
-/* The card fills its wrapper's column in the v2 run pane and the Builder panel, and never
-   shrinks or scrolls: it is a short, fixed-shape notice with its own buttons, not a dump of
-   arbitrary error text. (The v2 error wrapper is otherwise a capped scroller.) */
+/* Keep this fixed-size notice outside the output scroller. */
 .gooey-builder-insufficient-credits,
 .v2-run-error:has(.insufficient-credits) {
   flex-shrink: 0;
@@ -23,10 +21,7 @@
   width: 100%;
 }
 
-/* The content carrying on underneath the card fades in from its top edge, rather than the
-   card painting a translucent band over it. Fading the content itself (a mask) instead of
-   overlaying it keeps the effect invisible against whatever is below - a white message, a
-   dark code block - where a white veil would read as a grey bar over the dark one. */
+/* Fade the output beneath the notice without tinting its contents. */
 :has(> .gooey-builder-insufficient-credits) #gooey-builder-embed,
 .v2-run-error:has(.insufficient-credits) ~ .v2-run-output {
   mask-image: linear-gradient(to bottom, transparent, #000 2.5rem);

--- a/gooey-gui/app/components/InsufficientCredits.tsx
+++ b/gooey-gui/app/components/InsufficientCredits.tsx
@@ -14,23 +14,27 @@ type InsufficientCreditsProps = CustomComponentProps & {
   showRerun: boolean;
   rerunWorkspaceName: string | null;
   rerunWorkspaceBalance: number | null;
+  rerunEvent?: string | null;
 };
 
 function SubmitKeyBtn({
   name,
   label,
   variant = "primary",
+  onClick,
 }: {
   name: string;
   label: string;
   variant?: "primary" | "secondary";
+  onClick?: () => void;
 }) {
   return (
     <button
-      type="submit"
+      type={onClick ? "button" : "submit"}
       name={name}
       value="1"
       className={`btn btn-theme p-2 m-0 btn-${variant}`}
+      onClick={onClick}
     >
       {label}
     </button>
@@ -82,6 +86,7 @@ export function InsufficientCredits({
   showRerun,
   rerunWorkspaceName,
   rerunWorkspaceBalance,
+  rerunEvent,
 }: InsufficientCreditsProps) {
   if (isAnonymous) {
     return (
@@ -113,6 +118,11 @@ export function InsufficientCredits({
             name={rerunKey}
             label={`Re-run in ${rerunWorkspaceName}`}
             variant={showUpgrade ? "secondary" : "primary"}
+            onClick={
+              rerunEvent
+                ? () => window.dispatchEvent(new CustomEvent(rerunEvent))
+                : undefined
+            }
           />
         ) : (
           <SubmitKeyBtn

--- a/gooey-gui/app/components/RecipeTopBar/RecipeTopBar.css
+++ b/gooey-gui/app/components/RecipeTopBar/RecipeTopBar.css
@@ -613,27 +613,30 @@ a.gooey-topbar-cost:hover {
   }
 }
 
-/* ---------------------------------------------------- gooey builder close
-
-   The Builder's collapse control, on the panel's own top-right corner. It belongs to the
-   panel, not to the workflow, so it sits on the panel's edge rather than in the top bar.
-   v2 only: v1 keeps the widget's own header and never renders this. */
-.v2-builder-close {
-  /* absolute against `.gooey-sidebar`, which is positioned at every width, so there is no
-     app-header offset to hardcode */
+/* v2 supplies the Builder header because the embedded widget's header is hidden. */
+.v2-builder-header {
   position: absolute;
-  top: 0.5rem;
-  right: 0.5rem;
+  top: 0;
+  right: 0;
+  left: 0;
   z-index: 5;
+  display: flex;
+  align-items: center;
+  flex: none;
+  padding: 0.5rem;
 }
 
-/* The panel's title and its "new conversation" control, since v2 hides the widget's own
-   header. Anchored like the close button. */
-.v2-builder-new {
-  position: absolute;
-  top: 0.6rem;
-  left: 0.5rem;
-  z-index: 5;
+.v2-builder-header:has(+ .gooey-builder-insufficient-credits) {
+  position: relative;
+  background: var(--gooey-bg-page);
+}
+
+.v2-builder-header .v2-pane-control {
+  background: rgb(255 255 255 / 92%);
+}
+
+.v2-builder-close {
+  margin-left: auto;
 }
 
 /* The shell paints the ground the Builder panel and the tab body sit on. Without it the
@@ -718,6 +721,11 @@ a.gooey-topbar-cost:hover {
   .v2-builder-close {
     /* `!important`: the control renders with Bootstrap display utilities. */
     display: none !important;
+  }
+
+  /* Do not leave an empty header above a new conversation. */
+  .v2-builder-header:not(:has(.v2-builder-new)) {
+    display: none;
   }
 }
 

--- a/gooey-gui/app/components/RecipeTopBar/RecipeTopBar.css
+++ b/gooey-gui/app/components/RecipeTopBar/RecipeTopBar.css
@@ -639,40 +639,19 @@ a.gooey-topbar-cost:hover {
   margin-left: auto;
 }
 
-/* The shell paints the ground the Builder panel and the tab body sit on. Without it the
-   `gap-2` between the two shows whatever is behind the shell instead. */
+/* Paint the gap between the Builder and tab body. */
 .v2-app-shell {
   background-color: var(--gooey-bg-page);
 }
 
-/* v2 mounts the panel inside the app shell, below the top bar, so `100dvh` would overrun
-   its container by the bar's height. Scoped so v1's full-height sidebar is untouched. */
+/* v2 mounts the panel inside the app shell, below the top bar. */
 .v2-app-shell .gooey-sidebar {
   height: 100%;
-  /* Panels and rails share one surface; `#f9f9f9` is v1's and stays there. */
   background-color: var(--gooey-surface-50);
 }
 
-/* Ask Gooey is a surface *below* the header in v2, not a takeover of it.
-
-   `.gooey-sidebar-open` goes `position: fixed; width: 100vw; z-index: 1035` at this width, and
-   its own comment says why: it had to sit above `.nav-mobile-topbar`, the sidebar's slim mobile
-   bar, because the panel was meant to cover the whole app. That bar no longer exists - this bar
-   is the app's only header now - so the takeover covers the one piece of chrome the design
-   keeps on screen, and with it the way back out of the panel.
-
-   So the panel goes back in flow and fills the shell it is already mounted in, which starts
-   below the header. The pane behind it is dropped rather than left to share the row: `Sidebar`
-   lays its two children out as a flex row, so a full-width panel would otherwise squeeze the
-   workspace to nothing beside it instead of replacing it. Selecting a view from the sheet
-   closes the panel, which brings that pane straight back.
-
-   Scoped to `.v2-app-shell`, so v1 keeps its own behaviour. */
+/* Keep the v2 Builder inside the shell instead of covering the app header. */
 @media (max-width: 1140px) {
-  /* v1 turns the panel into a fixed, full-viewport takeover below this width, because there
-     it flanks the whole page. v2 mounts it inside the shell, below the header, so it stays in
-     flow at every width - otherwise it covers the one piece of chrome that gets you back out.
-     Still a rail down to lg; only below that does it replace what sits beside it. */
   .v2-app-shell .gooey-sidebar-open {
     position: relative;
     z-index: auto;
@@ -683,17 +662,12 @@ a.gooey-topbar-cost:hover {
     max-width: var(--sidebar_open_width);
   }
 
-  /* The panel is a box inside the body's padding here, not the viewport, so the widget fills
-     the panel rather than `--sidebar_mobile_width`. */
   .v2-app-shell .gooey-sidebar #gooey-builder-embed {
     width: 100%;
   }
 }
 
-/* Below lg the shell shows one surface at a time, so Ask Gooey takes the row. Same threshold
-   as the top bar's navigation stack and the pane fold - the panel used to switch at the
-   sidebar's own 1140 instead, which left it covering the screen while the bar above it was
-   still in its desktop arrangement. */
+/* Below lg, the Builder replaces the workspace body. */
 @media (max-width: 991.98px) {
   .v2-app-shell .gooey-sidebar-open {
     min-width: 0;
@@ -701,25 +675,18 @@ a.gooey-topbar-cost:hover {
     max-width: 100%;
   }
 
-  /* ...and the workspace behind it steps aside. `:has()` rather than a descendant match,
-     since on API or Deploy the sibling is the tab's own body, not a pane. `!important`
-     because that sibling carries Bootstrap's `d-flex`. */
+  /* The sibling carries Bootstrap's `d-flex`. */
   .v2-app-shell:has(.recipe-workspace) .gooey-sidebar-open ~ div {
     display: none !important;
   }
 
-  /* Not shown on those tabs at all: Ask Gooey is the root of the workspace stack, so over
-     API or Deploy there would be nothing behind it to close back to. This covers arriving
-     with it already open - Back, a reload, a deep link. */
+  /* API and Deploy have no workspace view to return to. */
   .v2-app-shell:not(:has(.recipe-workspace)) .gooey-sidebar-open {
     display: none !important;
   }
 
-  /* The close control goes - at the root of the stack there is no view to close back to.
-     The title pill stays: it names the surface and starts a new conversation, and the panel
-     is the whole screen here, so there is nothing beside it for the label to crowd. */
+  /* At the root of the mobile stack there is no view to close back to. */
   .v2-builder-close {
-    /* `!important`: the control renders with Bootstrap display utilities. */
     display: none !important;
   }
 

--- a/gooey-gui/app/components/RecipeWorkspace/RecipeWorkspace.css
+++ b/gooey-gui/app/components/RecipeWorkspace/RecipeWorkspace.css
@@ -107,6 +107,11 @@
   min-height: 0;
   max-height: 45%;
   overflow-y: auto;
+  /* Same reading column as the output below it: capped and centred, so the notice lines up
+     with the content instead of stretching across the whole pane. */
+  width: 100%;
+  max-width: 760px;
+  margin-inline: auto;
 }
 
 .recipe-workspace-controls {

--- a/gooey-gui/app/components/RecipeWorkspace/RecipeWorkspace.css
+++ b/gooey-gui/app/components/RecipeWorkspace/RecipeWorkspace.css
@@ -107,8 +107,6 @@
   min-height: 0;
   max-height: 45%;
   overflow-y: auto;
-  /* Same reading column as the output below it: capped and centred, so the notice lines up
-     with the content instead of stretching across the whole pane. */
   width: 100%;
   max-width: 760px;
   margin-inline: auto;

--- a/gooey-gui/app/styles/app.css
+++ b/gooey-gui/app/styles/app.css
@@ -406,8 +406,10 @@ button .gui-html-container,
   border-right: 1px solid #e0e0e0;
 }
 
-/* Default: fill whatever holds it - the standalone builder page has no panel around it. */
+/* Fill the space left below Builder headers and notices. */
 #gooey-builder-embed {
+  flex: 1 1 0;
+  min-height: 0;
   width: 100%;
 }
 

--- a/routers/ask_gooey_new.py
+++ b/routers/ask_gooey_new.py
@@ -59,7 +59,7 @@ def gooey_builder_run_route(request: Request, title: str, run_id: str):
     if gui.session_state.pop("builderOnNewConversation", None):
         raise gui.RedirectException(get_route_path(ask_gooey_new_page))
 
-    # explicit viewport height so the embed's h-100 fills the screen
+    # Bound the flex column so the Builder embed can fill its remaining height.
     with (
         sidebar_page_wrapper(request, full_width_content=True),
         gui.div(

--- a/routers/ask_gooey_new.py
+++ b/routers/ask_gooey_new.py
@@ -59,7 +59,6 @@ def gooey_builder_run_route(request: Request, title: str, run_id: str):
     if gui.session_state.pop("builderOnNewConversation", None):
         raise gui.RedirectException(get_route_path(ask_gooey_new_page))
 
-    # Bound the flex column so the Builder embed can fill its remaining height.
     with (
         sidebar_page_wrapper(request, full_width_content=True),
         gui.div(

--- a/tests/test_layout_v2.py
+++ b/tests/test_layout_v2.py
@@ -32,6 +32,8 @@ from gooey_gui.types.recipe_workspace_props import (
 from recipes.VideoBots import VideoBotsPage
 from recipes.VideoBots_v2 import VideoBotsPageV2
 from routers.root import RecipeTabs
+from widgets.errors import insufficient_credits_error
+from workspaces.widgets import SESSION_SELECTED_WORKSPACE
 
 
 def test_video_bots_v2_uses_existing_celery_runner_class():
@@ -264,6 +266,32 @@ def test_submit_intent_is_consumed_once():
 
     assert page._pop_submit_intent() == RunIntent()
     assert page._pop_submit_intent() is None
+
+
+def test_v2_translates_insufficient_credits_rerun_to_run_intent():
+    workspace = SimpleNamespace(id=42, balance=10, is_personal=True)
+    user = SimpleNamespace(
+        uid="user-1",
+        is_anonymous=False,
+        cached_workspaces=[workspace],
+        get_or_create_personal_workspace=lambda: (workspace, False),
+    )
+    saved_run = SimpleNamespace(uid=user.uid, workspace=workspace)
+    request = SimpleNamespace(user=user, session={})
+    page = object.__new__(VideoBotsPageV2)
+    page.request = request
+    page.current_sr = saved_run
+    page.current_workspace = workspace
+    gui.session_state.clear()
+    gui.session_state["--insufficient-credits-rerun"] = "1"
+
+    with pytest.raises(gui.RerunException):
+        insufficient_credits_error(page._get_default_error_params())
+
+    assert request.session[SESSION_SELECTED_WORKSPACE] == workspace.id
+    assert gui.session_state == {"-submit-workflow": True}
+    assert page._pop_submit_intent() == RunIntent()
+    assert not gui.session_state
 
 
 def test_about_deployment_cards_carry_the_chips_targets():

--- a/widgets/errors.py
+++ b/widgets/errors.py
@@ -17,6 +17,7 @@ def insufficient_credits_error(error_params: dict):
     sr = error_params["sr"]
     current_workspace = error_params.get("current_workspace")
     price = error_params.get("price", None)
+    on_rerun = error_params.get("on_rerun")
     current_user = request.user
     personal_workspace = (
         current_user and current_user.get_or_create_personal_workspace()[0]
@@ -66,6 +67,8 @@ def insufficient_credits_error(error_params: dict):
     if gui.session_state.pop(RERUN_KEY, None):
         if rerun_workspace:
             set_current_workspace(request.session, rerun_workspace.id)
+        if on_rerun:
+            return on_rerun()
         gui.session_state["-submit-workflow"] = True
         raise gui.RerunException()
 

--- a/widgets/errors.py
+++ b/widgets/errors.py
@@ -17,10 +17,12 @@ def insufficient_credits_error(error_params: dict):
     sr = error_params["sr"]
     current_workspace = error_params.get("current_workspace")
     price = error_params.get("price", None)
-    on_rerun = error_params.get("on_rerun")
+    rerun_key = error_params.get("rerun_key", RERUN_KEY)
     current_user = request.user
-    personal_workspace = (
-        current_user and current_user.get_or_create_personal_workspace()[0]
+    rerun_workspace = get_insufficient_credits_rerun_workspace(
+        current_user=current_user,
+        sr=sr,
+        current_workspace=current_workspace,
     )
 
     show_upgrade = False
@@ -31,17 +33,14 @@ def insufficient_credits_error(error_params: dict):
         or sr.workspace not in current_user.cached_workspaces
     ):
         title = "Run failed (Not enough credits)"
-        rerun_workspace = current_workspace
 
     elif current_user.uid == sr.uid and len(current_user.cached_workspaces) <= 1:
         title = "You've run out of Gooey.AI credits"
-        rerun_workspace = personal_workspace
 
     else:
         title = (
             f"You've run out of credits in {sr.workspace.display_name(current_user)}"
         )
-        rerun_workspace = personal_workspace
         if not sr.workspace.is_personal and current_user in sr.workspace.get_admins():
             show_upgrade = True
 
@@ -64,11 +63,9 @@ def insufficient_credits_error(error_params: dict):
     else:
         account_url = get_app_route_url(account_route)
 
-    if gui.session_state.pop(RERUN_KEY, None):
+    if gui.session_state.pop(rerun_key, None):
         if rerun_workspace:
             set_current_workspace(request.session, rerun_workspace.id)
-        if on_rerun:
-            return on_rerun()
         gui.session_state["-submit-workflow"] = True
         raise gui.RerunException()
 
@@ -87,7 +84,7 @@ def insufficient_credits_error(error_params: dict):
         accountUrl=account_url,
         isAnonymous=is_anonymous,
         verifiedEmailUserFreeCredits=settings.VERIFIED_EMAIL_USER_FREE_CREDITS,
-        rerunKey=RERUN_KEY,
+        rerunKey=rerun_key,
         upgradeKey=UPGRADE_KEY,
         buyCreditsKey=BUY_CREDITS_KEY,
         price=price,
@@ -97,3 +94,15 @@ def insufficient_credits_error(error_params: dict):
         rerunWorkspaceBalance=(rerun_workspace.balance if rerun_workspace else None),
         rerunWorkspaceName=rerun_workspace_name,
     )
+
+
+def get_insufficient_credits_rerun_workspace(*, current_user, sr, current_workspace):
+    # Keep the current workspace if the user cannot access the run workspace.
+    # Otherwise, retry in the personal workspace because the run workspace has insufficient credits.
+    if (
+        not current_user
+        or not sr.workspace
+        or sr.workspace not in current_user.cached_workspaces
+    ):
+        return current_workspace
+    return current_user.get_or_create_personal_workspace()[0]

--- a/widgets/errors.py
+++ b/widgets/errors.py
@@ -17,7 +17,6 @@ def insufficient_credits_error(error_params: dict):
     sr = error_params["sr"]
     current_workspace = error_params.get("current_workspace")
     price = error_params.get("price", None)
-    rerun_key = error_params.get("rerun_key", RERUN_KEY)
     current_user = request.user
     rerun_workspace = get_insufficient_credits_rerun_workspace(
         current_user=current_user,
@@ -63,7 +62,7 @@ def insufficient_credits_error(error_params: dict):
     else:
         account_url = get_app_route_url(account_route)
 
-    if gui.session_state.pop(rerun_key, None):
+    if gui.session_state.pop(RERUN_KEY, None):
         if rerun_workspace:
             set_current_workspace(request.session, rerun_workspace.id)
         gui.session_state["-submit-workflow"] = True
@@ -84,7 +83,8 @@ def insufficient_credits_error(error_params: dict):
         accountUrl=account_url,
         isAnonymous=is_anonymous,
         verifiedEmailUserFreeCredits=settings.VERIFIED_EMAIL_USER_FREE_CREDITS,
-        rerunKey=rerun_key,
+        rerunKey=RERUN_KEY,
+        rerunEvent=error_params.get("rerun_event"),
         upgradeKey=UPGRADE_KEY,
         buyCreditsKey=BUY_CREDITS_KEY,
         price=price,
@@ -97,8 +97,7 @@ def insufficient_credits_error(error_params: dict):
 
 
 def get_insufficient_credits_rerun_workspace(*, current_user, sr, current_workspace):
-    # Keep the current workspace if the user cannot access the run workspace.
-    # Otherwise, retry in the personal workspace because the run workspace has insufficient credits.
+    # Keep the current workspace when the run's workspace is inaccessible.
     if (
         not current_user
         or not sr.workspace


### PR DESCRIPTION
- Builder credit failures bypassed the normal workflow error surface, so the sidebar and /new flow could lose retry actions, show a failed assistant placeholder, or drop existing conversation history.

- Reuse the shared credit renderer with a Builder-specific retry, preserve prior messages, reject cross-user retries, and keep the Builder header and embed bounded without changing other embed surfaces.

### Q/A checklist

- [ ] I have tested my UI changes on mobile and they look acceptable
- [ ] I have tested changes to the workflows in both the API and the UI
- [ ] I have done a code review of my changes and looked at each line of the diff + the references of each function I have changed
- [ ] My changes have not increased the import time of the server

<details>
<summary>How to check import time?</summary>
<p>

```bash
time python -c 'import server'
```

You can visualize this using tuna:

```bash
python3 -X importtime -c 'import server' 2> out.log && tuna out.log
```

To measure import time for a specific library:

```bash
$ time python -c 'import pandas'

________________________________________________________
Executed in    1.15 secs    fish           external
   usr time    2.22 secs   86.00 micros    2.22 secs
   sys time    0.72 secs  613.00 micros    0.72 secs
```

To reduce import times, import libraries that take a long time inside the functions that use them instead of at the top of the file:

```python
def my_function():
    import pandas as pd
    ...
```

</p>
</details>

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
