### PR TITLE
fix: disable avoid repetition by default

### DIFF
--- a/daras_ai_v2/language_model.py
+++ b/daras_ai_v2/language_model.py
@@ -180,6 +180,9 @@ def run_language_model(
         "Pleave provide exactly one of { prompt, messages }"
     )
 
+    # Accept this deprecated option for backward compatibility, but ignore its value.
+    avoid_repetition = False
+
     model: AIModelSpec = AIModelSpec.objects.get(name=model)
 
     if "gemini_live" in model.name:

--- a/daras_ai_v2/language_model_settings_widgets.py
+++ b/daras_ai_v2/language_model_settings_widgets.py
@@ -79,15 +79,8 @@ def language_model_settings(selected_models: str | list[str] | None = None) -> N
 
     llms = list(AIModelSpec.objects.filter(name__in=selected_models))
 
-    col1, col2 = gui.columns(2)
+    col1, _ = gui.columns(2)
     with col1:
-        gui.checkbox(
-            label="**" + field_title(LanguageModelSettings, "avoid_repetition") + "**",
-            help=field_desc(LanguageModelSettings, "avoid_repetition"),
-            key="avoid_repetition",
-        )
-
-    with col2:
         gui.selectbox(
             label=(
                 "###### " + field_title(LanguageModelSettings, "response_format_type")


### PR DESCRIPTION
## Summary
- default Avoid Repetition to false across the six workflows that previously enabled it
- remove the Avoid Repetition checkbox from shared language-model settings
- preserve the request field for saved-run and API compatibility

## Validation
- ruff check on all changed Python files
- focused assertions for workflow defaults and UI removal
- git diff --check