### PR TITLE
feat: add GPT Image 2.5 Sunburst and Flare

### DIFF
--- a/daras_ai_v2/img_model_settings_widgets.py
+++ b/daras_ai_v2/img_model_settings_widgets.py
@@ -14,8 +14,8 @@ PROPRIETARY_MODELS = {
     Text2ImgModels.nano_banana_pro.name,
     Text2ImgModels.nano_banana_2.name,
     Text2ImgModels.nano_banana.name,
-    Text2ImgModels.gpt_image_sunburst.name,
-    Text2ImgModels.gpt_image_flare.name,
+    Text2ImgModels.gpt_image_2_5_sunburst.name,
+    Text2ImgModels.gpt_image_2_5_flare.name,
     Text2ImgModels.gpt_image_2.name,
     Text2ImgModels.gpt_image_1.name,
     Text2ImgModels.gpt_image_1_5.name,
@@ -232,8 +232,8 @@ def quality_setting(selected_models: set[str]):
         )
 
     if selected_models & {
-        Text2ImgModels.gpt_image_sunburst.name,
-        Text2ImgModels.gpt_image_flare.name,
+        Text2ImgModels.gpt_image_2_5_sunburst.name,
+        Text2ImgModels.gpt_image_2_5_flare.name,
         Text2ImgModels.gpt_image_2.name,
         Text2ImgModels.gpt_image_1.name,
         Text2ImgModels.gpt_image_1_5.name,
@@ -371,8 +371,8 @@ def output_resolution_setting(selected_models: set[str]):
         pixel_options = ["1024p"]
         allowed_shapes = ["square", "wide"]
     elif selected_models <= {
-        Text2ImgModels.gpt_image_sunburst.name,
-        Text2ImgModels.gpt_image_flare.name,
+        Text2ImgModels.gpt_image_2_5_sunburst.name,
+        Text2ImgModels.gpt_image_2_5_flare.name,
         Text2ImgModels.gpt_image_2.name,
         Text2ImgModels.gpt_image_1.name,
         Text2ImgModels.gpt_image_1_5.name,

--- a/daras_ai_v2/img_model_settings_widgets.py
+++ b/daras_ai_v2/img_model_settings_widgets.py
@@ -14,6 +14,8 @@ PROPRIETARY_MODELS = {
     Text2ImgModels.nano_banana_pro.name,
     Text2ImgModels.nano_banana_2.name,
     Text2ImgModels.nano_banana.name,
+    Text2ImgModels.gpt_image_sunburst.name,
+    Text2ImgModels.gpt_image_flare.name,
     Text2ImgModels.gpt_image_2.name,
     Text2ImgModels.gpt_image_1.name,
     Text2ImgModels.gpt_image_1_5.name,
@@ -230,6 +232,8 @@ def quality_setting(selected_models: set[str]):
         )
 
     if selected_models & {
+        Text2ImgModels.gpt_image_sunburst.name,
+        Text2ImgModels.gpt_image_flare.name,
         Text2ImgModels.gpt_image_2.name,
         Text2ImgModels.gpt_image_1.name,
         Text2ImgModels.gpt_image_1_5.name,
@@ -367,6 +371,8 @@ def output_resolution_setting(selected_models: set[str]):
         pixel_options = ["1024p"]
         allowed_shapes = ["square", "wide"]
     elif selected_models <= {
+        Text2ImgModels.gpt_image_sunburst.name,
+        Text2ImgModels.gpt_image_flare.name,
         Text2ImgModels.gpt_image_2.name,
         Text2ImgModels.gpt_image_1.name,
         Text2ImgModels.gpt_image_1_5.name,

--- a/daras_ai_v2/stable_diffusion.py
+++ b/daras_ai_v2/stable_diffusion.py
@@ -49,8 +49,8 @@ class Text2ImgModels(Enum):
 
     flux_1_dev = "FLUX.1 [dev]"
 
-    gpt_image_sunburst = "GPT Image Sunburst (OpenAI)"
-    gpt_image_flare = "GPT Image Flare (OpenAI)"
+    gpt_image_2_5_sunburst = "GPT Image 2.5 Sunburst (OpenAI)"
+    gpt_image_2_5_flare = "GPT Image 2.5 Flare (OpenAI)"
     gpt_image_2 = "GPT Image 2 (OpenAI)"
     gpt_image_1 = "GPT Image 1 (OpenAI)"
     gpt_image_1_5 = "GPT Image 1.5 (OpenAI)"
@@ -93,8 +93,8 @@ text2img_model_ids = {
     Text2ImgModels.nano_banana_pro: "fal-ai/nano-banana-pro",
     Text2ImgModels.nano_banana_2: "fal-ai/nano-banana-2",
     Text2ImgModels.nano_banana: "fal-ai/nano-banana",
-    Text2ImgModels.gpt_image_sunburst: "gpt-image-sunburst",
-    Text2ImgModels.gpt_image_flare: "gpt-image-flare",
+    Text2ImgModels.gpt_image_2_5_sunburst: "gpt-image-2.5-sunburst",
+    Text2ImgModels.gpt_image_2_5_flare: "gpt-image-2.5-flare",
     Text2ImgModels.gpt_image_2: "gpt-image-2",
     Text2ImgModels.gpt_image_1: "gpt-image-1",
     Text2ImgModels.gpt_image_1_5: "gpt-image-1.5",
@@ -115,8 +115,8 @@ class Img2ImgModels(Enum):
 
     flux_pro_kontext = "FLUX.1 Pro Kontext (fal.ai)"
 
-    gpt_image_sunburst = "GPT Image Sunburst (OpenAI)"
-    gpt_image_flare = "GPT Image Flare (OpenAI)"
+    gpt_image_2_5_sunburst = "GPT Image 2.5 Sunburst (OpenAI)"
+    gpt_image_2_5_flare = "GPT Image 2.5 Flare (OpenAI)"
     gpt_image_2 = "GPT Image 2 (OpenAI)"
     gpt_image_1 = "GPT Image 1 (OpenAI)"
     gpt_image_1_5 = "GPT Image 1.5 (OpenAI)"
@@ -156,8 +156,8 @@ class Img2ImgModels(Enum):
             cls.nano_banana,
             cls.nano_banana_2,
             cls.nano_banana_pro,
-            cls.gpt_image_sunburst,
-            cls.gpt_image_flare,
+            cls.gpt_image_2_5_sunburst,
+            cls.gpt_image_2_5_flare,
             cls.gpt_image_2,
             cls.gpt_image_1,
             cls.gpt_image_1_5,
@@ -171,8 +171,8 @@ img2img_model_ids = {
     Img2ImgModels.dream_shaper: "Lykon/DreamShaper",
     Img2ImgModels.dreamlike_2: "dreamlike-art/dreamlike-photoreal-2.0",
     Img2ImgModels.dall_e: "dall-e-2",
-    Img2ImgModels.gpt_image_sunburst: "gpt-image-sunburst",
-    Img2ImgModels.gpt_image_flare: "gpt-image-flare",
+    Img2ImgModels.gpt_image_2_5_sunburst: "gpt-image-2.5-sunburst",
+    Img2ImgModels.gpt_image_2_5_flare: "gpt-image-2.5-flare",
     Img2ImgModels.gpt_image_2: "gpt-image-2",
     Img2ImgModels.gpt_image_1: "gpt-image-1",
     Img2ImgModels.gpt_image_1_5: "gpt-image-1.5",
@@ -355,8 +355,8 @@ def text2img(
     if model not in {
         Text2ImgModels.dall_e_3,
         Text2ImgModels.flux_1_dev,
-        Text2ImgModels.gpt_image_sunburst,
-        Text2ImgModels.gpt_image_flare,
+        Text2ImgModels.gpt_image_2_5_sunburst,
+        Text2ImgModels.gpt_image_2_5_flare,
         Text2ImgModels.gpt_image_2,
         Text2ImgModels.gpt_image_1,
         Text2ImgModels.gpt_image_1_5,
@@ -388,8 +388,8 @@ def text2img(
             )
             return output_images
         case (
-            Text2ImgModels.gpt_image_sunburst
-            | Text2ImgModels.gpt_image_flare
+            Text2ImgModels.gpt_image_2_5_sunburst
+            | Text2ImgModels.gpt_image_2_5_flare
             | Text2ImgModels.gpt_image_2
             | Text2ImgModels.gpt_image_1
             | Text2ImgModels.gpt_image_1_5
@@ -602,8 +602,8 @@ def img2img(
 
     if not prompt and selected_model in (
         Img2ImgModels.flux_pro_kontext.name,
-        Img2ImgModels.gpt_image_sunburst.name,
-        Img2ImgModels.gpt_image_flare.name,
+        Img2ImgModels.gpt_image_2_5_sunburst.name,
+        Img2ImgModels.gpt_image_2_5_flare.name,
         Img2ImgModels.gpt_image_2.name,
         Img2ImgModels.gpt_image_1.name,
         Img2ImgModels.gpt_image_1_5.name,
@@ -640,8 +640,8 @@ def img2img(
 
             return output_images
         case (
-            Img2ImgModels.gpt_image_sunburst.name
-            | Img2ImgModels.gpt_image_flare.name
+            Img2ImgModels.gpt_image_2_5_sunburst.name
+            | Img2ImgModels.gpt_image_2_5_flare.name
             | Img2ImgModels.gpt_image_2.name
             | Img2ImgModels.gpt_image_1.name
             | Img2ImgModels.gpt_image_1_5.name

--- a/daras_ai_v2/stable_diffusion.py
+++ b/daras_ai_v2/stable_diffusion.py
@@ -49,6 +49,8 @@ class Text2ImgModels(Enum):
 
     flux_1_dev = "FLUX.1 [dev]"
 
+    gpt_image_sunburst = "GPT Image Sunburst (OpenAI)"
+    gpt_image_flare = "GPT Image Flare (OpenAI)"
     gpt_image_2 = "GPT Image 2 (OpenAI)"
     gpt_image_1 = "GPT Image 1 (OpenAI)"
     gpt_image_1_5 = "GPT Image 1.5 (OpenAI)"
@@ -91,6 +93,8 @@ text2img_model_ids = {
     Text2ImgModels.nano_banana_pro: "fal-ai/nano-banana-pro",
     Text2ImgModels.nano_banana_2: "fal-ai/nano-banana-2",
     Text2ImgModels.nano_banana: "fal-ai/nano-banana",
+    Text2ImgModels.gpt_image_sunburst: "gpt-image-sunburst",
+    Text2ImgModels.gpt_image_flare: "gpt-image-flare",
     Text2ImgModels.gpt_image_2: "gpt-image-2",
     Text2ImgModels.gpt_image_1: "gpt-image-1",
     Text2ImgModels.gpt_image_1_5: "gpt-image-1.5",
@@ -111,6 +115,8 @@ class Img2ImgModels(Enum):
 
     flux_pro_kontext = "FLUX.1 Pro Kontext (fal.ai)"
 
+    gpt_image_sunburst = "GPT Image Sunburst (OpenAI)"
+    gpt_image_flare = "GPT Image Flare (OpenAI)"
     gpt_image_2 = "GPT Image 2 (OpenAI)"
     gpt_image_1 = "GPT Image 1 (OpenAI)"
     gpt_image_1_5 = "GPT Image 1.5 (OpenAI)"
@@ -150,6 +156,8 @@ class Img2ImgModels(Enum):
             cls.nano_banana,
             cls.nano_banana_2,
             cls.nano_banana_pro,
+            cls.gpt_image_sunburst,
+            cls.gpt_image_flare,
             cls.gpt_image_2,
             cls.gpt_image_1,
             cls.gpt_image_1_5,
@@ -163,6 +171,8 @@ img2img_model_ids = {
     Img2ImgModels.dream_shaper: "Lykon/DreamShaper",
     Img2ImgModels.dreamlike_2: "dreamlike-art/dreamlike-photoreal-2.0",
     Img2ImgModels.dall_e: "dall-e-2",
+    Img2ImgModels.gpt_image_sunburst: "gpt-image-sunburst",
+    Img2ImgModels.gpt_image_flare: "gpt-image-flare",
     Img2ImgModels.gpt_image_2: "gpt-image-2",
     Img2ImgModels.gpt_image_1: "gpt-image-1",
     Img2ImgModels.gpt_image_1_5: "gpt-image-1.5",
@@ -345,6 +355,8 @@ def text2img(
     if model not in {
         Text2ImgModels.dall_e_3,
         Text2ImgModels.flux_1_dev,
+        Text2ImgModels.gpt_image_sunburst,
+        Text2ImgModels.gpt_image_flare,
         Text2ImgModels.gpt_image_2,
         Text2ImgModels.gpt_image_1,
         Text2ImgModels.gpt_image_1_5,
@@ -376,7 +388,9 @@ def text2img(
             )
             return output_images
         case (
-            Text2ImgModels.gpt_image_2
+            Text2ImgModels.gpt_image_sunburst
+            | Text2ImgModels.gpt_image_flare
+            | Text2ImgModels.gpt_image_2
             | Text2ImgModels.gpt_image_1
             | Text2ImgModels.gpt_image_1_5
         ):
@@ -588,6 +602,8 @@ def img2img(
 
     if not prompt and selected_model in (
         Img2ImgModels.flux_pro_kontext.name,
+        Img2ImgModels.gpt_image_sunburst.name,
+        Img2ImgModels.gpt_image_flare.name,
         Img2ImgModels.gpt_image_2.name,
         Img2ImgModels.gpt_image_1.name,
         Img2ImgModels.gpt_image_1_5.name,
@@ -624,7 +640,9 @@ def img2img(
 
             return output_images
         case (
-            Img2ImgModels.gpt_image_2.name
+            Img2ImgModels.gpt_image_sunburst.name
+            | Img2ImgModels.gpt_image_flare.name
+            | Img2ImgModels.gpt_image_2.name
             | Img2ImgModels.gpt_image_1.name
             | Img2ImgModels.gpt_image_1_5.name
         ):

--- a/recipes/CompareText2Img.py
+++ b/recipes/CompareText2Img.py
@@ -283,8 +283,8 @@ class CompareText2ImgPage(BasePage):
                 case (
                     Text2ImgModels.gpt_image_1.name
                     | Text2ImgModels.gpt_image_1_5.name
-                    | Text2ImgModels.gpt_image_sunburst.name
-                    | Text2ImgModels.gpt_image_flare.name
+                    | Text2ImgModels.gpt_image_2_5_sunburst.name
+                    | Text2ImgModels.gpt_image_2_5_flare.name
                     | Text2ImgModels.gpt_image_2.name
                 ):
                     grouped_costs = self.get_grouped_linked_usage_cost_in_credits()

--- a/recipes/CompareText2Img.py
+++ b/recipes/CompareText2Img.py
@@ -283,6 +283,8 @@ class CompareText2ImgPage(BasePage):
                 case (
                     Text2ImgModels.gpt_image_1.name
                     | Text2ImgModels.gpt_image_1_5.name
+                    | Text2ImgModels.gpt_image_sunburst.name
+                    | Text2ImgModels.gpt_image_flare.name
                     | Text2ImgModels.gpt_image_2.name
                 ):
                     grouped_costs = self.get_grouped_linked_usage_cost_in_credits()

--- a/recipes/Img2Img.py
+++ b/recipes/Img2Img.py
@@ -187,6 +187,8 @@ class Img2ImgPage(BasePage):
             request.selected_model
             in [
                 Img2ImgModels.dall_e.name,
+                Img2ImgModels.gpt_image_sunburst.name,
+                Img2ImgModels.gpt_image_flare.name,
                 Img2ImgModels.gpt_image_2.name,
                 Img2ImgModels.gpt_image_1.name,
                 Img2ImgModels.gpt_image_1_5.name,
@@ -251,6 +253,8 @@ class Img2ImgPage(BasePage):
             case (
                 Img2ImgModels.gpt_image_1.name
                 | Img2ImgModels.gpt_image_1_5.name
+                | Img2ImgModels.gpt_image_sunburst.name
+                | Img2ImgModels.gpt_image_flare.name
                 | Img2ImgModels.gpt_image_2.name
             ):
                 match state.get("gpt_image_1_quality"):

--- a/recipes/Img2Img.py
+++ b/recipes/Img2Img.py
@@ -187,8 +187,8 @@ class Img2ImgPage(BasePage):
             request.selected_model
             in [
                 Img2ImgModels.dall_e.name,
-                Img2ImgModels.gpt_image_sunburst.name,
-                Img2ImgModels.gpt_image_flare.name,
+                Img2ImgModels.gpt_image_2_5_sunburst.name,
+                Img2ImgModels.gpt_image_2_5_flare.name,
                 Img2ImgModels.gpt_image_2.name,
                 Img2ImgModels.gpt_image_1.name,
                 Img2ImgModels.gpt_image_1_5.name,
@@ -253,8 +253,8 @@ class Img2ImgPage(BasePage):
             case (
                 Img2ImgModels.gpt_image_1.name
                 | Img2ImgModels.gpt_image_1_5.name
-                | Img2ImgModels.gpt_image_sunburst.name
-                | Img2ImgModels.gpt_image_flare.name
+                | Img2ImgModels.gpt_image_2_5_sunburst.name
+                | Img2ImgModels.gpt_image_2_5_flare.name
                 | Img2ImgModels.gpt_image_2.name
             ):
                 match state.get("gpt_image_1_quality"):

--- a/scripts/init_image_generation_pricing.py
+++ b/scripts/init_image_generation_pricing.py
@@ -29,18 +29,17 @@ def run():
         notes="Token-based pricing: $5/1M text input tokens, $10/1M image input tokens, $40/1M output tokens",
     )
 
-    # Provisional rates for Sunburst and Flare, matching our GPT Image 2 rates.
     # GPT Image 2.5 Sunburst (OpenAI) - Token-based pricing
     image_generation_pricing_create(
         model_id="gpt-image-2.5-sunburst",
         model_name=Text2ImgModels.gpt_image_2_5_sunburst.name,
         unit_cost_text_input=5.0,  # $5 per 1M tokens
-        unit_cost_image_input=10.0,  # $10 per 1M tokens
-        unit_cost_output=40.0,  # $40 per 1M tokens
+        unit_cost_image_input=8.0,  # $8 per 1M tokens
+        unit_cost_output=30.0,  # $30 per 1M tokens
         unit_quantity=1e6,  # 1 million tokens
         provider=ModelProvider.openai,
-        pricing_url="https://openai.com/api/pricing",
-        notes="Provisional, matching GPT Image 2: $5/1M text input tokens, $10/1M image input tokens, $40/1M output tokens",
+        pricing_url="https://developers.openai.com/api/docs/pricing",
+        notes="Token-based pricing: $5/1M text input tokens, $8/1M image input tokens, $30/1M image output tokens. Provider cached-input rates: $1.25/1M text, $2/1M image; cached usage is not tracked separately here",
     )
 
     # GPT Image 2.5 Flare (OpenAI) - Token-based pricing
@@ -48,12 +47,12 @@ def run():
         model_id="gpt-image-2.5-flare",
         model_name=Text2ImgModels.gpt_image_2_5_flare.name,
         unit_cost_text_input=5.0,  # $5 per 1M tokens
-        unit_cost_image_input=10.0,  # $10 per 1M tokens
-        unit_cost_output=40.0,  # $40 per 1M tokens
+        unit_cost_image_input=8.0,  # $8 per 1M tokens
+        unit_cost_output=30.0,  # $30 per 1M tokens
         unit_quantity=1e6,  # 1 million tokens
         provider=ModelProvider.openai,
-        pricing_url="https://openai.com/api/pricing",
-        notes="Provisional, matching GPT Image 2: $5/1M text input tokens, $10/1M image input tokens, $40/1M output tokens",
+        pricing_url="https://developers.openai.com/api/docs/pricing",
+        notes="Token-based pricing: $5/1M text input tokens, $8/1M image input tokens, $30/1M image output tokens. Provider cached-input rates: $1.25/1M text, $2/1M image; cached usage is not tracked separately here",
     )
 
     # GPT Image 2 (OpenAI) - Token-based pricing

--- a/scripts/init_image_generation_pricing.py
+++ b/scripts/init_image_generation_pricing.py
@@ -30,10 +30,10 @@ def run():
     )
 
     # Provisional rates for Sunburst and Flare, matching our GPT Image 2 rates.
-    # GPT Image Sunburst (OpenAI) - Token-based pricing
+    # GPT Image 2.5 Sunburst (OpenAI) - Token-based pricing
     image_generation_pricing_create(
-        model_id="gpt-image-sunburst",
-        model_name=Text2ImgModels.gpt_image_sunburst.name,
+        model_id="gpt-image-2.5-sunburst",
+        model_name=Text2ImgModels.gpt_image_2_5_sunburst.name,
         unit_cost_text_input=5.0,  # $5 per 1M tokens
         unit_cost_image_input=10.0,  # $10 per 1M tokens
         unit_cost_output=40.0,  # $40 per 1M tokens
@@ -43,10 +43,10 @@ def run():
         notes="Provisional, matching GPT Image 2: $5/1M text input tokens, $10/1M image input tokens, $40/1M output tokens",
     )
 
-    # GPT Image Flare (OpenAI) - Token-based pricing
+    # GPT Image 2.5 Flare (OpenAI) - Token-based pricing
     image_generation_pricing_create(
-        model_id="gpt-image-flare",
-        model_name=Text2ImgModels.gpt_image_flare.name,
+        model_id="gpt-image-2.5-flare",
+        model_name=Text2ImgModels.gpt_image_2_5_flare.name,
         unit_cost_text_input=5.0,  # $5 per 1M tokens
         unit_cost_image_input=10.0,  # $10 per 1M tokens
         unit_cost_output=40.0,  # $40 per 1M tokens

--- a/scripts/init_image_generation_pricing.py
+++ b/scripts/init_image_generation_pricing.py
@@ -29,6 +29,33 @@ def run():
         notes="Token-based pricing: $5/1M text input tokens, $10/1M image input tokens, $40/1M output tokens",
     )
 
+    # Provisional rates for Sunburst and Flare, matching our GPT Image 2 rates.
+    # GPT Image Sunburst (OpenAI) - Token-based pricing
+    image_generation_pricing_create(
+        model_id="gpt-image-sunburst",
+        model_name=Text2ImgModels.gpt_image_sunburst.name,
+        unit_cost_text_input=5.0,  # $5 per 1M tokens
+        unit_cost_image_input=10.0,  # $10 per 1M tokens
+        unit_cost_output=40.0,  # $40 per 1M tokens
+        unit_quantity=1e6,  # 1 million tokens
+        provider=ModelProvider.openai,
+        pricing_url="https://openai.com/api/pricing",
+        notes="Provisional, matching GPT Image 2: $5/1M text input tokens, $10/1M image input tokens, $40/1M output tokens",
+    )
+
+    # GPT Image Flare (OpenAI) - Token-based pricing
+    image_generation_pricing_create(
+        model_id="gpt-image-flare",
+        model_name=Text2ImgModels.gpt_image_flare.name,
+        unit_cost_text_input=5.0,  # $5 per 1M tokens
+        unit_cost_image_input=10.0,  # $10 per 1M tokens
+        unit_cost_output=40.0,  # $40 per 1M tokens
+        unit_quantity=1e6,  # 1 million tokens
+        provider=ModelProvider.openai,
+        pricing_url="https://openai.com/api/pricing",
+        notes="Provisional, matching GPT Image 2: $5/1M text input tokens, $10/1M image input tokens, $40/1M output tokens",
+    )
+
     # GPT Image 2 (OpenAI) - Token-based pricing
     image_generation_pricing_create(
         model_id="gpt-image-2",


### PR DESCRIPTION
Adds GPT Image 2.5 Sunburst and Flare to text-to-image and image editing, including multiple input images. Both models use the existing OpenAI image generation/editing paths, quality and resolution controls, usage recording, and workflow billing.

Uses the requested GPT Image 2.5 aliases (`gpt-image-2.5-sunburst` and `gpt-image-2.5-flare`) with enum names `gpt_image_2_5_sunburst` and `gpt_image_2_5_flare` and matching display labels. Pricing seed entries use the supplied rates for both models: $5/$8/$30 per million text-input/image-input/image-output tokens. Provider cached-input rates ($1.25 text, $2 image per million tokens) are documented in pricing notes; the existing image usage tracker does not split cached tokens. The pricing initialization script has not been run against a database. This remains a draft pending runtime validation of the existing GPT Image settings with the new models.

Validation: Ruff lint and formatting checks, Python compilation for all five changed files, static checks for model mappings, availability, multi-image support, and inclusion in existing GPT Image routing/settings/billing groups; `git diff --check`. Runtime validation could not start because local Firebase credentials are missing. No live image API calls were made.

Based on and rebased against the latest fetched `origin/master`.

